### PR TITLE
Backend server stats

### DIFF
--- a/src/app/components/configure-app/configure-app.component.css
+++ b/src/app/components/configure-app/configure-app.component.css
@@ -1,6 +1,9 @@
 #node-stats {
     cursor: pointer;
 }
+.node-stats-disabled {
+    color: #bbb;
+}
 #node-stats-table td {
     padding-right: 20px;
 }

--- a/src/app/components/configure-app/configure-app.component.css
+++ b/src/app/components/configure-app/configure-app.component.css
@@ -1,0 +1,6 @@
+#node-stats {
+    cursor: pointer;
+}
+#node-stats-table td {
+    padding-right: 20px;
+}

--- a/src/app/components/configure-app/configure-app.component.css
+++ b/src/app/components/configure-app/configure-app.component.css
@@ -1,5 +1,7 @@
 #node-stats {
     cursor: pointer;
+    position: relative;
+    bottom: 2px;
 }
 .node-stats-disabled {
     color: #bbb;

--- a/src/app/components/configure-app/configure-app.component.html
+++ b/src/app/components/configure-app/configure-app.component.html
@@ -311,9 +311,6 @@
                             <strong>Block Count</strong>
                           </tr>
                           <tr>
-                            <strong>Cemented Blocks</strong>
-                          </tr>
-                          <tr>
                             <strong>Uncemented Blocks</strong>
                           </tr>
                           <tr>
@@ -329,9 +326,6 @@
                           </tr>
                           <tr>
                             {{nodeBlockCount}}
-                          </tr>
-                          <tr>
-                            {{nodeCemented}}
                           </tr>
                           <tr>
                             {{nodeUncemented}}

--- a/src/app/components/configure-app/configure-app.component.html
+++ b/src/app/components/configure-app/configure-app.component.html
@@ -298,7 +298,7 @@
           <div class="uk-width-1-1">
             <div class="uk-form-horizontal">
               <div>
-                <label class="uk-form-label uk-text-right">Node Stats <span id="node-stats" uk-icon="icon: refresh;" (click)="updateNodeStats(true)" uk-tooltip title="Can be used for troubleshooting. Click refresh to update."></span></label>
+                <label class="uk-form-label uk-text-right">Node Stats <span class="{{statsRefreshEnabled ? '':'node-stats-disabled'}}" id="node-stats" uk-icon="icon: refresh;" (click)="updateNodeStats(true)" uk-tooltip title="Can be used for troubleshooting. Click refresh to update."></span></label>
                 <div class="uk-form-controls">
                   <div class="uk-inline uk-width-1-1">
                     <span class="uk-text-meta">
@@ -311,10 +311,10 @@
                             <strong>Block Count</strong>
                           </tr>
                           <tr>
-                            <strong>Unchecked Blocks</strong>
+                            <strong>Cemented Blocks</strong>
                           </tr>
                           <tr>
-                            <strong>Cemented Blocks</strong>
+                            <strong>Uncemented Blocks</strong>
                           </tr>
                           <tr>
                             <strong>Node Version</strong>
@@ -325,16 +325,16 @@
                         </td>
                         <td>
                           <tr>
-                            {{serverAPI ? serverAPI:'Save settings to update'}}
+                            {{serverAPIUpdated ? serverAPI:'Save settings to update'}}
                           </tr>
                           <tr>
                             {{nodeBlockCount}}
                           </tr>
                           <tr>
-                            {{nodeUnchecked}}
+                            {{nodeCemented}}
                           </tr>
                           <tr>
-                            {{nodeCemented}}
+                            {{nodeUncemented}}
                           </tr>
                           <tr>
                             {{nodeVendor}}

--- a/src/app/components/configure-app/configure-app.component.html
+++ b/src/app/components/configure-app/configure-app.component.html
@@ -295,6 +295,62 @@
             </div>
           </div>
 
+          <div class="uk-width-1-1">
+            <div class="uk-form-horizontal">
+              <div>
+                <label class="uk-form-label uk-text-right">Node Stats <span id="node-stats" uk-icon="icon: refresh;" (click)="updateNodeStats(true)" uk-tooltip title="Can be used for troubleshooting. Click refresh to update."></span></label>
+                <div class="uk-form-controls">
+                  <div class="uk-inline uk-width-1-1">
+                    <span class="uk-text-meta">
+                      <table id="node-stats-table">
+                        <td>
+                          <tr>
+                            <strong>Server</strong>
+                          </tr>
+                          <tr>
+                            <strong>Block Count</strong>
+                          </tr>
+                          <tr>
+                            <strong>Unchecked Blocks</strong>
+                          </tr>
+                          <tr>
+                            <strong>Cemented Blocks</strong>
+                          </tr>
+                          <tr>
+                            <strong>Node Version</strong>
+                          </tr>
+                          <tr>
+                            <strong>Network</strong>
+                          </tr>
+                        </td>
+                        <td>
+                          <tr>
+                            {{serverAPI ? serverAPI:'Save settings to update'}}
+                          </tr>
+                          <tr>
+                            {{nodeBlockCount}}
+                          </tr>
+                          <tr>
+                            {{nodeUnchecked}}
+                          </tr>
+                          <tr>
+                            {{nodeCemented}}
+                          </tr>
+                          <tr>
+                            {{nodeVendor}}
+                          </tr>
+                          <tr>
+                            {{nodeNetwork}}
+                          </tr>
+                        </td>
+                      </table>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
         </div>
       </div>
       <div class="uk-card-footer uk-text-right">

--- a/src/app/components/configure-app/configure-app.component.html
+++ b/src/app/components/configure-app/configure-app.component.html
@@ -325,16 +325,16 @@
                             {{serverAPIUpdated ? serverAPI:'Save settings to update'}}
                           </tr>
                           <tr>
-                            {{nodeBlockCount}}
+                            {{nodeBlockCount || 'N/A'}}
                           </tr>
                           <tr>
-                            {{nodeUncemented}}
+                            {{nodeUncemented || 'N/A'}}
                           </tr>
                           <tr>
-                            {{nodeVendor}}
+                            {{nodeVendor || 'N/A'}}
                           </tr>
                           <tr>
-                            {{nodeNetwork}}
+                            {{nodeNetwork || 'N/A'}}
                           </tr>
                         </td>
                       </table>

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -120,12 +120,12 @@ export class ConfigureAppComponent implements OnInit {
   showServerValues = () => this.selectedServer && this.selectedServer !== 'random';
   showServerConfigs = () => this.selectedServer && this.selectedServer === 'custom';
 
-  nodeBlockCount = 'N/A';
-  nodeUnchecked = 'N/A';
-  nodeCemented = 'N/A';
-  nodeUncemented = 'N/A';
-  nodeVendor = 'N/A';
-  nodeNetwork = 'N/A';
+  nodeBlockCount = null;
+  nodeUnchecked = null;
+  nodeCemented = null;
+  nodeUncemented = null;
+  nodeVendor = null;
+  nodeNetwork = null;
   statsRefreshEnabled = true;
 
   constructor(

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -148,7 +148,7 @@ export class ConfigureAppComponent implements OnInit {
   }
 
   async updateNodeStats(refresh=false) {
-    if (this.serverAPIUpdated != this.appSettings.settings.serverAPI || (refresh && !this.statsRefreshEnabled)) return
+    if ((this.serverAPIUpdated != this.appSettings.settings.serverAPI && this.selectedServer === 'random') || (refresh && !this.statsRefreshEnabled)) return
     this.statsRefreshEnabled = false;
     try {
       let blockCount = await this.api.blockCount()
@@ -166,7 +166,7 @@ export class ConfigureAppComponent implements OnInit {
     }
     catch {console.warn("Failed to get node stats: version")}
 
-    setTimeout(() => this.statsRefreshEnabled = true, 10000);
+    setTimeout(() => this.statsRefreshEnabled = true, 5000);
   }
 
   loadFromSettings() {
@@ -365,6 +365,7 @@ export class ConfigureAppComponent implements OnInit {
     const custom = this.serverOptions.find(c => c.value === newServer);
     if (custom) {
       this.serverAPI = custom.api;
+      this.serverAPIUpdated = custom.api;
       this.serverWS = custom.ws;
       this.serverAuth = custom.auth;
     }
@@ -376,8 +377,9 @@ export class ConfigureAppComponent implements OnInit {
     this.nodeUncemented = 'N/A';
     this.nodeVendor = 'N/A';
     this.nodeNetwork = 'N/A';
-    this.serverAPIUpdated = null;
-    this.statsRefreshEnabled = false;
+    this.statsRefreshEnabled = newServer == 'random' ? false:true;
+
+    this.updateNodeStats()
   }
 
   async clearWorkCache() {

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -152,10 +152,10 @@ export class ConfigureAppComponent implements OnInit {
     this.statsRefreshEnabled = false;
     try {
       let blockCount = await this.api.blockCount()
-      this.nodeBlockCount = this.util.string.addCommas(blockCount.count.toString())
-      this.nodeUnchecked = this.util.string.addCommas(blockCount.unchecked.toString())
-      this.nodeCemented = this.util.string.addCommas(blockCount.cemented.toString())
-      this.nodeUncemented = (parseInt(this.nodeBlockCount) - parseInt(this.nodeCemented)).toString()
+      this.nodeBlockCount = Number(blockCount.count).toLocaleString('en-US')
+      this.nodeUnchecked = Number(blockCount.unchecked).toLocaleString('en-US')
+      this.nodeCemented = Number(blockCount.cemented).toLocaleString('en-US')
+      this.nodeUncemented = Number(blockCount.count - blockCount.cemented).toLocaleString('en-US')
     }
     catch {console.warn("Failed to get node stats: block count")}
     

--- a/src/app/services/util.service.ts
+++ b/src/app/services/util.service.ts
@@ -37,7 +37,6 @@ export class UtilService {
   };
   string = {
     isNumeric: isNumeric,
-    addCommas: addCommas,
   };
   account = {
     generateAccountSecretKeyBytes: generateAccountSecretKeyBytes,
@@ -213,19 +212,6 @@ function stringToUint5(string) {
   return uint5;
 }
 
-//thousand separator
-function addCommas(nStr) {
-  nStr += '';
-  var x = nStr.split('.');
-  var x1 = x[0];
-  var x2 = x.length > 1 ? '.' + x[1] : '';
-  var rgx = /(\d+)(\d{3})/;
-  while (rgx.test(x1)) {
-      x1 = x1.replace(rgx, '$1,$2');
-  }
-  return x1 + x2;
-}
-
 function isNumeric(val) {
   //numerics and last character is not a dot and number of dots is 0 or 1
   let isnum = /^-?\d*\.?\d*$/.test(val) && val != ''
@@ -379,7 +365,6 @@ const util = {
   },
   string: {
     isNumeric: isNumeric,
-    addCommas: addCommas,
   },
   account: {
     generateAccountSecretKeyBytes: generateAccountSecretKeyBytes,

--- a/src/app/services/util.service.ts
+++ b/src/app/services/util.service.ts
@@ -37,6 +37,7 @@ export class UtilService {
   };
   string = {
     isNumeric: isNumeric,
+    addCommas: addCommas,
   };
   account = {
     generateAccountSecretKeyBytes: generateAccountSecretKeyBytes,
@@ -212,6 +213,19 @@ function stringToUint5(string) {
   return uint5;
 }
 
+//thousand separator
+function addCommas(nStr) {
+  nStr += '';
+  var x = nStr.split('.');
+  var x1 = x[0];
+  var x2 = x.length > 1 ? '.' + x[1] : '';
+  var rgx = /(\d+)(\d{3})/;
+  while (rgx.test(x1)) {
+      x1 = x1.replace(rgx, '$1,$2');
+  }
+  return x1 + x2;
+}
+
 function isNumeric(val) {
   //numerics and last character is not a dot and number of dots is 0 or 1
   let isnum = /^-?\d*\.?\d*$/.test(val) && val != ''
@@ -365,6 +379,7 @@ const util = {
   },
   string: {
     isNumeric: isNumeric,
+    addCommas: addCommas,
   },
   account: {
     generateAccountSecretKeyBytes: generateAccountSecretKeyBytes,

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,4 +23,4 @@
 
 .uk-panel-scrollable {
     resize: none;
-  }
+}


### PR DESCRIPTION
A first test of how server info can be displayed. Useful for troubleshooting transactions during network saturation. Fixes #50 

Works for random, pre-configured or custom backend. Stats can be refreshed on the fly but not faster than every 10sec.

![image](https://user-images.githubusercontent.com/2406720/87405898-55142e00-c5c0-11ea-97b7-ec5e9453b85d.png)
![image](https://user-images.githubusercontent.com/2406720/87406153-a15f6e00-c5c0-11ea-8029-55928b9c2dc0.png)
