### PR TITLE
Support for custom API auth headers

### DIFF
--- a/src/app/components/configure-app/configure-app.component.html
+++ b/src/app/components/configure-app/configure-app.component.html
@@ -226,7 +226,7 @@
                     <strong>{{ serverAPI }}</strong>
                   </div>
                   <div class="uk-inline uk-width-1-1" *ngIf="showServerConfigs()">
-                    <input [(ngModel)]="serverAPI" class="uk-input uk-margin-small-bottom" type="text" placeholder="">
+                    <input [(ngModel)]="serverAPI" class="uk-input uk-margin-small-bottom" type="text" placeholder="https://domain.com/path">
                     <span class="uk-text-meta">
                       This has to be a valid <a href="https://docs.nano.org/commands/rpc-protocol/" target="_blank" rel="noopener">Nano RPC endpoint</a> or an API compliant with it.
                     </span>
@@ -246,10 +246,31 @@
                   </div>
 
                   <div class="uk-inline uk-width-1-1" *ngIf="showServerConfigs()">
-                    <input [(ngModel)]="serverWS" class="uk-input uk-margin-small-bottom" id="form-horizontal-text2" type="text" placeholder="">
+                    <input [(ngModel)]="serverWS" class="uk-input uk-margin-small-bottom" id="form-horizontal-text2" type="text" placeholder="wss://domain.com/path">
                     <span class="uk-text-meta">
                       This has to be a <a href="https://docs.nano.org/integration-guides/websockets/#configuration" target="_blank" rel="noopener">Nano Node Websocket</a> or a WebSocket API compliant with it.<br>
                       <i>Note: Since this server only notifies about new transactions, most of the wallet functions fine without it.</i>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="uk-width-1-1">
+            <div class="uk-form-horizontal">
+              <div class="">
+                <label class="uk-form-label uk-text-right">Auth Header <span uk-icon="icon: info;" uk-tooltip title="If API requires authentication. For example using basic auth: Basic xyz"></span></label>
+                <div class="uk-form-controls">
+
+                  <div class="uk-inline uk-width-1-1" *ngIf="!showServerConfigs()">
+                    <strong>{{ serverAuth }}</strong>
+                  </div>
+                  <div class="uk-inline uk-width-1-1" *ngIf="showServerConfigs()">
+                    <input [(ngModel)]="serverAuth" class="uk-input uk-margin-small-bottom" type="text" placeholder="Optional">
+                    <span class="uk-text-meta">
+                      This has to be a valid Authorization header.<br>
+                      <i>For example, basic auth defined as "Authorization: Basic base64Encode(username:password)"<br>In that case, enter: Basic dHV0c3BsdXM6MTIzNDU2</i>
                     </span>
                   </div>
                 </div>

--- a/src/app/components/configure-app/configure-app.component.html
+++ b/src/app/components/configure-app/configure-app.component.html
@@ -257,7 +257,7 @@
             </div>
           </div>
 
-          <div class="uk-width-1-1">
+          <div class="uk-width-1-1" *ngIf="showServerValues()">
             <div class="uk-form-horizontal">
               <div class="">
                 <label class="uk-form-label uk-text-right">Auth Header <span uk-icon="icon: info;" uk-tooltip title="If API requires authentication. For example using basic auth: Basic xyz"></span></label>

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -119,31 +119,37 @@ export class ConfigureAppComponent implements OnInit {
       name: 'ninja',
       api: 'https://mynano.ninja/api/node',
       ws: 'wss://ws.mynano.ninja',
+      auth: '',
     },
     {
       name: 'nanos',
       api: 'https://proxy.nanos.cc/proxy',
       ws: 'wss://socket.nanos.cc',
+      auth: '',
     },
     {
       name: 'nanex',
       api: 'https://api.nanex.cc',
       ws: 'wss://ws.nanocrawler.cc',
+      auth: '',
     },
     {
       name: 'nanocrawler',
       api: 'https://vault.nanocrawler.cc/api/node-api',
       ws: 'wss://ws.nanocrawler.cc',
+      auth: '',
     },
     {
       name: 'nanovault',
       api: null,
       ws: null,
+      auth: null,
     },
   ];
 
   serverAPI = null;
   serverWS = null;
+  serverAuth = null;
   minimumReceive = null;
 
   showServerConfigs = () => this.selectedServer && this.selectedServer === 'custom';
@@ -190,6 +196,7 @@ export class ConfigureAppComponent implements OnInit {
 
     this.serverAPI = settings.serverAPI;
     this.serverWS = settings.serverWS;
+    this.serverAuth = settings.serverAuth;
 
     this.minimumReceive = settings.minimumReceive;
     this.defaultRepresentative = settings.defaultRepresentative;
@@ -277,6 +284,7 @@ export class ConfigureAppComponent implements OnInit {
       serverName: this.selectedServer,
       serverAPI: null,
       serverWS: null,
+      serverAuth: null,
     };
 
     // Custom... do some basic validation
@@ -294,6 +302,10 @@ export class ConfigureAppComponent implements OnInit {
       } else {
         return this.notifications.sendWarning(`Custom Update Server has an invalid address.`);
       }
+    }
+
+    if (this.serverAuth != null && this.serverAuth.trim().length > 1) {
+      newSettings.serverAuth = this.serverAuth;
     }
 
     this.appSettings.setAppSettings(newSettings);
@@ -344,6 +356,7 @@ export class ConfigureAppComponent implements OnInit {
     if (custom) {
       this.serverAPI = custom.api;
       this.serverWS = custom.ws;
+      this.serverAuth = custom.auth;
     }
   }
 

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -25,7 +25,6 @@ export class ApiService {
     }
     var header = undefined;
     if (this.appSettings.settings.serverAuth != null && this.appSettings.settings.serverAuth != "") {
-      console.log("test")
       header = {
         headers: new HttpHeaders()
           .set('Authorization',  this.appSettings.settings.serverAuth)

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import {HttpClient} from "@angular/common/http";
+import {HttpHeaders} from "@angular/common/http";
 import {NodeService} from "./node.service";
 import {AppSettingsService} from "./app-settings.service";
 
@@ -22,7 +23,15 @@ export class ApiService {
     if (this.node.node.status === false) {
       this.node.setLoading();
     }
-    return await this.http.post(apiUrl, data).toPromise()
+    var header = undefined;
+    if (this.appSettings.settings.serverAuth != null && this.appSettings.settings.serverAuth != "") {
+      console.log("test")
+      header = {
+        headers: new HttpHeaders()
+          .set('Authorization',  this.appSettings.settings.serverAuth)
+      }
+    }
+    return await this.http.post(apiUrl, data, header).toPromise()
       .then(res => {
         this.node.setOnline();
         return res;

--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -16,6 +16,7 @@ interface AppSettings {
   serverName: string;
   serverAPI: string | null;
   serverWS: string | null;
+  serverAuth: string | null;
   minimumReceive: string | null;
   walletVersion: number | null;
 }
@@ -36,6 +37,7 @@ export class AppSettingsService {
     serverName: 'ninja',
     serverAPI: null,
     serverWS: null,
+    serverAuth: null,
     minimumReceive: null,
     walletVersion: 1
   };
@@ -89,6 +91,7 @@ export class AppSettingsService {
       serverName: 'ninja',
       serverAPI: null,
       serverWS: null,
+      serverAuth: null,
       minimumReceive: null,
       walletVersion: 1,
     };


### PR DESCRIPTION
Could you take a look at this @BitDesert if you think the GUI is ok?

I have verified that the authentication works against one of my public APIs that has it enforced. It will typically always be empty for predefined APIs since creds can't be perfectly hidden anyway in a client-side wallet.

![1](https://user-images.githubusercontent.com/2406720/86136107-f6dd4a80-baeb-11ea-9e60-ac5e51fc93ca.PNG)

Ref: #10 
