### PR TITLE
Mac target only dmg

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
       "app": "./"
     },
     "mac": {
+      "target": "dmg",
       "category": "public.app-category.finance",
       "extendInfo": {
         "CFBundleURLTypes": [


### PR DESCRIPTION
Solves #51 by removing the zip target.
I can't test the Mac releases, so I cannot improve it.
But if @pawapps states that the dmg release works fine it might be better to release just it for now.
That's better for newcomers and reduces confusion.