### PR TITLE
Preparation for webgl and cpu pow with new threshold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Nault",
+  "name": "nault",
   "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -7667,6 +7667,22 @@
       "resolved": "https://registry.npmjs.org/nano-base32/-/nano-base32-1.0.1.tgz",
       "integrity": "sha1-ulSMh578+5DaHE2eCX20pGySVe8="
     },
+    "nanocurrency": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/nanocurrency/-/nanocurrency-2.4.0.tgz",
+      "integrity": "sha512-mmPvHcc6Rwds5YcQpCYdSkotOzqVJwn8JKQjAfkngDustRdWkmc7XCOn8NktI/8njjQWwgatDYgj9GAycfCNqQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0",
+        "blakejs": "^1.1.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+        }
+      }
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -14196,6 +14212,58 @@
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
+      }
+    },
+    "worker-loader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
+      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.0",
+        "schema-utils": "^0.4.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.0.tgz",
+          "integrity": "sha512-eyoaac3btgU8eJlvh01En8OCKzRqlLe2G5jDsCr3RiE2uLGMEEB1aaGwVVpwR8M95956tGH6R+9edC++OvzaVw==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "crypto-js": "^3.1.9-1",
     "electron-updater": "^2.21.0",
     "hw-app-nano": "^1.3.0",
+    "nanocurrency": "^2.4.0",
     "ngx-clipboard": "^9.1.2",
     "node-hid": "^1.3.0",
     "qrcode": "^1.4.4",
@@ -85,7 +86,8 @@
     "ts-node": "~3.2.0",
     "tslint": "~5.7.0",
     "typescript": "~2.4.2",
-    "uikit": "^3.0.0-beta.40"
+    "uikit": "^3.0.0-beta.40",
+    "worker-loader": "^2.0.0"
   },
   "build": {
     "appId": "cc.nault",

--- a/src/assets/lib/cpupow.js
+++ b/src/assets/lib/cpupow.js
@@ -1,0 +1,8 @@
+const NanoCurrency = require('nanocurrency')
+// When the parent theard requires it, render the HTML
+self.addEventListener("message", async (message) => {
+  //TODO: Pass threshold to nanocurrency lib once supported
+  const { blockHash, workerIndex, workerCount } = message.data;
+  const result = await NanoCurrency.computeWork(blockHash, { workerIndex, workerCount });
+  self.postMessage(result);
+});

--- a/src/assets/lib/pow/nano-webgl-pow.js
+++ b/src/assets/lib/pow/nano-webgl-pow.js
@@ -3,15 +3,17 @@
 // Author:  numtel <ben@latenightsketches.com>
 // License: MIT
 
-// window.NanoWebglPow(hashHex, callback, progressCallback);
+// window.NanoWebglPow(hashHex, callback, progressCallback, threshold);
 // @param hashHex           String   Previous Block Hash as Hex String
 // @param callback          Function Called when work value found
 //   Receives single string argument, work value as hex
 // @param progressCallback  Function Optional
 //   Receives single argument: n, number of frames so far
 //   Return true to abort
+// @param threshold         String   Optional difficulty threshold (default=0xFFFFFFF8 since v21)
 
 (function(){
+const defaultThreshold = '0xFFFFFFF8'
 
 function array_hex(arr, index, length) {
   let out='';
@@ -29,7 +31,7 @@ function hex_reverse(hex) {
   return out;
 }
 
-function calculate(hashHex, callback, progressCallback) {
+function calculate(hashHex, callback, progressCallback, threshold = defaultThreshold) {
   const canvas = document.createElement('canvas');
 
   canvas.width = window.NanoWebglPow.width;
@@ -212,7 +214,7 @@ function calculate(hashHex, callback, progressCallback) {
 
       // Threshold test, first 4 bytes not significant,
       //  only calculate digest of the second 4 bytes
-      if((BLAKE2B_IV32_1 ^ v[1] ^ v[17]) > 0xFFFFFFC0u) {
+      if((BLAKE2B_IV32_1 ^ v[1] ^ v[17]) > ` + threshold + `u) {
         // Success found, return pixel data so work value can be constructed
         fragColor = vec4(
           float(x_index + 1u)/255., // +1 to distinguish from 0 (unsuccessful) pixels
@@ -287,7 +289,7 @@ function calculate(hashHex, callback, progressCallback) {
 
     gl.uniform4uiv(work0Location, Array.from(work0));
     gl.uniform4uiv(work1Location, Array.from(work1));
-    
+
     // Check with progressCallback every 100 frames
     if(n%100===0 && typeof progressCallback === 'function' && progressCallback(n))
       return;

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,5 +1,12 @@
 /* SystemJS module definition */
 declare var module: NodeModule;
+declare module 'worker-loader!*' {
+  class WebpackWorker extends Worker {
+    constructor();
+  }
+
+  export default WebpackWorker;
+}
 interface NodeModule {
   id: string;
 }


### PR DESCRIPTION
Step 1 of preparing for new local pow threshold. No threshold changed yet which means this PR can be merged now and a new one can be made later for step2 for actually changing the threshold, which should be a quick fix.

**What's changed:**
* webgl can take any threshold via constant "webglThreshold"
* cpu pow has been rewritten to use nanocurrency.js via web workers (multithreaded). Once that lib has been upgraded it should be an easy thing to pass down the constant "cpuThreshold"

Also with this change, it should be possible to do both 8x work for send/change blocks and 1/8x work for open/receive but we'll see what to do with that. Problem is the work is precomputed and both 8x and 1/8x would need to be done and then use the right one depending on what action happens in the wallet. Possible and optimal for the user but easier to just to 8x all the time.