### PR TITLE
Enhanced transaction handling and bug fixes

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -69,10 +69,10 @@
           <li>
             <a routerLink="/receive" routerLinkActive="active" class="uk-margin-left">
               <div uk-grid>
-                <div class="uk-width-3-4">
+                <div class="uk-width-expand">
                   Receive
                 </div>
-                <div class="uk-width-1-4 uk-text-center">
+                <div class="uk-width-auto uk-text-center">
                   <span *ngIf="walletService.hasPendingTransactions()" class="uk-badge uk-text-top uk-align-center" style="font-size: 16px; padding-bottom: 2px;">New</span>
                 </div>
               </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,7 +5,6 @@ import {AppSettingsService} from "./services/app-settings.service";
 import {WebsocketService} from "./services/websocket.service";
 import {PriceService} from "./services/price.service";
 import {NotificationService} from "./services/notification.service";
-import {PowService} from "./services/pow.service";
 import {WorkPoolService} from "./services/work-pool.service";
 import {Router} from "@angular/router";
 import {RepresentativeService} from "./services/representative.service";
@@ -39,7 +38,6 @@ export class AppComponent implements OnInit {
     public settings: AppSettingsService,
     private websocket: WebsocketService,
     private notifications: NotificationService,
-    private pow: PowService,
     public nodeService: NodeService,
     private representative: RepresentativeService,
     private router: Router,
@@ -64,9 +62,12 @@ export class AppComponent implements OnInit {
 
     this.representative.loadRepresentativeList();
 
-    // If the wallet is locked and there is a pending balance, show a warning to unlock the wallet
-    if (this.wallet.locked && this.walletService.hasPendingTransactions()) {
-      this.notifications.sendWarning(`New incoming transaction - unlock the wallet to receive it!`, { length: 0, identifier: 'pending-locked' });
+    // If the wallet is locked and there is a pending balance, show a warning to unlock the wallet (if not receive priority is set to manual)
+    if (this.wallet.locked && this.walletService.hasPendingTransactions() && this.settings.settings.pendingOption !== 'manual') {
+      this.notifications.sendWarning(`New incoming transaction(s) - Unlock the wallet to receive`, { length: 10000, identifier: 'pending-locked' });
+    }
+    else if (this.walletService.hasPendingTransactions() && this.settings.settings.pendingOption === 'manual') {
+      this.notifications.sendWarning(`Incoming transaction(s) found - Set to be received manually`, { length: 10000, identifier: 'pending-locked' });
     }
 
     // If they are using a Ledger device with a bad browser, warn them

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -1,0 +1,9 @@
+#refresh {
+    cursor: pointer;
+    margin-left: 10px;
+    position: relative;
+    bottom: 3px;
+}
+.refresh-disabled {
+    color: #bbb;
+}

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -143,7 +143,7 @@
 
         <div uk-grid style="margin-top: 25px;">
           <div class="uk-width-1-1">
-            <h3 class="uk-heading-divider uk-text-center" style="margin-bottom: 0;">Recent Transactions<span></span></h3>
+            <h3 class="uk-heading-divider uk-text-center" style="margin-bottom: 0;">Recent Transactions<span class="{{statsRefreshEnabled ? '':'refresh-disabled'}}" id="refresh" uk-icon="icon: refresh;" (click)="loadAccountDetails(true)" uk-tooltip title="Reload the transaction history from the network."></span></h3>
 
 
             <table class="uk-table uk-table-striped uk-table-small" style="margin-top: 0;">

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -80,7 +80,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     this.updateList();
   }
 
-  // check for new pending in any account every 2sec and update list if needed
+  // check for new pending in the main wallet and update list if needed
   async updateList() {
     let accounts = this.wallet.wallet.accounts;
     var tempPending = [];

--- a/src/app/components/configure-app/configure-app.component.html
+++ b/src/app/components/configure-app/configure-app.component.html
@@ -128,7 +128,7 @@
             <div class="uk-form-horizontal">
 
               <div class="uk-margin">
-                <label class="uk-form-label">Receive Priority <span uk-icon="icon: info;" uk-tooltip title="If receiving incoming transactions with the largest amount first or chronological from recorded time."></span></label>
+                <label class="uk-form-label">Receive Method <span uk-icon="icon: info;" uk-tooltip title="If automatically receiving incoming transactions with the largest amount first or chronological from recorded time. Manual will allow you to pick your own transactions from the receive screen."></span></label>
                 <div class="uk-form-controls">
 
                   <div class="uk-inline uk-width-1-1">

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -95,7 +95,7 @@ export class ConfigureAppComponent implements OnInit {
   pendingOptions = [
     { name: 'Largest Amount First', value: 'amount' },
     { name: 'Oldest Transaction First', value: 'date' },
-    { name: 'Manual Receive', value: 'manual' },
+    { name: 'Manual', value: 'manual' },
   ];
   selectedPendingOption = this.pendingOptions[0].value;
 

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -95,6 +95,7 @@ export class ConfigureAppComponent implements OnInit {
   pendingOptions = [
     { name: 'Largest Amount First', value: 'amount' },
     { name: 'Oldest Transaction First', value: 'date' },
+    { name: 'Manual Receive', value: 'manual' },
   ];
   selectedPendingOption = this.pendingOptions[0].value;
 
@@ -213,7 +214,9 @@ export class ConfigureAppComponent implements OnInit {
     }
 
     const resaveWallet = this.appSettings.settings.walletStore !== newStorage;
-    const reloadPending = this.appSettings.settings.minimumReceive != this.minimumReceive;
+
+    // reload pending if threshold changes or if receive priority changes from manual to auto
+    const reloadPending = this.appSettings.settings.minimumReceive != this.minimumReceive || (pendingOption !== 'manual' && pendingOption != this.appSettings.settings.pendingOption);
 
     if (this.defaultRepresentative && this.defaultRepresentative.length) {
       const valid = await this.api.validateAccountNumber(this.defaultRepresentative);

--- a/src/app/components/notifications/notifications.component.css
+++ b/src/app/components/notifications/notifications.component.css
@@ -15,3 +15,10 @@
   left: 15%;
   z-index: 1050;
 }
+
+.uk-alert-success {
+  color: #1fac58;
+}
+.uk-alert-warning {
+  color: #e07421;
+}

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -10,7 +10,7 @@
       <div class="uk-width-1-1">
         <p>
           Select an account to show the deposit QR.<br>
-          Funds should be received automatically if the wallet is unlocked. If not, you can try find them and receive manually.<br>
+          Depending on app setting, funds are received automatically if the wallet is unlocked. If not, you can find them and receive manually.<br>
           You can also find full transaction history under <a routerLink="/accounts" routerLinkActive="active">Accounts</a>
         </p>
       </div>
@@ -51,7 +51,7 @@
                 <div uk-grid>
                   <div class="uk-width-expand uk-text-truncate">
                     <a [routerLink]="'/account/' + block.account" class="uk-link-text" title="View Account Details" uk-tooltip>
-                      {{ block.account }}
+                      {{ block.account | squeeze }}
                     </a>
                   </div>
                   <div class="uk-width-auto" style="padding-left: 10px;">
@@ -65,7 +65,7 @@
                 <div uk-grid>
                   <div class="uk-width-expand uk-text-truncate">
                     <a [routerLink]="'/account/' + block.source" class="uk-link-text" title="View Account Details" uk-tooltip>
-                      {{ block.source }}
+                      {{ block.source | squeeze }}
                     </a>
                   </div>
                   <div class="uk-width-auto" style="padding-left: 10px;">

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -24,7 +24,7 @@
         </select>
       </div>
       <div class="uk-width-1-4@s">
-        <button class="uk-button uk-button-primary uk-width-1-1" (click)="getPending(pendingAccountModel)"> Find Incoming</button>
+        <button class="uk-button uk-button-primary uk-width-1-1" (click)="getPending()"> Find Incoming</button>
       </div>
               
       <div *ngIf="qrCodeImage" class="uk-width-3-4@s narrow-div">
@@ -47,7 +47,7 @@
             </thead>
             <tbody>
             <tr *ngFor="let block of pendingBlocks">
-              <td class="uk-visible-toggle">
+              <td *ngIf="block.account == pendingAccountModel || pendingAccountModel == 0" class="uk-visible-toggle">
                 <div uk-grid>
                   <div class="uk-width-expand uk-text-truncate">
                     <a [routerLink]="'/account/' + block.account" class="uk-link-text" title="View Account Details" uk-tooltip>
@@ -61,7 +61,7 @@
                   </div>
                 </div>
               </td>
-              <td class="uk-visible-toggle">
+              <td *ngIf="block.account == pendingAccountModel || pendingAccountModel == 0" class="uk-visible-toggle">
                 <div uk-grid>
                   <div class="uk-width-expand uk-text-truncate">
                     <a [routerLink]="'/account/' + block.source" class="uk-link-text" title="View Account Details" uk-tooltip>
@@ -75,8 +75,8 @@
                   </div>
                 </div>
               </td>
-              <td>{{ block.amount | rai: settings.settings.displayDenomination }}</td>
-              <td class="uk-text-nowrap">
+              <td *ngIf="block.account == pendingAccountModel || pendingAccountModel == 0">{{ block.amount | rai: settings.settings.displayDenomination }}</td>
+              <td *ngIf="block.account == pendingAccountModel || pendingAccountModel == 0" class="uk-text-nowrap">
                 <button *ngIf="!block.loading" (click)="receivePending(block)" class="uk-button uk-button-secondary uk-button-small">Receive</button>
                 <button *ngIf="block.loading" class="uk-button uk-button-secondary uk-disabled uk-button-small"><span class="uk-margin-right" uk-spinner></span> Loading</button>
               </td>

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -38,7 +38,9 @@ export class ReceiveComponent implements OnInit {
     private util: UtilService) { }
 
   async ngOnInit() {
-    await this.loadPendingForAll();
+    setTimeout(() => {
+      this.getPending();
+    }, 100);
   }
 
   async loadPendingForAll() {
@@ -57,6 +59,8 @@ export class ReceiveComponent implements OnInit {
   }
 
   async getPending() {
+    // clear the list of pending blocks. Updated again with reloadBalances()
+    this.walletService.clearPendingBlocks()
     await this.walletService.reloadBalances(true)
     await this.loadPendingForAll();
   }
@@ -98,7 +102,7 @@ export class ReceiveComponent implements OnInit {
 
     if (newBlock) {
       this.notificationService.sendSuccess(`Successfully received Nano!`);
-      // clear the list of pending blocks
+      // clear the list of pending blocks. Updated again with reloadBalances()
       this.walletService.clearPendingBlocks()
     } else {
       if (!this.walletService.isLedgerWallet()) {

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -50,7 +50,7 @@ export class ReceiveComponent implements OnInit {
     this.shouldLoop = false;
   }
 
-  // check for new pending in any account every 2sec and update list if needed
+  // check for new pending in the main wallet and update list if needed
   async updateList() {
     let accounts = this.walletService.wallet.accounts;
     var tempPending = [];

--- a/src/app/components/wallet-widget/wallet-widget.component.css
+++ b/src/app/components/wallet-widget/wallet-widget.component.css
@@ -1,3 +1,7 @@
 .wallet-bar a {
   color: #fff;
 }
+
+.uk-button {
+  margin-left: 10px;
+}

--- a/src/app/components/wallet-widget/wallet-widget.component.html
+++ b/src/app/components/wallet-widget/wallet-widget.component.html
@@ -25,7 +25,7 @@
           <div *ngIf="walletService.isLocked()" class="uk-text-bottom">
             <span style="cursor: pointer;" (click)="modal.show()">
               <span uk-icon="icon: lock" class="uk-text-top"></span> <span class="uk-text-bottom">Wallet Locked</span>
-              <span *ngIf="walletService.hasPendingTransactions()" style="display: block; padding-left: 3px; font-size: 12px;" class="uk-text-bottom">Unlock to Receive Incoming Funds</span>
+              <span *ngIf="walletService.hasPendingTransactions() && settings.settings.pendingOption !== 'manual'" style="display: block; padding-left: 3px; font-size: 12px;" class="uk-text-bottom">Unlock to Receive Incoming Funds</span>
             </span>
           </div>
           <div *ngIf="!walletService.isLocked()">

--- a/src/app/components/wallet-widget/wallet-widget.component.ts
+++ b/src/app/components/wallet-widget/wallet-widget.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import {WalletService} from "../../services/wallet.service";
 import {NotificationService} from "../../services/notification.service";
 import {LedgerService} from "../../services/ledger.service";
+import {AppSettingsService} from "../../services/app-settings.service";
 
 @Component({
   selector: 'app-wallet-widget',
@@ -17,7 +18,11 @@ export class WalletWidgetComponent implements OnInit {
 
   modal: any = null;
 
-  constructor(public walletService: WalletService, private notificationService: NotificationService, public ledgerService: LedgerService) { }
+  constructor(
+    public walletService: WalletService,
+    private notificationService: NotificationService,
+    public ledgerService: LedgerService,
+    public settings: AppSettingsService) { }
 
   ngOnInit() {
     const UIkit = (window as any).UIkit;

--- a/src/app/services/nano-block.service.ts
+++ b/src/app/services/nano-block.service.ts
@@ -51,7 +51,6 @@ export class NanoBlockService {
       work: null,
     };
 
-    let signature = null;
     if (ledger) {
       const ledgerBlock = {
         previousBlock: toAcct.frontier,
@@ -63,7 +62,7 @@ export class NanoBlockService {
         await this.ledgerService.updateCache(walletAccount.index, toAcct.frontier);
         const sig = await this.ledgerService.signBlock(walletAccount.index, ledgerBlock);
         this.clearLedgerNotification();
-        signature = sig.signature;
+        blockData.signature = sig.signature;
       } catch (err) {
         this.clearLedgerNotification();
         this.sendLedgerDeniedNotification();

--- a/src/app/services/notification.service.ts
+++ b/src/app/services/notification.service.ts
@@ -40,8 +40,7 @@ export class NotificationService {
     this.sendWarning(
       `<b>Notice:</b> You may experience issues using a Ledger device with Google Chrome. ` +
       `If you do please use Brave/Opera browser or ` +
-      `<a href="https://github.com/BitDesert/Nault/releases" target="_blank" rel="noopener">Nault Desktop</a>. ` +
-      `&nbsp; <a href="https://github.com/BitDesert/Nault/issues/69" target="_blank" rel="noopener">More Info</a>`,
+      `<a href="https://github.com/BitDesert/Nault/releases" target="_blank" rel="noopener">Nault Desktop</a>.`,
       { length: 0, identifier: 'chrome-ledger' }
       );
   }

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -114,15 +114,21 @@ export class WalletService {
         const walletAccount = this.wallet.accounts.find(a => a.id === transaction.block.link_as_account);
         if (walletAccount) {
           // If the wallet is locked, show a notification
-          if (this.wallet.locked) {
-            this.notifications.sendWarning(`New incoming transaction - unlock the wallet to receive it!`, { length: 0, identifier: 'pending-locked' });
+          if (this.wallet.locked && this.appSettings.settings.pendingOption !== 'manual') {
+            this.notifications.sendWarning(`New incoming transaction - Unlock the wallet to receive`, { length: 10000, identifier: 'pending-locked' });
+          }
+          else if (this.appSettings.settings.pendingOption === 'manual') {
+            this.notifications.sendWarning(`New incoming transaction - Set to be received manually`, { length: 5000, identifier: 'pending-locked' });
           }
           this.addPendingBlock(walletAccount.id, transaction.hash, transaction.amount);
           await this.processPendingBlocks();
         }
       } else if (transaction.block.type == 'state' && transaction.block.subtype == 'send' && walletAccountIDs.indexOf(transaction.block.link_as_account) !== -1) {
-        if (this.wallet.locked) {
-          this.notifications.sendWarning(`New incoming transaction - unlock the wallet to receive it!`, { length: 0, identifier: 'pending-locked' });
+        if (this.wallet.locked && this.appSettings.settings.pendingOption !== 'manual') {
+          this.notifications.sendWarning(`New incoming transaction - Unlock the wallet to receive`, { length: 10000, identifier: 'pending-locked' });
+        }
+        else if (this.appSettings.settings.pendingOption === 'manual') {
+          this.notifications.sendWarning(`New incoming transaction - Set to be received manually`, { length: 5000, identifier: 'pending-locked' });
         }
 
         await this.processStateBlock(transaction);
@@ -130,7 +136,7 @@ export class WalletService {
       }else if (transaction.block.type == 'state') {
         /* Don't understand when this is ever needed / Json
         if (this.wallet.locked) {
-          this.notifications.sendWarning(`New incoming transaction - unlock the wallet to receive it!`, { length: 0, identifier: 'pending-locked' });
+          this.notifications.sendWarning(`New incoming transaction - Unlock the wallet to receive`, { length: 10000, identifier: 'pending-locked' });
         }*/
 
         await this.processStateBlock(transaction);
@@ -826,7 +832,7 @@ export class WalletService {
   }
 
   async processPendingBlocks() {
-    if (this.processingPending || this.wallet.locked || !this.pendingBlocks.length) return;
+    if (this.processingPending || this.wallet.locked || !this.pendingBlocks.length || this.appSettings.settings.pendingOption === 'manual') return;
 
     // Sort pending by amount
     if (this.appSettings.settings.pendingOption === 'amount') {

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -118,7 +118,7 @@ export class WalletService {
             this.notifications.sendWarning(`New incoming transaction - Unlock the wallet to receive`, { length: 10000, identifier: 'pending-locked' });
           }
           else if (this.appSettings.settings.pendingOption === 'manual') {
-            this.notifications.sendWarning(`New incoming transaction - Set to be received manually`, { length: 5000, identifier: 'pending-locked' });
+            this.notifications.sendWarning(`New incoming transaction - Set to be received manually`, { length: 10000, identifier: 'pending-locked' });
           }
           this.addPendingBlock(walletAccount.id, transaction.hash, transaction.amount);
           await this.processPendingBlocks();
@@ -128,7 +128,7 @@ export class WalletService {
           this.notifications.sendWarning(`New incoming transaction - Unlock the wallet to receive`, { length: 10000, identifier: 'pending-locked' });
         }
         else if (this.appSettings.settings.pendingOption === 'manual') {
-          this.notifications.sendWarning(`New incoming transaction - Set to be received manually`, { length: 5000, identifier: 'pending-locked' });
+          this.notifications.sendWarning(`New incoming transaction - Set to be received manually`, { length: 10000, identifier: 'pending-locked' });
         }
 
         await this.processStateBlock(transaction);

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -28,6 +28,14 @@ export interface WalletAccount {
   pendingFiat: number;
   addressBookName: string|null;
 }
+
+export interface Block {
+  account: string;
+  hash: string;
+  amount: string;
+  source: string;
+}
+
 export interface FullWallet {
   type: WalletType;
   seedBytes: any;
@@ -43,6 +51,7 @@ export interface FullWallet {
   accountsIndex: number;
   locked: boolean;
   password: string;
+  pendingBlocks: Block[];
 }
 
 export interface BaseApiAccount {
@@ -83,10 +92,10 @@ export class WalletService {
     accountsIndex: 0,
     locked: false,
     password: '',
+    pendingBlocks: [],
   };
 
   processingPending = false;
-  pendingBlocks = [];
   successfulBlocks = [];
 
   constructor(
@@ -120,7 +129,7 @@ export class WalletService {
           else if (this.appSettings.settings.pendingOption === 'manual') {
             this.notifications.sendWarning(`New incoming transaction - Set to be received manually`, { length: 10000, identifier: 'pending-locked' });
           }
-          this.addPendingBlock(walletAccount.id, transaction.hash, transaction.amount);
+          this.addPendingBlock(walletAccount.id, transaction.hash, transaction.amount, transaction.block.link_as_account);
           await this.processPendingBlocks();
         }
       } else if (transaction.block.type == 'state' && transaction.block.subtype == 'send' && walletAccountIDs.indexOf(transaction.block.link_as_account) !== -1) {
@@ -174,12 +183,12 @@ export class WalletService {
         const minAmount = this.util.nano.mnanoToRaw(this.appSettings.settings.minimumReceive);
 
         if (txAmount.gt(minAmount)) {
-          this.addPendingBlock(walletAccount.id, transaction.hash, txAmount);
+          this.addPendingBlock(walletAccount.id, transaction.hash, txAmount, transaction.account);
         } else {
           console.log(`Found new pending block that was below minimum receive amount: `, transaction.amount, this.appSettings.settings.minimumReceive);
         }
       } else {
-        this.addPendingBlock(walletAccount.id, transaction.hash, txAmount);
+        this.addPendingBlock(walletAccount.id, transaction.hash, txAmount, transaction.account);
       }
 
       await this.processPendingBlocks();
@@ -788,13 +797,24 @@ export class WalletService {
     return true;
   }
 
-  addPendingBlock(accountID, blockHash, amount) {
+  addPendingBlock(accountID, blockHash, amount, source) {
     if (this.successfulBlocks.indexOf(blockHash) !== -1) return; // Already successful with this block
-    const existingHash = this.pendingBlocks.find(b => b.hash == blockHash);
+    const existingHash = this.wallet.pendingBlocks.find(b => b.hash == blockHash);
     if (existingHash) return; // Already added
 
-    this.pendingBlocks.push({ account: accountID, hash: blockHash, amount: amount });
+    this.wallet.pendingBlocks.push({ account: accountID, hash: blockHash, amount: amount, source: source });
     this.wallet.hasPending = true;
+  }
+
+  // Remove a pending account from the pending list
+  async removePendingBlock(blockHash) {
+    let index = this.wallet.pendingBlocks.findIndex(b => b.hash == blockHash)
+    this.wallet.pendingBlocks.splice(index, 1);
+  }
+
+  // Clear the list of pending blocks
+  async clearPendingBlocks() {
+    this.wallet.pendingBlocks.splice(0, this.wallet.pendingBlocks.length);
   }
 
   async loadPendingBlocksForWallet() {
@@ -816,11 +836,11 @@ export class WalletService {
         if (!pending.blocks[account].hasOwnProperty(block)) continue;
         if (pending.blocks[account] == '') continue; // Accounts show up as nothing with threshold there...
 
-        this.addPendingBlock(account, block, pending.blocks[account][block].amount);
+        this.addPendingBlock(account, block, pending.blocks[account][block].amount, pending.blocks[account][block].source);
       }
     }
 
-    if (this.pendingBlocks.length) {
+    if (this.wallet.pendingBlocks.length) {
       this.processPendingBlocks();
     }
   }
@@ -832,16 +852,16 @@ export class WalletService {
   }
 
   async processPendingBlocks() {
-    if (this.processingPending || this.wallet.locked || !this.pendingBlocks.length || this.appSettings.settings.pendingOption === 'manual') return;
+    if (this.processingPending || this.wallet.locked || !this.wallet.pendingBlocks.length || this.appSettings.settings.pendingOption === 'manual') return;
 
     // Sort pending by amount
     if (this.appSettings.settings.pendingOption === 'amount') {
-      this.pendingBlocks.sort(this.sortByAmount);
+      this.wallet.pendingBlocks.sort(this.sortByAmount);
     }
 
     this.processingPending = true;
 
-    const nextBlock = this.pendingBlocks[0];
+    const nextBlock = this.wallet.pendingBlocks[0];
     if (this.successfulBlocks.find(b => b.hash == nextBlock.hash)) {
       return setTimeout(() => this.processPendingBlocks(), 1500); // Block has already been processed
     }
@@ -865,7 +885,7 @@ export class WalletService {
       return this.notifications.sendError(`There was a problem performing the receive transaction, try manually!`);
     }
 
-    this.pendingBlocks.shift(); // Remove it after processing, to prevent attempting to receive duplicated messages
+    this.wallet.pendingBlocks.shift(); // Remove it after processing, to prevent attempting to receive duplicated messages
     this.processingPending = false;
 
     setTimeout(() => this.processPendingBlocks(), 1500);
@@ -925,5 +945,4 @@ export class WalletService {
       )
     );
   }
-
 }


### PR DESCRIPTION
Made a few changes for how the user interacts with incoming transactions and solved some bugs.

- Added manual option in "receive priority" setting (incoming will be received manually by the user from the receive-page). Also confirmed to work with the Ledger
- The notification of new incoming is cleared after 10sec instead of forced user interaction. The extra message below the wallet lock should be enough to help the user (Unlock to receive incoming).
- Custom notification messages when manual receive is selected
- Automatically receive incoming (if any) when changing back settings from manual to auto
- Removed bad "issue reference link" in a ledger notification message (old nanovault issue)
- Improved notification warning and success text color to make it actually readable (orange and green)
- Temp fix: receive-table view on small screen (by compacting addresses). Fixes #37
- GUI fix for the "New" label beside receive menu on small devices: Now visible
- Update the receive list automatically when new incoming arrive or incoming received (all accounts or individual)
- Update the account detail list automatically when new incoming arrive or incoming received
- Fixed the bug where representative could not be changed on Ledger device fixes #54