### PR TITLE
Setting for incoming tx with largest amount first

### DIFF
--- a/src/app/components/configure-app/configure-app.component.html
+++ b/src/app/components/configure-app/configure-app.component.html
@@ -128,7 +128,7 @@
             <div class="uk-form-horizontal">
 
               <div class="uk-margin">
-                <label class="uk-form-label">Receive Largest First <span uk-icon="icon: info;" uk-tooltip title="If receiving incoming transactions with largest amount first."></span></label>
+                <label class="uk-form-label">Receive Priority <span uk-icon="icon: info;" uk-tooltip title="If receiving incoming transactions with the largest amount first or chronological from recorded time."></span></label>
                 <div class="uk-form-controls">
 
                   <div class="uk-inline uk-width-1-1">
@@ -145,7 +145,7 @@
             <div class="uk-form-horizontal">
 
               <div class="uk-margin">
-                <label class="uk-form-label">Minimum Receive Amount <span uk-icon="icon: info;" uk-tooltip title="Transactions below this amount will be ignored by the wallet.  Set to blank or 0 to accept all transactions."></span></label>
+                <label class="uk-form-label">Minimum Receive Amount <span uk-icon="icon: info;" uk-tooltip title="Transactions below this amount will be ignored by the wallet both for receiving and in the transaction list.  Set to blank or 0 to accept all transactions."></span></label>
                 <div class="uk-form-controls">
                   <div uk-grid>
                     <div class="uk-width-3-5">

--- a/src/app/components/configure-app/configure-app.component.html
+++ b/src/app/components/configure-app/configure-app.component.html
@@ -128,6 +128,23 @@
             <div class="uk-form-horizontal">
 
               <div class="uk-margin">
+                <label class="uk-form-label">Receive Largest First <span uk-icon="icon: info;" uk-tooltip title="If receiving incoming transactions with largest amount first."></span></label>
+                <div class="uk-form-controls">
+
+                  <div class="uk-inline uk-width-1-1">
+                    <select class="uk-select" [(ngModel)]="selectedPendingOption">
+                      <option *ngFor="let pending of pendingOptions" [value]="pending.value">{{ pending.name }}</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="uk-width-1-1">
+            <div class="uk-form-horizontal">
+
+              <div class="uk-margin">
                 <label class="uk-form-label">Minimum Receive Amount <span uk-icon="icon: info;" uk-tooltip title="Transactions below this amount will be ignored by the wallet.  Set to blank or 0 to accept all transactions."></span></label>
                 <div class="uk-form-controls">
                   <div uk-grid>

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -94,8 +94,8 @@ export class ConfigureAppComponent implements OnInit {
   selectedPoWOption = this.powOptions[0].value;
 
   pendingOptions = [
-    { name: 'Largest Amount First', value: 1 },
-    { name: 'Oldest Transaction First', value: 0 },
+    { name: 'Largest Amount First', value: 'amount' },
+    { name: 'Oldest Transaction First', value: 'date' },
   ];
   selectedPendingOption = this.pendingOptions[0].value;
 

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -94,8 +94,8 @@ export class ConfigureAppComponent implements OnInit {
   selectedPoWOption = this.powOptions[0].value;
 
   pendingOptions = [
-    { name: 'Yes', value: 1 },
-    { name: 'No', value: 0 },
+    { name: 'Largest Amount First', value: 1 },
+    { name: 'Oldest Transaction First', value: 0 },
   ];
   selectedPendingOption = this.pendingOptions[0].value;
 

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -93,6 +93,12 @@ export class ConfigureAppComponent implements OnInit {
   ];
   selectedPoWOption = this.powOptions[0].value;
 
+  pendingOptions = [
+    { name: 'Yes', value: 1 },
+    { name: 'No', value: 0 },
+  ];
+  selectedPendingOption = this.pendingOptions[0].value;
+
   // prefixOptions = [
   //   { name: 'xrb_', value: 'xrb' },
   //   { name: 'nano_', value: 'nano' },
@@ -152,6 +158,9 @@ export class ConfigureAppComponent implements OnInit {
     const matchingPowOption = this.powOptions.find(d => d.value === settings.powSource);
     this.selectedPoWOption = matchingPowOption ? matchingPowOption.value : this.powOptions[0].value;
 
+    const matchingPendingOption = this.pendingOptions.find(d => d.value == settings.pendingOption);
+    this.selectedPendingOption = matchingPendingOption ? matchingPendingOption.value : this.pendingOptions[0].value;
+
     this.serverOptions = this.appSettings.serverOptions;
     this.selectedServer = settings.serverName;
     this.serverAPI = settings.serverAPI;
@@ -198,6 +207,7 @@ export class ConfigureAppComponent implements OnInit {
   async updateWalletSettings() {
     const newStorage = this.selectedStorage;
     let newPoW = this.selectedPoWOption;
+    let pendingOption = this.selectedPendingOption
 
     const resaveWallet = this.appSettings.settings.walletStore !== newStorage;
     const reloadPending = this.appSettings.settings.minimumReceive != this.minimumReceive;
@@ -224,6 +234,7 @@ export class ConfigureAppComponent implements OnInit {
       walletStore: newStorage,
       lockInactivityMinutes: new Number(this.selectedInactivityMinutes),
       powSource: newPoW,
+      pendingOption: pendingOption,
       minimumReceive: this.minimumReceive || null,
       defaultRepresentative: this.defaultRepresentative || null,
     };

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -62,10 +62,10 @@ export class ApiService {
     return await this.request('accounts_frontiers', { accounts });
   }
   async accountsPending(accounts: string[], count: number = 50): Promise<{blocks: any }> {
-    return await this.request('accounts_pending', { accounts, count, source: true });
+    return await this.request('accounts_pending', { accounts, count, source: true, sorting: this.appSettings.settings.pendingOption == 1 ? true:false, include_only_confirmed: true });
   }
   async accountsPendingLimit(accounts: string[], threshold: string, count: number = 50): Promise<{blocks: any }> {
-    return await this.request('accounts_pending', { accounts, count, threshold, source: true });
+    return await this.request('accounts_pending', { accounts, count, threshold, source: true, sorting: this.appSettings.settings.pendingOption == 1 ? true:false, include_only_confirmed: true });
   }
   async delegatorsCount(account: string): Promise<{ count: string }> {
     return await this.request('delegators_count', { account });
@@ -96,9 +96,9 @@ export class ApiService {
     return await this.request('validate_account_number', { account });
   }
   async pending(account, count): Promise<any> {
-    return await this.request('pending', { account, count, source: true });
+    return await this.request('pending', { account, count, source: true, sorting: this.appSettings.settings.pendingOption == 1 ? true:false, include_only_confirmed: true });
   }
   async pendingLimit(account, count, threshold): Promise<any> {
-    return await this.request('pending', { account, count, threshold, source: true });
+    return await this.request('pending', { account, count, threshold, source: true, sorting: this.appSettings.settings.pendingOption == 1 ? true:false, include_only_confirmed: true });
   }
 }

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -62,10 +62,10 @@ export class ApiService {
     return await this.request('accounts_frontiers', { accounts });
   }
   async accountsPending(accounts: string[], count: number = 50): Promise<{blocks: any }> {
-    return await this.request('accounts_pending', { accounts, count, source: true, sorting: this.appSettings.settings.pendingOption == 1 ? true:false, include_only_confirmed: true });
+    return await this.request('accounts_pending', { accounts, count, source: true, include_only_confirmed: true });
   }
   async accountsPendingLimit(accounts: string[], threshold: string, count: number = 50): Promise<{blocks: any }> {
-    return await this.request('accounts_pending', { accounts, count, threshold, source: true, sorting: this.appSettings.settings.pendingOption == 1 ? true:false, include_only_confirmed: true });
+    return await this.request('accounts_pending', { accounts, count, threshold, source: true, include_only_confirmed: true });
   }
   async delegatorsCount(account: string): Promise<{ count: string }> {
     return await this.request('delegators_count', { account });
@@ -96,9 +96,9 @@ export class ApiService {
     return await this.request('validate_account_number', { account });
   }
   async pending(account, count): Promise<any> {
-    return await this.request('pending', { account, count, source: true, sorting: this.appSettings.settings.pendingOption == 1 ? true:false, include_only_confirmed: true });
+    return await this.request('pending', { account, count, source: true, include_only_confirmed: true });
   }
   async pendingLimit(account, count, threshold): Promise<any> {
-    return await this.request('pending', { account, count, threshold, source: true, sorting: this.appSettings.settings.pendingOption == 1 ? true:false, include_only_confirmed: true });
+    return await this.request('pending', { account, count, threshold, source: true, include_only_confirmed: true });
   }
 }

--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -13,7 +13,7 @@ interface AppSettings {
   lockOnClose: number;
   lockInactivityMinutes: number;
   powSource: PoWSource;
-  pendingOption: number;
+  pendingOption: string;
   serverName: string;
   serverAPI: string | null;
   serverWS: string | null;
@@ -35,7 +35,7 @@ export class AppSettingsService {
     lockOnClose: 1,
     lockInactivityMinutes: 30,
     powSource: 'best',
-    pendingOption: 1,
+    pendingOption: 'amount',
     serverName: 'random',
     serverAPI: null,
     serverWS: null,
@@ -163,7 +163,7 @@ export class AppSettingsService {
       lockOnClose: 1,
       lockInactivityMinutes: 30,
       powSource: 'best',
-      pendingOption: 1,
+      pendingOption: 'amount',
       serverName: 'random',
       serverAPI: null,
       serverWS: null,

--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -13,6 +13,7 @@ interface AppSettings {
   lockOnClose: number;
   lockInactivityMinutes: number;
   powSource: PoWSource;
+  pendingOption: number;
   serverName: string;
   serverAPI: string | null;
   serverWS: string | null;
@@ -34,6 +35,7 @@ export class AppSettingsService {
     lockOnClose: 1,
     lockInactivityMinutes: 30,
     powSource: 'best',
+    pendingOption: 1,
     serverName: 'random',
     serverAPI: null,
     serverWS: null,
@@ -161,6 +163,7 @@ export class AppSettingsService {
       lockOnClose: 1,
       lockInactivityMinutes: 30,
       powSource: 'best',
+      pendingOption: 1,
       serverName: 'random',
       serverAPI: null,
       serverWS: null,

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -811,9 +811,19 @@ export class WalletService {
     }
   }
 
+  sortByAmount(a, b) {
+    var x = new BigNumber(a.amount);
+    var y = new BigNumber(b.amount);
+    return y.comparedTo(x);
+  }
+
   async processPendingBlocks() {
     if (this.processingPending || this.wallet.locked || !this.pendingBlocks.length) return;
-
+    // Sort pending by amount
+    if (this.appSettings.settings.pendingOption == 1) {
+      this.pendingBlocks.sort(this.sortByAmount)
+    }
+    
     this.processingPending = true;
 
     const nextBlock = this.pendingBlocks[0];

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -812,18 +812,19 @@ export class WalletService {
   }
 
   sortByAmount(a, b) {
-    var x = new BigNumber(a.amount);
-    var y = new BigNumber(b.amount);
+    const x = new BigNumber(a.amount);
+    const y = new BigNumber(b.amount);
     return y.comparedTo(x);
   }
 
   async processPendingBlocks() {
     if (this.processingPending || this.wallet.locked || !this.pendingBlocks.length) return;
+
     // Sort pending by amount
-    if (this.appSettings.settings.pendingOption == 1) {
-      this.pendingBlocks.sort(this.sortByAmount)
+    if (this.appSettings.settings.pendingOption === 'amount') {
+      this.pendingBlocks.sort(this.sortByAmount);
     }
-    
+
     this.processingPending = true;
 
     const nextBlock = this.pendingBlocks[0];


### PR DESCRIPTION
Affects both incoming transactions for the account history view and the order of how they are processed. Regardless of the wallet was closed or opened while they arrived. Sending a large tx while smaller ones are processed will get the largest first as well.

Solves #23 

Available as app setting with Yes as default value.

Question is if the list should be sorted or not but I think it's an advantage if 1000 smaller ones are there and you are just interested in the large ones.

![1](https://user-images.githubusercontent.com/2406720/86290281-80287600-bbed-11ea-875f-8ade00f68b7e.PNG)
![2](https://user-images.githubusercontent.com/2406720/86290289-83bbfd00-bbed-11ea-88a8-a7304f797564.PNG)
![3](https://user-images.githubusercontent.com/2406720/86290295-861e5700-bbed-11ea-80a7-2f4e1655aa29.PNG)

**EDIT:
The list is now unaffected by the setting. The min receive amount can be set to filter out spam.**
![1](https://user-images.githubusercontent.com/2406720/86320322-e7b6e380-bc36-11ea-94a7-11c9f32c8578.PNG)
![2](https://user-images.githubusercontent.com/2406720/86320325-ea193d80-bc36-11ea-958c-20feebf5ac09.PNG)

