### PR TITLE
Improved receive screen

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -67,14 +67,16 @@
           <li routerLink="/accounts" routerLinkActive="uk-active"><a routerLink="/accounts" routerLinkActive="active" class="uk-margin-left">Accounts</a></li>
           <li><a routerLink="/send" routerLinkActive="active" class="uk-margin-left">Send</a></li>
           <li>
-            <div uk-grid>
-              <div class="uk-width-3-4">
-                <a routerLink="/receive" routerLinkActive="active" class="uk-margin-left">Receive</a>
+            <a routerLink="/receive" routerLinkActive="active" class="uk-margin-left">
+              <div uk-grid>
+                <div class="uk-width-3-4">
+                  Receive
+                </div>
+                <div class="uk-width-1-4 uk-text-center">
+                  <span *ngIf="walletService.hasPendingTransactions()" class="uk-badge uk-text-top uk-align-center" style="font-size: 16px; padding-bottom: 2px;">New</span>
+                </div>
               </div>
-              <div class="uk-width-1-4 uk-text-center">
-                <span *ngIf="walletService.hasPendingTransactions()" class="uk-badge uk-text-top uk-align-center" style="font-size: 16px; padding-bottom: 2px;">New</span>
-              </div>
-            </div>
+            </a>
           </li>
           <li><a routerLink="/address-book" routerLinkActive="active" class="uk-margin-left">Address Book</a></li>
           <li class="uk-parent">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -48,7 +48,7 @@
       <ul class="uk-nav uk-nav-default uk-nav-parent-icon left-nav" uk-nav>
         <li routerLink="/accounts" routerLinkActive="uk-active"><a routerLink="/accounts" routerLinkActive="active" class="uk-margin-left " uk-toggle="target: #mobile-nav">Accounts</a></li>
         <li><a routerLink="/send" routerLinkActive="active" class="uk-margin-left " uk-toggle="target: #mobile-nav">Send</a></li>
-        <li *ngIf="walletService.hasPendingTransactions()">
+        <li>
           <div uk-grid>
             <div class="uk-width-3-4">
               <a routerLink="/receive" routerLinkActive="active" class="uk-margin-left " uk-toggle="target: #mobile-nav">Receive</a>
@@ -160,7 +160,7 @@
         <ul class="uk-nav uk-nav-default uk-nav-parent-icon left-nav" uk-nav>
           <li routerLink="/accounts" routerLinkActive="uk-active"><a routerLink="/accounts" routerLinkActive="active" class="uk-margin-left">Accounts</a></li>
           <li><a routerLink="/send" routerLinkActive="active" class="uk-margin-left">Send</a></li>
-          <li *ngIf="walletService.hasPendingTransactions()">
+          <li>
             <div uk-grid>
               <div class="uk-width-3-4">
                 <a routerLink="/receive" routerLinkActive="active" class="uk-margin-left">Receive</a>

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -208,6 +208,10 @@ export class ConfigureAppComponent implements OnInit {
     const newStorage = this.selectedStorage;
     let newPoW = this.selectedPoWOption;
     let pendingOption = this.selectedPendingOption
+    let minReceive = null
+    if (this.util.account.isValidNanoAmount(this.minimumReceive)) {
+      minReceive = this.minimumReceive
+    }
 
     const resaveWallet = this.appSettings.settings.walletStore !== newStorage;
     const reloadPending = this.appSettings.settings.minimumReceive != this.minimumReceive;
@@ -235,7 +239,7 @@ export class ConfigureAppComponent implements OnInit {
       lockInactivityMinutes: new Number(this.selectedInactivityMinutes),
       powSource: newPoW,
       pendingOption: pendingOption,
-      minimumReceive: this.minimumReceive || null,
+      minimumReceive: minReceive,
       defaultRepresentative: this.defaultRepresentative || null,
     };
 

--- a/src/app/components/configure-wallet/configure-wallet.component.html
+++ b/src/app/components/configure-wallet/configure-wallet.component.html
@@ -45,7 +45,7 @@
           <div class="uk-margin">
             <label class="uk-form-label" for="form-horizontal-select">Select Import Type</label>
             <div class="uk-form-controls">
-              <select class="uk-select" [(ngModel)]="selectedImportOption" id="form-horizontal-select" (change)="onMethodChange($event.target.value)">
+              <select class="uk-select" [(ngModel)]="selectedImportOption" id="form-horizontal-select" (change)="onMethodChange(selectedImportOption)">
                 <option *ngFor="let option of importOptions" [value]="option.value">{{ option.name }}</option>
               </select>
             </div>

--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -1,0 +1,3 @@
+.narrow-div {
+    margin-top: 20px;
+}

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -9,22 +9,29 @@
     <div uk-grid>
       <div class="uk-width-1-1">
         <p>
-          When someone sends you Nano, you are also in charge of performing a receive block to actually receive the funds.<br>
-          If you have the wallet open when you receive a transaction, this will be performed automatically.<br>
-          Otherwise, select the account you are expecting to receive from below to search for incoming transactions.
+          Select an account to show the deposit QR.<br>
+          Funds should be received automatically if the wallet is unlocked. If not, you can try find them and receive manually.<br>
+          You can also find full transaction history under <a routerLink="/accounts" routerLinkActive="active">Accounts</a>
         </p>
       </div>
     </div>
 
     <div uk-grid>
       <div class="uk-width-3-4@s">
-        <select class="uk-select" [(ngModel)]="pendingAccountModel">
+        <select class="uk-select" [(ngModel)]="pendingAccountModel" (change)="changeQRAccount(pendingAccountModel)">
           <option [value]="0">All Accounts</option>
           <option *ngFor="let account of accounts" [value]="account.id">{{ account.id }}</option>
         </select>
       </div>
       <div class="uk-width-1-4@s">
         <button class="uk-button uk-button-primary uk-width-1-1" (click)="getPending(pendingAccountModel)"> Find Incoming</button>
+      </div>
+              
+      <div *ngIf="qrCodeImage" class="uk-width-3-4@s narrow-div">
+        <input [(ngModel)]="receiveAmount" class="uk-input uk-margin-small-bottom" type="text" (ngModelChange)="changeQRAmount(receiveAmount)" title="Amount to be included in the QR and read by the sending wallet." placeholder="Optional Nano amount">
+      </div>
+      <div class="uk-width-1-1@s narrow-div">
+        <img *ngIf="qrCodeImage" [src]="qrCodeImage"><br />
       </div>
       <div class="uk-width-1-1">
         <div class="uk-card uk-card-default">

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -3,13 +3,12 @@ import {WalletService} from "../../services/wallet.service";
 import {NotificationService} from "../../services/notification.service";
 import {ModalService} from "../../services/modal.service";
 import {ApiService} from "../../services/api.service";
-import * as blake from 'blakejs';
-import BigNumber from "bignumber.js";
 import {UtilService} from "../../services/util.service";
 import {WorkPoolService} from "../../services/work-pool.service";
 import {AppSettingsService} from "../../services/app-settings.service";
 import {NanoBlockService} from "../../services/nano-block.service";
-const nacl = window['nacl'];
+import * as QRCode from 'qrcode';
+import BigNumber from 'bignumber.js';
 
 @Component({
   selector: 'app-receive',
@@ -21,6 +20,9 @@ export class ReceiveComponent implements OnInit {
 
   pendingAccountModel = 0;
   pendingBlocks = [];
+  qrCodeImage = null;
+  qrAccount = "";
+  qrAmount:BigNumber = null;
 
   constructor(
     private walletService: WalletService,
@@ -105,6 +107,33 @@ export class ReceiveComponent implements OnInit {
       await this.loadPendingForAll();
     } else {
       await this.loadPendingForAccount(account);
+    }
+  }
+
+  async changeQRAccount(account) {
+    this.qrAccount = "";
+    var qrCode = null;
+    if (account.length > 1) {
+      this.qrAccount = account;
+      qrCode = await QRCode.toDataURL("nano:"+account + (this.qrAmount ? "?amount="+this.qrAmount.toString(10):""));
+    }
+    this.qrCodeImage = qrCode;
+  }
+
+  async changeQRAmount(amount) {
+    this.qrAmount = null;
+    var qrCode = null;
+    if (amount != "") {
+      if (this.util.account.isValidNanoAmount(amount)) {
+        this.qrAmount = this.util.nano.mnanoToRaw(amount);
+      }
+      else {
+        return
+      }
+    }
+    if (this.qrAccount.length > 1) {
+      qrCode = await QRCode.toDataURL("nano:"+this.qrAccount + (this.qrAmount ? "?amount="+this.qrAmount.toString(10):""));
+      this.qrCodeImage = qrCode;
     }
   }
 

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -127,9 +127,6 @@ export class ReceiveComponent implements OnInit {
       if (this.util.account.isValidNanoAmount(amount)) {
         this.qrAmount = this.util.nano.mnanoToRaw(amount);
       }
-      else {
-        return
-      }
     }
     if (this.qrAccount.length > 1) {
       qrCode = await QRCode.toDataURL("nano:"+this.qrAccount + (this.qrAmount ? "?amount="+this.qrAmount.toString(10):""));

--- a/src/app/services/util.service.ts
+++ b/src/app/services/util.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import * as blake from 'blakejs';
-import {BigNumber} from 'bignumber.js'
+import {BigNumber} from 'bignumber.js';
+import * as nanocurrency from 'nanocurrency';
 
 const nacl = window['nacl'];
 
@@ -37,6 +38,7 @@ export class UtilService {
     generateSeedBytes: generateSeedBytes,
     getAccountPublicKey: getAccountPublicKey,
     setPrefix: setPrefix,
+    isValidNanoAmount: isValidNanoAmount,
   };
   nano = {
     mnanoToRaw: mnanoToRaw,
@@ -297,6 +299,23 @@ function generateSeedBytes() {
   return nacl.randomBytes(32);
 }
 
+// Check if a string is a numeric and larger than 0 but less than Nano supply
+function isValidNanoAmount(val:string) {
+  //numerics and last character is not a dot and number of dots is 0 or 1
+  let isnum = /^-?\d*\.?\d*$/.test(val)
+  if (isnum && String(val).slice(-1) !== '.') {
+    if (parseFloat(val) > 0 && nanocurrency.checkAmount(mnanoToRaw(val).toString(10))) {
+      return true
+    }
+    else {
+      return false
+    }
+  }
+  else {
+    return false
+  }
+}
+
 const util = {
   hex: {
     toUint4: hexToUint4,
@@ -325,6 +344,7 @@ const util = {
     generateSeedBytes: generateSeedBytes,
     getAccountPublicKey: getAccountPublicKey,
     setPrefix: setPrefix,
+    isValidNanoAmount: isValidNanoAmount,
   },
   nano: {
     mnanoToRaw: mnanoToRaw,


### PR DESCRIPTION
The old receive screen is lacking use case. It's always hidden in the menu accept when the wallet is locked and new incoming tx has been detected. Then you can see them in the list but to receive you must unlock but at that time the wallet has already auto-received them. There is only one use case of that screen; if using Ledger and it messes up the receive block and you have to do it again manually.

The old screen looks like this:
![1](https://user-images.githubusercontent.com/2406720/86539842-203d1280-bf00-11ea-987c-6ae441319bbe.PNG)

**The changes coming with this PR:**

- Always visible in the menu, with a "new" flag visible if there are new incoming
- Same functionality as before to check incoming and do manual receive but when you select an account:
- Display QR (standard syntax for wallets to pick up deeplink)
- Optional amount to be encoded in the QR
- A function that checks if an input string is a valid Nano amount (numerical, not too little, not too big). Also implemented at the "min receive" in the settings page.

This is more in par with how other wallets work and the user should feel more familiar than having to go to the account page, click on the account and then get a QR than is not even compliant with deep link (nano:nano_abc).

New screen:
![2](https://user-images.githubusercontent.com/2406720/86539918-bf620a00-bf00-11ea-9400-0e38f055362f.PNG)
![3](https://user-images.githubusercontent.com/2406720/86539921-cb4dcc00-bf00-11ea-8344-7ae6d9eb6d6c.PNG)
