### PR TITLE
Add support for expanded private keys

### DIFF
--- a/src/app/components/configure-wallet/configure-wallet.component.html
+++ b/src/app/components/configure-wallet/configure-wallet.component.html
@@ -99,6 +99,22 @@
         </div>
       </div>
     </div>
+    <div uk-grid *ngIf="selectedImportOption === 'privateKey'" class="uk-margin-top">
+      <div class="uk-width-1-1">
+        <p>
+          Enter your Nano private key below. These are not to be confused with Nano seeds, which are more common, and produce many private keys.
+        </p>
+        <input type="text" class="uk-input" (keyup.enter)="importSingleKeyWallet()" [(ngModel)]="importPrivateKeyModel" placeholder="Your Nano Private Key">
+      </div>
+    </div>
+    <div uk-grid *ngIf="selectedImportOption === 'expandedKey'" class="uk-margin-top">
+      <div class="uk-width-1-1">
+        <p>
+          Enter your expanded private key below. These are rare, and are usually generated from multi-party cryptography magic.
+        </p>
+        <input type="text" class="uk-input" (keyup.enter)="importSingleKeyWallet()" [(ngModel)]="importExpandedKeyModel" placeholder="Your Nano Expanded Private Key">
+      </div>
+    </div>
   </div>
   <div class="uk-card-footer uk-text-right">
     <div *ngIf="selectedImportOption === 'file'" class="js-upload" uk-form-custom style="display: inline-block;">
@@ -109,6 +125,8 @@
     <button *ngIf="selectedImportOption === 'seed'" class="uk-button uk-button-primary" (click)="importExistingWallet()">Import From Seed</button>
     <button *ngIf="selectedImportOption === 'ledger' && ledger.status === ledgerStatus.READY" class="uk-button uk-button-primary" (click)="importLedgerWallet()">Import From Ledger</button>
     <button *ngIf="selectedImportOption === 'ledger' && ledger.status !== ledgerStatus.READY" class="uk-button uk-button-primary" (click)="importLedgerWallet(true)">Refresh Ledger Status</button>
+    <button *ngIf="selectedImportOption === 'privateKey'" class="uk-button uk-button-primary" (click)="importSingleKeyWallet()">Import From Private Key</button>
+    <button *ngIf="selectedImportOption === 'expandedKey'" class="uk-button uk-button-primary" (click)="importSingleKeyWallet()">Import From Expanded Private Key</button>
   </div>
 </div>
 

--- a/src/app/components/configure-wallet/configure-wallet.component.ts
+++ b/src/app/components/configure-wallet/configure-wallet.component.ts
@@ -19,6 +19,8 @@ export class ConfigureWalletComponent implements OnInit {
   newWalletMnemonic = '';
   newWalletMnemonicLines = [];
   importSeedModel = '';
+  importPrivateKeyModel = '';
+  importExpandedKeyModel = '';
   importSeedMnemonicModel = '';
   walletPasswordModel = '';
   walletPasswordConfirmModel = '';
@@ -29,6 +31,8 @@ export class ConfigureWalletComponent implements OnInit {
     { name: 'Nano Mnemonic Phrase', value: 'mnemonic' },
     { name: 'Nault Wallet File', value: 'file' },
     { name: 'Ledger Nano S', value: 'ledger' },
+    { name: 'Private Key', value: 'privateKey' },
+    { name: 'Expanded Private Key', value: 'expandedKey' },
   ];
 
   ledgerStatus = LedgerStatus;
@@ -81,6 +85,23 @@ export class ConfigureWalletComponent implements OnInit {
     await this.walletService.createWalletFromSeed(importSeed);
 
     this.notifications.removeNotification('importing-loading');
+
+    this.activePanel = 4;
+    this.notifications.sendSuccess(`Successfully imported wallet!`);
+  }
+
+  async importSingleKeyWallet() {
+    // Now, if a wallet is configured, make sure they confirm an overwrite first
+    const confirmed = await this.confirmWalletOverwrite();
+    if (!confirmed) return;
+
+    if (this.selectedImportOption === 'privateKey') {
+      this.walletService.createWalletFromSingleKey(this.importPrivateKeyModel, false);
+    } else if (this.selectedImportOption === 'expandedKey') {
+      this.walletService.createWalletFromSingleKey(this.importExpandedKeyModel, true);
+    } else {
+      return this.notifications.sendError(`Invalid import option`);
+    }
 
     this.activePanel = 4;
     this.notifications.sendSuccess(`Successfully imported wallet!`);

--- a/src/app/services/nano-block.service.ts
+++ b/src/app/services/nano-block.service.ts
@@ -325,7 +325,7 @@ export class NanoBlockService {
     const hashBytes = blake.blake2bFinal(context);
 
     const privKey = walletAccount.keyPair.secretKey;
-    const signed = nacl.sign.detached(hashBytes, privKey);
+    const signed = nacl.sign.detached(hashBytes, privKey, walletAccount.keyPair.expanded);
     const signature = this.util.hex.fromUint8(signed);
 
     return signature;
@@ -342,7 +342,7 @@ export class NanoBlockService {
     const hashBytes = blake.blake2bFinal(context);
 
     // Sign the hash bytes with the account priv key bytes
-    const signed = nacl.sign.detached(hashBytes, walletAccount.keyPair.secretKey);
+    const signed = nacl.sign.detached(hashBytes, walletAccount.keyPair.secretKey, walletAccount.keyPair.expanded);
     const signature = this.util.hex.fromUint8(signed);
 
     return signature;
@@ -359,7 +359,7 @@ export class NanoBlockService {
     const hashBytes = blake.blake2bFinal(context);
 
     const privKey = walletAccount.keyPair.secretKey;
-    const signed = nacl.sign.detached(hashBytes, privKey);
+    const signed = nacl.sign.detached(hashBytes, privKey, walletAccount.keyPair.expanded);
     const signature = this.util.hex.fromUint8(signed);
 
     return signature;

--- a/src/app/services/util.service.ts
+++ b/src/app/services/util.service.ts
@@ -202,8 +202,8 @@ function generateAccountSecretKeyBytes(seedBytes, accountIndex) {
   return newKey;
 }
 
-function generateAccountKeyPair(accountSecretKeyBytes) {
-  return nacl.sign.keyPair.fromSecretKey(accountSecretKeyBytes);
+function generateAccountKeyPair(accountSecretKeyBytes, expanded = false) {
+  return nacl.sign.keyPair.fromSecretKey(accountSecretKeyBytes, expanded);
 }
 
 function getPublicAccountID(accountPublicKeyBytes, prefix = 'nano') {

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -12,7 +12,7 @@ import {AppSettingsService} from "./app-settings.service";
 import {PriceService} from "./price.service";
 import {LedgerService} from "./ledger.service";
 
-export type WalletType = "seed" | "ledger" | "privateKey";
+export type WalletType = "seed" | "ledger" | "privateKey" | "expandedKey";
 
 export interface WalletAccount {
   id: string;
@@ -219,12 +219,10 @@ export class WalletService {
     const walletJson = JSON.parse(walletData);
     const walletType = walletJson.type || 'seed';
     this.wallet.type = walletType;
-    if (walletType === 'seed') {
+    if (walletType === 'seed' || walletType === 'privateKey' || walletType === 'expandedKey') {
       this.wallet.seed = walletJson.seed;
       this.wallet.seedBytes = this.util.hex.toUint8(walletJson.seed);
-    }
-    // Remove support for unlocked wallet
-    if (walletType === 'seed' || walletType === 'privateKey') {
+      // Remove support for unlocked wallet
       this.wallet.locked = walletJson.locked;
       this.wallet.password = walletJson.password || null;
     }
@@ -336,8 +334,12 @@ export class WalletService {
       this.wallet.seed = decryptedSeed;
       this.wallet.seedBytes = this.util.hex.toUint8(this.wallet.seed);
       this.wallet.accounts.forEach(a => {
-        a.secret = this.util.account.generateAccountSecretKeyBytes(this.wallet.seedBytes, a.index);
-        a.keyPair = this.util.account.generateAccountKeyPair(a.secret);
+        if (this.wallet.type === 'seed') {
+          a.secret = this.util.account.generateAccountSecretKeyBytes(this.wallet.seedBytes, a.index);
+        } else {
+          a.secret = this.wallet.seedBytes;
+        }
+        a.keyPair = this.util.account.generateAccountKeyPair(a.secret, this.wallet.type === 'expandedKey');
       });
 
       this.wallet.locked = false;
@@ -445,6 +447,19 @@ export class WalletService {
     return this.wallet;
   }
 
+  createWalletFromSingleKey(key: string, expanded: boolean) {
+    this.resetWallet();
+
+    this.wallet.type = expanded ? 'expandedKey' : 'privateKey';
+    this.wallet.seed = key;
+    this.wallet.seedBytes = this.util.hex.toUint8(key);
+
+    this.wallet.accounts.push(this.createSingleKeyAccount(expanded));
+    this.saveWalletExport();
+
+    return this.wallet;
+  }
+
   async createLedgerAccount(index) {
     const account: any = await this.ledgerService.getLedgerAccount(index);
 
@@ -470,9 +485,7 @@ export class WalletService {
     return newAccount;
   }
 
-  async createSeedAccount(index) {
-    const accountBytes = this.util.account.generateAccountSecretKeyBytes(this.wallet.seedBytes, index);
-    const accountKeyPair = this.util.account.generateAccountKeyPair(accountBytes);
+  createKeyedAccount(index, accountBytes, accountKeyPair) {
     const accountName = this.util.account.getPublicAccountID(accountKeyPair.publicKey);
     const addressBookName = this.addressBook.getAccountName(accountName);
 
@@ -492,6 +505,18 @@ export class WalletService {
     };
 
     return newAccount;
+  }
+
+  async createSeedAccount(index) {
+    const accountBytes = this.util.account.generateAccountSecretKeyBytes(this.wallet.seedBytes, index);
+    const accountKeyPair = this.util.account.generateAccountKeyPair(accountBytes);
+    return this.createKeyedAccount(index, accountBytes, accountKeyPair);
+  }
+
+  createSingleKeyAccount(expanded: boolean) {
+    const accountBytes = this.wallet.seedBytes;
+    const accountKeyPair = this.util.account.generateAccountKeyPair(accountBytes, expanded);
+    return this.createKeyedAccount(0, accountBytes, accountKeyPair);
   }
 
   /**
@@ -517,6 +542,8 @@ export class WalletService {
 
   isConfigured() {
     switch (this.wallet.type) {
+      case 'privateKey':
+      case 'expandedKey':
       case 'seed': return !!this.wallet.seed;
       case 'ledger': return true; // ?
       case 'privateKey': return false;
@@ -526,6 +553,7 @@ export class WalletService {
   isLocked() {
     switch (this.wallet.type) {
       case 'privateKey':
+      case 'expandedKey':
       case 'seed': return this.wallet.locked;
       case 'ledger': return false;
     }
@@ -693,7 +721,7 @@ export class WalletService {
 
     let newAccount: WalletAccount|null;
 
-    if (this.wallet.type === 'privateKey') {
+    if (this.wallet.type === 'privateKey' || this.wallet.type === 'expandedKey') {
       throw new Error(`Cannot add another account in private key mode`);
     } else if (this.wallet.type === 'seed') {
       newAccount = await this.createSeedAccount(index);
@@ -844,9 +872,7 @@ export class WalletService {
     };
 
     if (this.wallet.type === 'ledger') {
-    }
-
-    if (this.wallet.type === 'seed') {
+    } else {
       // Forcefully encrypt the seed so an unlocked wallet is never saved
       if (!this.wallet.locked) {
         const encryptedSeed = CryptoJS.AES.encrypt(this.wallet.seed, this.wallet.password || '');


### PR DESCRIPTION
Also exposes support for normal private keys. I've copied this PR from https://github.com/cronoh/nanovault/pull/93

Explanation of expanded private keys: Basically, private keys are first hashed, and that hash is the "expanded private key" that the signing elliptic cryptography is done on. A lot of fancy cryptography like "public seeds"/non-hardened derivation, where you can generate addresses from a public seed without knowing corresponding private keys from the private seed, is built using elliptic cryptography, so the keys it generates are the elliptic cryptography input to the signing algorithm, aka the expanded private key.