### PR TITLE
Remote signing

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -16,6 +16,7 @@ import {RepresentativesComponent} from "./components/representatives/representat
 import {SweeperComponent} from "./components/sweeper/sweeper.component";
 import {QrScanComponent} from "./components/qr-scan/qr-scan.component";
 import {SignComponent} from "./components/sign/sign.component";
+import {RemoteSigningComponent} from "./components/remote-signing/remote-signing.component";
 
 import { environment } from '../environments/environment';
 import {ManageRepresentativesComponent} from "./components/manage-representatives/manage-representatives.component";
@@ -38,6 +39,7 @@ const routes: Routes = [
   { path: 'transaction/:transaction', component: TransactionDetailsComponent },
   { path: 'sweeper', component: SweeperComponent },
   { path: 'sign', component: SignComponent },
+  { path: 'remote-signing', component: RemoteSigningComponent },
 ];
 
 @NgModule({

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -15,6 +15,7 @@ import { ImportAddressBookComponent } from './components/import-address-book/imp
 import {RepresentativesComponent} from "./components/representatives/representatives.component";
 import {SweeperComponent} from "./components/sweeper/sweeper.component";
 import {QrScanComponent} from "./components/qr-scan/qr-scan.component";
+import {SignComponent} from "./components/sign/sign.component";
 
 import { environment } from '../environments/environment';
 import {ManageRepresentativesComponent} from "./components/manage-representatives/manage-representatives.component";
@@ -36,6 +37,7 @@ const routes: Routes = [
   { path: 'manage-representatives', component: ManageRepresentativesComponent },
   { path: 'transaction/:transaction', component: TransactionDetailsComponent },
   { path: 'sweeper', component: SweeperComponent },
+  { path: 'sign', component: SignComponent },
 ];
 
 @NgModule({

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -81,12 +81,18 @@
           <li><a routerLink="/address-book" routerLinkActive="active" class="uk-margin-left">Address Book</a></li>
           <li><a routerLink="/qr-scan" routerLinkActive="active" class="uk-margin-left ">Scan QR Code</a></li>
           <li class="uk-parent">
+            <a href="#" class="uk-margin-left">Advanced Tools</a>
+            <ul class="uk-nav-sub">
+              <li><a routerLink="/sweeper" routerLinkActive="active" class="uk-margin-left">Wallet Sweeper</a></li>
+              <li><a routerLink="/remote-signing" routerLinkActive="active" class="uk-margin-left">Remote Signing</a></li>
+            </ul>
+          </li>
+          <li class="uk-parent">
             <a href="#" class="uk-margin-left">Settings</a>
             <ul class="uk-nav-sub">
               <li><a routerLink="/representatives" [queryParams]="" routerLinkActive="active" class="uk-margin-left">Representatives</a></li>
               <li><a routerLink="/configure-app" routerLinkActive="active" class="uk-margin-left">App Settings</a></li>
               <li><a routerLink="/manage-wallet" routerLinkActive="active" class="uk-margin-left">Manage Wallet</a></li>
-              <li><a routerLink="/sweeper" routerLinkActive="active" class="uk-margin-left">Wallet Sweeper</a></li>
               <li><a routerLink="/configure-wallet" routerLinkActive="active" class="uk-margin-left">Configure New Wallet</a></li>
             </ul>
           </li>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -113,7 +113,7 @@
         </div>
 
       </div>
-      <div class="uk-width-expand uk-width-1-1 content-container" [class.nav-expanded]="navExpanded" (click)="navExpanded = false;" style="background: #f0f1f1;" [style.height]="windowHeight + 'px'">
+      <div class="uk-width-expand uk-width-1-1 content-container" [class.nav-expanded]="navExpanded" (click)="closeNav()" style="background: #f0f1f1;" [style.height]="windowHeight + 'px'">
         <div class="uk-panel uk-panel-scrollable uk-height-1-1" style="border: 0; height: 100%;">
           <router-outlet></router-outlet>
         </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -109,6 +109,7 @@ export class AppComponent implements OnInit {
     }, 1000);
 
     try {
+      if (!this.settings.settings.serverAPI) return;
       await this.updateFiatPrices();
     } catch (err) {
       this.notifications.sendWarning(`There was an issue retrieving latest Nano price.  Ensure your AdBlocker is disabled on this page then reload to see accurate FIAT values.`, { length: 0, identifier: `price-adblock` });
@@ -165,6 +166,10 @@ export class AppComponent implements OnInit {
   }
 
   retryConnection() {
+    if (!this.settings.settings.serverAPI) {
+      this.notifications.sendInfo(`Wallet server settings is set to offline mode. Please change server first!`);
+      return;
+    }
     this.walletService.reloadBalances(true);
     this.notifications.sendInfo(`Attempting to reconnect to Nano node`);
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -135,6 +135,10 @@ export class AppComponent implements OnInit {
     this.navExpanded = !this.navExpanded
   }
 
+  closeNav() {
+    this.navExpanded = false;
+  }
+
   toggleSearch(mobile = false) {
     this.showSearchBar = !this.showSearchBar;
     if (this.showSearchBar) {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -49,6 +49,7 @@ import { ChangeRepWidgetComponent } from './components/change-rep-widget/change-
 import { SweeperComponent } from './components/sweeper/sweeper.component';
 import { QrScanComponent } from './components/qr-scan/qr-scan.component';
 import {SignComponent} from "./components/sign/sign.component";
+import {RemoteSigningComponent} from "./components/remote-signing/remote-signing.component";
 
 // QR code module
 import { ZXingScannerModule } from '@zxing/ngx-scanner';
@@ -82,6 +83,7 @@ import { ZXingScannerModule } from '@zxing/ngx-scanner';
     SweeperComponent,
     QrScanComponent,
     SignComponent,
+    RemoteSigningComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -48,6 +48,7 @@ import { AccountPipe } from './pipes/account.pipe';
 import { ChangeRepWidgetComponent } from './components/change-rep-widget/change-rep-widget.component';
 import { SweeperComponent } from './components/sweeper/sweeper.component';
 import { QrScanComponent } from './components/qr-scan/qr-scan.component';
+import {SignComponent} from "./components/sign/sign.component";
 
 // QR code module
 import { ZXingScannerModule } from '@zxing/ngx-scanner';
@@ -80,6 +81,7 @@ import { ZXingScannerModule } from '@zxing/ngx-scanner';
     ChangeRepWidgetComponent,
     SweeperComponent,
     QrScanComponent,
+    SignComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -50,6 +50,7 @@ import { SweeperComponent } from './components/sweeper/sweeper.component';
 import { QrScanComponent } from './components/qr-scan/qr-scan.component';
 import {SignComponent} from "./components/sign/sign.component";
 import {RemoteSigningComponent} from "./components/remote-signing/remote-signing.component";
+import {RemoteSignService} from "./services/remote-sign.service";
 
 // QR code module
 import { ZXingScannerModule } from '@zxing/ngx-scanner';
@@ -111,6 +112,7 @@ import { ZXingScannerModule } from '@zxing/ngx-scanner';
     NodeService,
     LedgerService,
     DesktopService,
+    RemoteSignService,
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -1,0 +1,17 @@
+.block-qr {
+    margin:auto;
+    max-width: 600px;
+}
+
+@media only screen and (max-width: 1200px) {
+    .block-qr {
+        max-width: 1200px;
+    }
+}
+
+#remote {
+    cursor: pointer;
+    margin-left: 10px;
+    position: relative;
+    bottom: 3px;
+}

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -9,6 +9,22 @@
     }
 }
 
+.modal-qr {
+    width: 80%;
+    max-width: 650px !important;
+    padding: 20px 0 0 0;
+}
+
+@media only screen and (max-width: 1200px) {
+    .modal-qr {
+        width: 100%;
+        max-width: 1200px !important;
+    }
+    .modal-qr-body {
+        padding: 30px 5px;
+    }
+}
+
 #remote {
     cursor: pointer;
     margin-left: 10px;

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -1,5 +1,6 @@
 .block-qr {
     margin:auto;
+    width: 100%;
     max-width: 600px;
 }
 
@@ -23,6 +24,16 @@
     .modal-qr-body {
         padding: 30px 5px;
     }
+
+    .modal-block-body {
+        padding: 30px 20px;
+    }
+}
+
+.modal-block {
+    width: 100%;
+    max-width: 1200px !important;
+    padding: 20px 0 0 0;
 }
 
 #remote {

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -12,7 +12,7 @@
 
 .modal-qr {
     width: 80%;
-    max-width: 650px !important;
+    max-width: 750px !important;
     padding: 20px 0 0 0;
 }
 

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -376,7 +376,7 @@
             <div class="uk-inline uk-width-1-1">
               <span class="uk-form-icon uk-form-icon-flip" *ngIf="toAccountStatus === 0" uk-icon="icon: warning"></span>
               <span class="uk-form-icon uk-form-icon-flip"*ngIf="toAccountStatus === 2" uk-icon="icon: check"></span>
-              <input (blur)="validateRepresentative()" (keyup)="searchRepresentatives()" (focus)="searchRepresentatives()" [(ngModel)]="representativeModel" class="uk-input" [ngClass]="{ 'uk-form-success': repStatus === 2, 'uk-form-danger': repStatus === 0 }" id="form-horizontal-text3" type="text" placeholder="nano_abc...123" #repInput>
+              <input (blur)="validateRepresentative()" (keyup)="searchRepresentatives()" (focus)="searchRepresentatives()" (keyup.enter)="generateChange()" [(ngModel)]="representativeModel" class="uk-input" [ngClass]="{ 'uk-form-success': repStatus === 2, 'uk-form-danger': repStatus === 0 }" id="form-horizontal-text3" type="text" placeholder="nano_abc...123" #repInput>
               
               <div *ngIf="(representativeResults$ | async).length" [hidden]="!showRepresentatives" class="uk-animation-slide-down-small uk-width-1-1 uk-card uk-card-default uk-card-body uk-position-absolute" style="z-index: 15000">
                 <ul class="uk-nav uk-nav-default">

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -142,17 +142,17 @@
         </div>
 
         <!--REMOTE SIGNING-->
-        <div uk-grid style="margin-top: 25px;">
+        <div uk-grid style="margin-top: 5px;">
           <div class="uk-width-1-1">
             <div class="uk-card-body">
-              <h3 class="uk-heading-divider uk-text-center">Remote Signing<span *ngIf="remoteVisible" id="remote" uk-icon="icon: shrink;" (click)="showRemote(remoteVisible)" uk-tooltip title="Start Remote Signing"></span><span *ngIf="!remoteVisible" id="remote" uk-icon="icon: expand;" (click)="showRemote(remoteVisible)" uk-tooltip title="Start Remote Signing"></span></h3>
+              <h3 class="uk-heading-divider uk-text-center">Remote Signing (Send or Change Rep)<span *ngIf="remoteVisible" id="remote" uk-icon="icon: shrink;" (click)="showRemote(remoteVisible)" uk-tooltip title="Start Remote Signing"></span><span *ngIf="!remoteVisible" id="remote" uk-icon="icon: expand;" (click)="showRemote(remoteVisible)" uk-tooltip title="Start Remote Signing"></span></h3>
               <div *ngIf="remoteVisible">
                 <div class="uk-form-horizontal">
                   <div class="uk-margin">
                     <ol>
-                      <li>Generate a send block</li>
-                      <li>Scan the QR with a remote wallet (for example an offline Nault) to sign it using a wallet owning to the account above</li>
-                      <li><a routerLink="/qr-scan" routerLinkActive="active">Scan the resulting QR code</a>. Then confirm to publish the block!</li>
+                      <li>Generate a Nano block</li>
+                      <li>Scan the unsigned QR with a remote wallet (for example an offline Nault). Sign it using the methods provided.</li>
+                      <li><a routerLink="/qr-scan" routerLinkActive="active">Scan the signed QR code</a>. Then confirm to publish the block!</li>
                     </ol>
                     <label class="uk-form-label" for="form-horizontal-text2">To Account</label>
                     <div class="uk-form-controls">
@@ -224,7 +224,7 @@
                 <img *ngIf="qrCodeImageBlock" [src]="qrCodeImageBlock"><br />
               </div>
               <div *ngIf="blockHash" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
-                <span class="uk-text-small" uk-tooltip title="Block Hash" style="overflow-wrap: anywhere;">{{blockHash}}</span>
+                <span class="uk-text-small" uk-tooltip title="Block Hash" style="overflow-wrap: anywhere;">{{blockHash | squeeze}}</span>
                 <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
                   <li><a ngxClipboard [cbContent]="blockHash" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
                 </ul>
@@ -243,9 +243,10 @@
               <thead>
               <tr>
                 <th class="uk-width-1-6@m uk-width-1-6">Date</th>
-                <th class="uk-width-2-5@m uk-width-1-3">Account</th>
+                <th class="uk-width-1-5@m uk-width-1-4">Account</th>
                 <th class="uk-width-1-5@m uk-width-1-4">Amount</th>
                 <th class="uk-width-1-5@m uk-width-1-4">Hash</th>
+                <th class="uk-width-1-5@m uk-width-1-4">Incoming</th>
               </tr>
               </thead>
               <tbody>
@@ -257,7 +258,7 @@
                   <div uk-grid>
                     <div class="uk-width-expand uk-text-truncate">
                       <a [routerLink]="'/account/' + pending.account" class="uk-link-text" title="View Account Details" uk-tooltip>
-                        <span *ngIf="pending.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ pending.addressBookName }}</span> {{ pending.account }}
+                        <span *ngIf="pending.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ pending.addressBookName }}</span> {{ pending.account | squeeze }}
                       </a>
                     </div>
                     <div class="uk-width-auto" style="padding-left: 10px;">
@@ -271,6 +272,7 @@
                   +{{ pending.amount | rai: settings.settings.displayDenomination }}*
                 </td>
                 <td class="uk-text-truncate"><a [routerLink]="'/transaction/' + pending.hash" class="uk-link-text" title="View Block Details" uk-tooltip>{{ pending.hash }}</a></td>
+                <td><button class="uk-button uk-button-primary uk-text-center uk-width-auto" style="height: 28px; line-height: 28px;" type="button" (click)="generateReceive(pending.hash)">REMOTE SIGN</button></td>
               </tr>
 
               <tr *ngFor="let history of accountHistory">
@@ -280,7 +282,7 @@
                   <div uk-grid>
                     <div class="uk-width-expand uk-text-truncate">
                       <a [routerLink]="'/account/' + (history.link_as_account || history.account)" class="uk-link-text" title="View Account Details" uk-tooltip>
-                        <span *ngIf="history.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ history.addressBookName }}</span> {{ history.link_as_account || history.account }}
+                        <span *ngIf="history.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ history.addressBookName }}</span> {{ history.link_as_account || history.account | squeeze }}
                       </a>
                     </div>
                     <div class="uk-width-auto" style="padding-left: 10px;">
@@ -317,5 +319,30 @@
       * Incoming Transaction
     </div>
 
+  </div>
+</div>
+
+<!-- Modal for remote receive incoming -->
+<div id="receive-modal" uk-modal>
+  <div class="uk-modal-dialog uk-modal-body modal-qr">
+    <button class="uk-modal-close-default" type="button" uk-close></button>
+    <div class="uk-modal-header">
+        <h2 class="uk-modal-title">Remote Signing of Incoming Block</h2>
+    </div>
+    <div class="uk-modal-body modal-qr-body">
+      <ol>
+        <li>Scan the unsigned QR with a remote wallet (for example an offline Nault). Sign it using the methods provided.</li>
+        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan the signed QR code</a>. Then confirm to publish the block!</li>
+      </ol>
+      <div class="uk-width-1-1 uk-text-center">
+        <img *ngIf="qrCodeImageBlockReceive" [src]="qrCodeImageBlockReceive"><br />
+      </div>
+      <div *ngIf="blockHashReceive" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
+        <span class="uk-text-small" uk-tooltip title="Block Hash" style="overflow-wrap: anywhere;">{{blockHashReceive | squeeze}}</span>
+        <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+          <li><a ngxClipboard [cbContent]="blockHashReceive" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
+        </ul>
+      </div>
+    </div>
   </div>
 </div>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -264,8 +264,8 @@
     </div>
     <div class="uk-modal-body modal-qr-body">
       <ol>
-        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the unsigned QR with an offline Nault, or copy the "Unsigned Block" to <a routerLink="/remote-signing" routerLinkActive="active">Step 2</a>.</li>
-        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the new signed QR with an online Nault, or copy the "Signed Block" to <a routerLink="/remote-signing" routerLinkActive="active">Step 3</a>.</li>
+        <li><a routerLink="/qr-scan" routerLinkActive="active" class="uk-modal-close">Scan</a> the unsigned QR with an offline Nault, or copy the "Unsigned Block" to <a routerLink="/remote-signing" routerLinkActive="active" class="uk-modal-close">Step 2</a>.</li>
+        <li><a routerLink="/qr-scan" routerLinkActive="active" class="uk-modal-close">Scan</a> the new signed QR with an online Nault, or copy the "Signed Block" to <a routerLink="/remote-signing" routerLinkActive="active" class="uk-modal-close">Step 3</a>.</li>
       </ol>
 
       <div *ngIf="blockHashReceive" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
@@ -296,8 +296,8 @@
     <div class="uk-modal-body modal-block-body">
       <ol>
         <li>Generate a Nano block below. No wallet login needed.</li>
-        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the unsigned QR with an offline Nault, or copy the "Unsigned Block" to <a routerLink="/remote-signing" routerLinkActive="active">Step 2</a>.</li>
-        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the new signed QR with an online Nault, or copy the "Signed Block" to <a routerLink="/remote-signing" routerLinkActive="active">Step 3</a>.</li>
+        <li><a routerLink="/qr-scan" routerLinkActive="active" class="uk-modal-close">Scan</a> the unsigned QR with an offline Nault, or copy the "Unsigned Block" to <a routerLink="/remote-signing" routerLinkActive="active" class="uk-modal-close">Step 2</a>.</li>
+        <li><a routerLink="/qr-scan" routerLinkActive="active" class="uk-modal-close">Scan</a> the new signed QR with an online Nault, or copy the "Signed Block" to <a routerLink="/remote-signing" routerLinkActive="active" class="uk-modal-close">Step 3</a>.</li>
       </ol>
 
       <span><strong>Block Type</strong></span><span uk-icon="icon: info;" uk-tooltip title="The block type to create for remote signing. Receiving can be done from the Recent Transactions below."></span><br>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -264,17 +264,23 @@
     </div>
     <div class="uk-modal-body modal-qr-body">
       <ol>
-        <li>Scan the unsigned QR with an offline Nault. Sign it using the methods provided.</li>
-        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the new signed QR with an online Nault. Confirm to publish the block!</li>
+        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the unsigned QR with an offline Nault, or copy the "Unsigned Block" to <a routerLink="/remote-signing" routerLinkActive="active">Step 2</a>.</li>
+        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the new signed QR with an online Nault, or copy the "Signed Block" to <a routerLink="/remote-signing" routerLinkActive="active">Step 3</a>.</li>
       </ol>
-      <div class="uk-width-1-1 uk-text-center">
-        <img *ngIf="qrCodeImageBlockReceive" [src]="qrCodeImageBlockReceive"><br />
-      </div>
+
       <div *ngIf="blockHashReceive" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
-        <span class="uk-text-small" uk-tooltip title="Block Hash" style="overflow-wrap: anywhere;">{{blockHashReceive | squeeze}}</span>
+        <span class="uk-text-small" uk-tooltip title="Unsigned block string to be copied to remote device" style="overflow-wrap: anywhere;"><strong>Unsigned Block</strong></span>
+        <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+          <li><a ngxClipboard [cbContent]="qrString" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
+        </ul>
+        <span class="uk-text-small" uk-tooltip title="Final block hash to be signed or verified" style="overflow-wrap: anywhere; margin-left: 50px;"><strong>Block Hash</strong></span>
         <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
           <li><a ngxClipboard [cbContent]="blockHashReceive" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
         </ul>
+      </div>
+
+      <div class="uk-width-1-1 uk-text-center">
+        <img *ngIf="qrCodeImageBlockReceive" [src]="qrCodeImageBlockReceive" class="block-qr"><br />
       </div>
     </div>
   </div>
@@ -289,9 +295,9 @@
     </div>
     <div class="uk-modal-body modal-block-body">
       <ol>
-        <li>Generate a Nano block below (no Nault login needed)</li>
-        <li>Scan the unsigned QR with an offline Nault. Sign it using the methods provided.</li>
-        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the new signed QR with an online Nault. Confirm to publish the block!</li>
+        <li>Generate a Nano block below. No wallet login needed.</li>
+        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the unsigned QR with an offline Nault, or copy the "Unsigned Block" to <a routerLink="/remote-signing" routerLinkActive="active">Step 2</a>.</li>
+        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the new signed QR with an online Nault, or copy the "Signed Block" to <a routerLink="/remote-signing" routerLinkActive="active">Step 3</a>.</li>
       </ol>
 
       <span><strong>Block Type</strong></span><span uk-icon="icon: info;" uk-tooltip title="The block type to create for remote signing. Receiving can be done from the Recent Transactions below."></span><br>
@@ -398,14 +404,18 @@
       <button *ngIf="blockTypeSelected === blockTypes[0]" class="uk-button uk-button-primary uk-text-center uk-width-1-1" type="button" style="margin-bottom: 20px;" (click)="generateSend()">Generate Send Block</button>
       <button *ngIf="blockTypeSelected === blockTypes[1]" class="uk-button uk-button-primary uk-text-center uk-width-1-1" type="button" style="margin-bottom: 20px;" (click)="generateChange()">Generate Change Block</button>
 
-      <div class="uk-width-1-1 uk-text-center">
-        <img *ngIf="qrCodeImageBlock" [src]="qrCodeImageBlock" class="block-qr"><br />
-      </div>
       <div *ngIf="blockHash" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
-        <span class="uk-text-small" uk-tooltip title="Block Hash" style="overflow-wrap: anywhere;">{{blockHash | squeeze}}</span>
+        <span class="uk-text-small" uk-tooltip title="Unsigned block string to be copied to remote device" style="overflow-wrap: anywhere;"><strong>Unsigned Block</strong></span>
+        <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+          <li><a ngxClipboard [cbContent]="qrString" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
+        </ul>
+        <span class="uk-text-small" uk-tooltip title="Final block hash to be signed or verified" style="overflow-wrap: anywhere; margin-left: 50px;"><strong>Block Hash</strong></span>
         <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
           <li><a ngxClipboard [cbContent]="blockHash" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
         </ul>
+      </div>
+      <div class="uk-width-1-1 uk-text-center">
+        <img *ngIf="qrCodeImageBlock" [src]="qrCodeImageBlock" class="block-qr"><br />
       </div>
     </div>
   </div>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -380,7 +380,7 @@
               
               <div *ngIf="(representativeResults$ | async).length" [hidden]="!showRepresentatives" class="uk-animation-slide-down-small uk-width-1-1 uk-card uk-card-default uk-card-body uk-position-absolute" style="z-index: 15000">
                 <ul class="uk-nav uk-nav-default">
-                  <li class="uk-nav-header">Recommended Representatives</li>
+                  <li class="uk-nav-header">Representative List Results</li>
                   <li class="uk-nav-divider"></li>
                   <li *ngFor="let rep of representativeResults$ | async">
                     <a (click)="selectRepresentative(rep.id)">

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -141,6 +141,99 @@
           </div>
         </div>
 
+        <!--REMOTE SIGNING-->
+        <div uk-grid style="margin-top: 25px;">
+          <div class="uk-width-1-1">
+            <div class="uk-card-body">
+              <h3 class="uk-heading-divider uk-text-center">Remote Signing<span *ngIf="remoteVisible" id="remote" uk-icon="icon: shrink;" (click)="showRemote(remoteVisible)" uk-tooltip title="Start Remote Signing"></span><span *ngIf="!remoteVisible" id="remote" uk-icon="icon: expand;" (click)="showRemote(remoteVisible)" uk-tooltip title="Start Remote Signing"></span></h3>
+              <div *ngIf="remoteVisible">
+                <div class="uk-form-horizontal">
+                  <div class="uk-margin">
+                    <ol>
+                      <li>Generate a send block</li>
+                      <li>Scan the QR with a remote wallet (for example an offline Nault) to sign it using a wallet corresponding to the account above</li>
+                      <li><a routerLink="/qr-scan" routerLinkActive="active">Scan the resulting QR code</a>. Then confirm to publish the block!</li>
+                    </ol>
+                    <label class="uk-form-label" for="form-horizontal-text2">To Account</label>
+                    <div class="uk-form-controls">
+                      <div class="uk-inline uk-width-1-1">
+                        <span class="uk-form-icon uk-form-icon-flip" *ngIf="toAccountStatus === 0" uk-icon="icon: warning"></span>
+                        <span class="uk-form-icon uk-form-icon-flip"*ngIf="toAccountStatus === 2" uk-icon="icon: check"></span>
+                        <input (blur)="validateDestination()" (keyup)="searchAddressBook()" (focus)="searchAddressBook()" [(ngModel)]="toAccountID" [ngClass]="{ 'uk-form-success': toAccountStatus === 2, 'uk-form-danger': toAccountStatus === 0 }" class="uk-input" id="form-horizontal-text2" type="text" placeholder="Account to send to" autocomplete="off">
+
+                        <div *ngIf="(addressBookResults$ | async).length" [hidden]="!showAddressBook" class="uk-animation-slide-down-small uk-width-1-1 uk-card uk-card-default uk-card-body uk-position-absolute" style="z-index: 15000">
+                          <ul class="uk-nav uk-nav-default">
+                            <li class="uk-nav-header">Address Book Results</li>
+                            <li class="uk-nav-divider"></li>
+                            <li *ngFor="let book of addressBookResults$ | async">
+                              <a (click)="selectBookEntry(book.account)">{{ book.name }}</a>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div class="uk-form-controls" *ngIf="addressBookMatch">
+                      <div class="uk-inline uk-width-1-1">
+                        <span class="uk-label uk-label-primary">{{ addressBookMatch }}</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div uk-grid>
+                    <div class="uk-width-1-1">
+                      <label class="uk-form-label" for="form-horizontal-text">Amount</label>
+                      <div class="uk-form-controls">
+                        <div uk-grid>
+                          <div class="uk-width-3-5">
+                            <div class="uk-inline uk-width-1-1">
+                              <a class="uk-form-icon uk-form-icon-flip" (click)="setMaxAmount()" style="padding-right: 7px;" uk-tooltip title="Set Maximum Amount">Max</a>
+                              <input [(ngModel)]="amount" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="text" placeholder="Amount of {{ selectedAmount.name }} to send">
+                            </div>
+
+                          </div>
+                          <div class="uk-width-2-5">
+                            <div class="uk-inline uk-width-1-1">
+                              <button class="uk-button uk-button-secondary uk-width-1-1" type="button" style="text-transform: none;">{{ selectedAmount.shortName }}</button>
+                              <div uk-dropdown>
+                                <ul class="uk-nav uk-dropdown-nav">
+                                  <li class="uk-active uk-dropdown-spacing" *ngFor="let amount of amounts" (click)="selectedAmount = amount; syncNanoPrice();">{{ amount.name }}</li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+
+                          <div class="uk-width-1-1 uk-width-3-5@s" style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
+                            <div class="uk-width-1-1 uk-inline">
+                              <a class="uk-form-icon uk-link-reset uk-link-muted" style="padding-left: 7px;" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
+                              <input [(ngModel)]="amountFiat" (keyup)="syncNanoPrice()" (change)="syncNanoPrice()" style="padding-left: 50px; border: 0; border-bottom: 1px solid #e5e5e5;" class="uk-input" id="form-horizontal-text-fiat" type="text" placeholder="Amount of {{ settings.settings.displayCurrency }} to send">
+                            </div>
+                          </div>
+
+                        </div>
+
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <button class="uk-button uk-button-primary uk-text-center uk-width-1-1" type="button" style="margin-bottom: 20px;" (click)="generateSend()">Generate Send Block</button>
+              </div>
+            </div>
+            <div *ngIf="remoteVisible">
+              <div class="uk-width-1-1@s uk-width-3-4@m uk-width-1-2@l uk-text-center block-qr">
+                <img *ngIf="qrCodeImageBlock" [src]="qrCodeImageBlock"><br />
+              </div>
+              <div *ngIf="blockHash" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
+                <span class="uk-text-small" uk-tooltip title="Block Hash" style="overflow-wrap: anywhere;">{{blockHash}}</span>
+                <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+                  <li><a ngxClipboard [cbContent]="blockHash" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!--END REMOTE SIGNING-->
+
         <div uk-grid style="margin-top: 25px;">
           <div class="uk-width-1-1">
             <h3 class="uk-heading-divider uk-text-center" style="margin-bottom: 0;">Recent Transactions<span></span></h3>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -59,11 +59,11 @@
                     Account Balance
                   </div>
                   <div class="uk-width-1-3 uk-text-right">
-                    {{ account.balance || 0 | rai: settings.settings.displayDenomination }}
-                    <span *ngIf="account.balanceRaw && account.balanceRaw > 0" style="display: block; font-size: 12px;" class="uk-text-muted">+{{ account.balanceRaw.toString(10) }} raw</span>
+                    {{ !account? 0:(account.balance || 0 | rai: settings.settings.displayDenomination) }}
+                    <span *ngIf="account && account.balanceRaw && account.balanceRaw > 0" style="display: block; font-size: 12px;" class="uk-text-muted">+{{ !account? 0:(account.balanceRaw.toString(10)) }} raw</span>
                   </div>
                   <div class="uk-width-1-3 uk-text-left">
-                    {{ account.balanceFiat | fiat: settings.settings.displayCurrency }}
+                    {{ !account? 0:(account.balanceFiat | fiat: settings.settings.displayCurrency) }}
                   </div>
                 </div>
               </div>
@@ -74,16 +74,16 @@
                     Incoming Amount
                   </div>
                   <div class="uk-width-1-3 uk-text-right">
-                    {{ account.pending || 0 | rai: settings.settings.displayDenomination }}
-                    <span *ngIf="account.pendingRaw && account.pendingRaw > 0" style="display: block; font-size: 12px;" class="uk-text-muted">+{{ account.pendingRaw.toString(10) }} raw</span>
+                    {{ !account? 0:(account.pending || 0 | rai: settings.settings.displayDenomination) }}
+                    <span *ngIf="account && account.pendingRaw && account.pendingRaw > 0" style="display: block; font-size: 12px;" class="uk-text-muted">+{{ !account? 0:(account.pendingRaw.toString(10)) }} raw</span>
                   </div>
                   <div class="uk-width-1-3 uk-text-left">
-                    {{ account.pendingFiat | fiat: settings.settings.displayCurrency }}
+                    {{ !account? 0:(account.pendingFiat | fiat: settings.settings.displayCurrency) }}
                   </div>
                 </div>
               </div>
 
-              <div class="uk-width-1-1" *ngIf="account.representative">
+              <div class="uk-width-1-1" *ngIf="account && account.representative">
                 <div uk-grid>
                   <div class="uk-width-1-3 uk-text-right">
                     Representative
@@ -122,9 +122,9 @@
                       <div uk-grid>
                         <div class="uk-width-expand uk-text-truncate ">
                           <span *ngIf="repLabel" class="uk-label uk-label-danger">{{ repLabel }}</span> 
-                          <app-nano-account-id [accountID]="account.representative"></app-nano-account-id>
+                          <app-nano-account-id [accountID]="!account ? '':account.representative"></app-nano-account-id>
                         </div>
-                        <div class="uk-width-auto" style="padding-left: 10px;" *ngIf="walletAccount && account.representative">
+                        <div class="uk-width-auto" style="padding-left: 10px;" *ngIf="walletAccount && account && account.representative">
                           <ul class="uk-hidden-hover uk-iconnav">
                             <!--<li><a uk-icon="icon: pencil;" title="Change Representative" uk-tooltip (click)="showEditRepresentative = true"></a></li>-->
                             <li><a uk-icon="icon: pencil;" title="Change Representative" uk-tooltip routerLink="/representatives" [queryParams]="{ hideOverview: true, showRecommended: true, accounts: accountID }"></a></li>
@@ -138,7 +138,7 @@
                 </div>
               </div>
 
-              <div class="uk-width-1-1">
+              <div *ngIf="settings.settings.serverAPI" class="uk-width-1-1">
                 <div uk-grid>
                   <div class="uk-width-1-3 uk-text-right">
                     <label>Enable Remote Signing</label>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -138,6 +138,16 @@
                 </div>
               </div>
 
+              <div class="uk-width-1-1">
+                <div uk-grid>
+                  <div class="uk-width-1-3 uk-text-right">
+                    <label>Enable Remote Signing</label>
+                  </div>
+                  <div class="uk-width-1-3 uk-text-right">
+                    <input class="uk-checkbox uk-margin-medium-left" type="checkbox" name="remoteVisible" value="1" [(ngModel)]="remoteVisible">
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <div class="uk-width-2-5@s uk-width-1-4@m uk-text-center">
@@ -146,137 +156,14 @@
           </div>
         </div>
 
-        <!--REMOTE SIGNING-->
-        <div uk-grid style="margin-top: 5px;">
+        <div *ngIf="remoteVisible" uk-grid>
           <div class="uk-width-1-1">
-            <div class="uk-card-body">
-              <h3 class="uk-heading-divider uk-text-center">Remote Signing (Send or Change Rep)<span *ngIf="remoteVisible" id="remote" uk-icon="icon: shrink;" (click)="showRemote(remoteVisible)" uk-tooltip title="Start Remote Signing"></span><span *ngIf="!remoteVisible" id="remote" uk-icon="icon: expand;" (click)="showRemote(remoteVisible)" uk-tooltip title="Start Remote Signing"></span></h3>
-              <div *ngIf="remoteVisible">
-                <ol>
-                  <li>Generate a Nano block</li>
-                  <li>Scan the unsigned QR with a remote wallet (for example an offline Nault). Sign it using the methods provided.</li>
-                  <li><a routerLink="/qr-scan" routerLinkActive="active">Scan the signed QR code</a>. Then confirm to publish the block!</li>
-                </ol>
-
-                <span><strong>Block Type</strong></span><span uk-icon="icon: info;" uk-tooltip title="The block type to create for remote signing. Receiving can be done from the Recent Transactions below."></span><br>
-                <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="blocktype" value={{blockTypes[0]}} [(ngModel)]="blockTypeSelected"> {{blockTypes[0]}}</label>
-                <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="blocktype" value={{blockTypes[1]}} [(ngModel)]="blockTypeSelected"> {{blockTypes[1]}}</label>
-                <br><br>
-
-                <div *ngIf="blockTypeSelected === blockTypes[0]" class="uk-form-horizontal">
-                  <div class="uk-margin">
-                    <label class="uk-form-label" for="form-horizontal-text2">To Account</label>
-                    <div class="uk-form-controls">
-                      <div class="uk-inline uk-width-1-1">
-                        <span class="uk-form-icon uk-form-icon-flip" *ngIf="toAccountStatus === 0" uk-icon="icon: warning"></span>
-                        <span class="uk-form-icon uk-form-icon-flip"*ngIf="toAccountStatus === 2" uk-icon="icon: check"></span>
-                        <input (blur)="validateDestination()" (keyup)="searchAddressBook()" (focus)="searchAddressBook()" [(ngModel)]="toAccountID" [ngClass]="{ 'uk-form-success': toAccountStatus === 2, 'uk-form-danger': toAccountStatus === 0 }" class="uk-input" id="form-horizontal-text2" type="text" placeholder="Account to send to" autocomplete="off">
-
-                        <div *ngIf="(addressBookResults$ | async).length" [hidden]="!showAddressBook" class="uk-animation-slide-down-small uk-width-1-1 uk-card uk-card-default uk-card-body uk-position-absolute" style="z-index: 15000">
-                          <ul class="uk-nav uk-nav-default">
-                            <li class="uk-nav-header">Address Book Results</li>
-                            <li class="uk-nav-divider"></li>
-                            <li *ngFor="let book of addressBookResults$ | async">
-                              <a (click)="selectBookEntry(book.account)">{{ book.name }}</a>
-                            </li>
-                          </ul>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div class="uk-form-controls" *ngIf="addressBookMatch">
-                      <div class="uk-inline uk-width-1-1">
-                        <span class="uk-label uk-label-primary">{{ addressBookMatch }}</span>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div uk-grid>
-                    <div class="uk-width-1-1">
-                      <label class="uk-form-label" for="form-horizontal-text">Amount</label>
-                      <div class="uk-form-controls">
-                        <div uk-grid>
-                          <div class="uk-width-3-5">
-                            <div class="uk-inline uk-width-1-1">
-                              <a class="uk-form-icon uk-form-icon-flip" (click)="setMaxAmount()" style="padding-right: 7px;" uk-tooltip title="Set Maximum Amount">Max</a>
-                              <input [(ngModel)]="amount" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="text" placeholder="Amount of {{ selectedAmount.name }} to send">
-                            </div>
-
-                          </div>
-                          <div class="uk-width-2-5">
-                            <div class="uk-inline uk-width-1-1">
-                              <button class="uk-button uk-button-secondary uk-width-1-1" type="button" style="text-transform: none;">{{ selectedAmount.shortName }}</button>
-                              <div uk-dropdown>
-                                <ul class="uk-nav uk-dropdown-nav">
-                                  <li class="uk-active uk-dropdown-spacing" *ngFor="let amount of amounts" (click)="selectedAmount = amount; syncNanoPrice();">{{ amount.name }}</li>
-                                </ul>
-                              </div>
-                            </div>
-                          </div>
-
-                          <div class="uk-width-1-1 uk-width-3-5@s" style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
-                            <div class="uk-width-1-1 uk-inline">
-                              <a class="uk-form-icon uk-link-reset uk-link-muted" style="padding-left: 7px;" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
-                              <input [(ngModel)]="amountFiat" (keyup)="syncNanoPrice()" (change)="syncNanoPrice()" style="padding-left: 50px; border: 0; border-bottom: 1px solid #e5e5e5;" class="uk-input" id="form-horizontal-text-fiat" type="text" placeholder="Amount of {{ settings.settings.displayCurrency }} to send">
-                            </div>
-                          </div>
-
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <div *ngIf="blockTypeSelected === blockTypes[1]" class="uk-form-horizontal">
-                  <div class="uk-margin">
-                    <label class="uk-form-label" for="form-horizontal-text3">Representative</label>
-                    <div class="uk-form-controls">
-                      <div class="uk-inline uk-width-1-1">
-                        <span class="uk-form-icon uk-form-icon-flip" *ngIf="toAccountStatus === 0" uk-icon="icon: warning"></span>
-                        <span class="uk-form-icon uk-form-icon-flip"*ngIf="toAccountStatus === 2" uk-icon="icon: check"></span>
-                        <input (blur)="validateRepresentative()" (keyup)="searchRepresentatives()" (focus)="searchRepresentatives()" [(ngModel)]="representativeModel" class="uk-input" [ngClass]="{ 'uk-form-success': repStatus === 2, 'uk-form-danger': repStatus === 0 }" id="form-horizontal-text3" type="text" placeholder="nano_abc...123" #repInput>
-                        
-                        <div *ngIf="(representativeResults$ | async).length" [hidden]="!showRepresentatives" class="uk-animation-slide-down-small uk-width-1-1 uk-card uk-card-default uk-card-body uk-position-absolute" style="z-index: 15000">
-                          <ul class="uk-nav uk-nav-default">
-                            <li class="uk-nav-header">Recommended Representatives</li>
-                            <li class="uk-nav-divider"></li>
-                            <li *ngFor="let rep of representativeResults$ | async">
-                              <a (click)="selectRepresentative(rep.id)">
-                                {{ rep.name }}
-                                <span *ngIf="rep.trusted" uk-icon="icon: star;" class="uk-text-success"></span>
-                                <span *ngIf="rep.warn" uk-icon="icon: warning;" class="uk-text-warning"></span>
-                              </a>
-                            </li>
-                          </ul>
-                        </div>
-                      </div>
-                    </div>
-                    <div class="uk-form-controls" *ngIf="representativeListMatch">
-                      <div class="uk-inline uk-width-1-1">
-                        <span class="uk-label uk-label-danger">{{ representativeListMatch }}</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <br>
-                <button *ngIf="blockTypeSelected === blockTypes[0]" class="uk-button uk-button-primary uk-text-center uk-width-1-1" type="button" style="margin-bottom: 20px;" (click)="generateSend()">Generate Send Block</button>
-                <button *ngIf="blockTypeSelected === blockTypes[1]" class="uk-button uk-button-primary uk-text-center uk-width-1-1" type="button" style="margin-bottom: 20px;" (click)="generateChange()">Generate Change Block</button>
-              </div>
-            </div>
-            <div *ngIf="remoteVisible">
-              <div class="uk-width-1-1@s uk-width-3-4@m uk-width-1-2@l uk-text-center block-qr">
-                <img *ngIf="qrCodeImageBlock" [src]="qrCodeImageBlock"><br />
-              </div>
-              <div *ngIf="blockHash" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
-                <span class="uk-text-small" uk-tooltip title="Block Hash" style="overflow-wrap: anywhere;">{{blockHash | squeeze}}</span>
-                <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
-                  <li><a ngxClipboard [cbContent]="blockHash" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
-                </ul>
-              </div>
+            <div class="uk-width-1-1 uk-margin-medium-left">
+              <p>Create a new SEND or CHANGE block below. For any incoming transaction in the table: Use REMOTE SIGN.</p>
+              <button class="uk-button uk-button-primary" (click)="showRemoteModal()">CREATE NEW BLOCK</button>
             </div>
           </div>
         </div>
-        <!--END REMOTE SIGNING-->
 
         <div uk-grid style="margin-top: 25px;">
           <div class="uk-width-1-1">
@@ -290,7 +177,7 @@
                 <th class="uk-width-1-5@m uk-width-1-4">Account</th>
                 <th class="uk-width-1-5@m uk-width-1-4">Amount</th>
                 <th class="uk-width-1-5@m uk-width-1-4">Hash</th>
-                <th class="uk-width-1-5@m uk-width-1-4">Incoming</th>
+                <th *ngIf="remoteVisible" class="uk-width-1-5@m uk-width-1-4">Incoming</th>
               </tr>
               </thead>
               <tbody>
@@ -317,7 +204,7 @@
                   +{{ pending.amount | rai: settings.settings.displayDenomination }}*
                 </td>
                 <td class="uk-text-truncate"><a [routerLink]="'/transaction/' + pending.hash" class="uk-link-text" title="View Block Details" uk-tooltip>{{ pending.hash }}</a></td>
-                <td><button class="uk-button uk-button-primary uk-text-center uk-width-auto" style="height: 28px; line-height: 28px;" type="button" (click)="generateReceive(pending.hash)">REMOTE SIGN</button></td>
+                <td *ngIf="remoteVisible"><button class="uk-button uk-button-primary uk-text-center uk-width-auto" style="height: 28px; line-height: 28px;" type="button" (click)="generateReceive(pending.hash)">REMOTE SIGN</button></td>
               </tr>
 
               <tr *ngFor="let history of accountHistory">
@@ -373,12 +260,12 @@
   <div class="uk-modal-dialog uk-modal-body modal-qr">
     <button class="uk-modal-close-default" type="button" uk-close></button>
     <div class="uk-modal-header">
-        <h2 class="uk-modal-title">Remote Signing of Incoming Block</h2>
+        <h2 class="uk-modal-title">Unsigned Incoming Block</h2>
     </div>
     <div class="uk-modal-body modal-qr-body">
       <ol>
-        <li>Scan the unsigned QR with a remote wallet (for example an offline Nault). Sign it using the methods provided.</li>
-        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan the signed QR code</a>. Then confirm to publish the block!</li>
+        <li>Scan the unsigned QR with an offline Nault. Sign it using the methods provided.</li>
+        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the new signed QR with an online Nault. Confirm to publish the block!</li>
       </ol>
       <div class="uk-width-1-1 uk-text-center">
         <img *ngIf="qrCodeImageBlockReceive" [src]="qrCodeImageBlockReceive"><br />
@@ -387,6 +274,137 @@
         <span class="uk-text-small" uk-tooltip title="Block Hash" style="overflow-wrap: anywhere;">{{blockHashReceive | squeeze}}</span>
         <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
           <li><a ngxClipboard [cbContent]="blockHashReceive" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Modal for creating send and change block for remote signing-->
+<div id="block-modal" uk-modal>
+  <div class="uk-modal-dialog uk-modal-body modal-block">
+    <button class="uk-modal-close-default" type="button" uk-close></button>
+    <div class="uk-modal-header">
+        <h2 class="uk-modal-title">Create Block for Remote Signing</h2>
+    </div>
+    <div class="uk-modal-body modal-block-body">
+      <ol>
+        <li>Generate a Nano block below (no Nault login needed)</li>
+        <li>Scan the unsigned QR with an offline Nault. Sign it using the methods provided.</li>
+        <li><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the new signed QR with an online Nault. Confirm to publish the block!</li>
+      </ol>
+
+      <span><strong>Block Type</strong></span><span uk-icon="icon: info;" uk-tooltip title="The block type to create for remote signing. Receiving can be done from the Recent Transactions below."></span><br>
+      <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="blocktype" value={{blockTypes[0]}} [(ngModel)]="blockTypeSelected"> {{blockTypes[0]}}</label>
+      <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="blocktype" value={{blockTypes[1]}} [(ngModel)]="blockTypeSelected"> {{blockTypes[1]}}</label>
+      <br><br>
+
+      <div *ngIf="blockTypeSelected === blockTypes[0]" class="uk-form-horizontal">
+        <div class="uk-margin">
+          <label class="uk-form-label" for="form-horizontal-text2">To Account</label>
+          <div class="uk-form-controls">
+            <div class="uk-inline uk-width-1-1">
+              <span class="uk-form-icon uk-form-icon-flip" *ngIf="toAccountStatus === 0" uk-icon="icon: warning"></span>
+              <span class="uk-form-icon uk-form-icon-flip"*ngIf="toAccountStatus === 2" uk-icon="icon: check"></span>
+              <input (blur)="validateDestination()" (keyup)="searchAddressBook()" (focus)="searchAddressBook()" [(ngModel)]="toAccountID" [ngClass]="{ 'uk-form-success': toAccountStatus === 2, 'uk-form-danger': toAccountStatus === 0 }" class="uk-input" id="form-horizontal-text2" type="text" placeholder="Account to send to" autocomplete="off">
+
+              <div *ngIf="(addressBookResults$ | async).length" [hidden]="!showAddressBook" class="uk-animation-slide-down-small uk-width-1-1 uk-card uk-card-default uk-card-body uk-position-absolute" style="z-index: 15000">
+                <ul class="uk-nav uk-nav-default">
+                  <li class="uk-nav-header">Address Book Results</li>
+                  <li class="uk-nav-divider"></li>
+                  <li *ngFor="let book of addressBookResults$ | async">
+                    <a (click)="selectBookEntry(book.account)">{{ book.name }}</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          <div class="uk-form-controls" *ngIf="addressBookMatch">
+            <div class="uk-inline uk-width-1-1">
+              <span class="uk-label uk-label-primary">{{ addressBookMatch }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div uk-grid>
+          <div class="uk-width-1-1">
+            <label class="uk-form-label" for="form-horizontal-text">Amount</label>
+            <div class="uk-form-controls">
+              <div uk-grid>
+                <div class="uk-width-3-5">
+                  <div class="uk-inline uk-width-1-1">
+                    <a class="uk-form-icon uk-form-icon-flip" (click)="setMaxAmount()" style="padding-right: 7px;" uk-tooltip title="Set Maximum Amount">Max</a>
+                    <input [(ngModel)]="amount" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="text" placeholder="Amount of {{ selectedAmount.name }} to send">
+                  </div>
+
+                </div>
+                <div class="uk-width-2-5">
+                  <div class="uk-inline uk-width-1-1">
+                    <button class="uk-button uk-button-secondary uk-width-1-1" type="button" style="text-transform: none;">{{ selectedAmount.shortName }}</button>
+                    <div uk-dropdown>
+                      <ul class="uk-nav uk-dropdown-nav">
+                        <li class="uk-active uk-dropdown-spacing" *ngFor="let amount of amounts" (click)="selectedAmount = amount; syncNanoPrice();">{{ amount.name }}</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="uk-width-1-1 uk-width-3-5@s" style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
+                  <div class="uk-width-1-1 uk-inline">
+                    <a class="uk-form-icon uk-link-reset uk-link-muted" style="padding-left: 7px;" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
+                    <input [(ngModel)]="amountFiat" (keyup)="syncNanoPrice()" (change)="syncNanoPrice()" style="padding-left: 50px; border: 0; border-bottom: 1px solid #e5e5e5;" class="uk-input" id="form-horizontal-text-fiat" type="text" placeholder="Amount of {{ settings.settings.displayCurrency }} to send">
+                  </div>
+                </div>
+
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div *ngIf="blockTypeSelected === blockTypes[1]" class="uk-form-horizontal">
+        <div class="uk-margin">
+          <label class="uk-form-label" for="form-horizontal-text3">Representative</label>
+          <div class="uk-form-controls">
+            <div class="uk-inline uk-width-1-1">
+              <span class="uk-form-icon uk-form-icon-flip" *ngIf="toAccountStatus === 0" uk-icon="icon: warning"></span>
+              <span class="uk-form-icon uk-form-icon-flip"*ngIf="toAccountStatus === 2" uk-icon="icon: check"></span>
+              <input (blur)="validateRepresentative()" (keyup)="searchRepresentatives()" (focus)="searchRepresentatives()" [(ngModel)]="representativeModel" class="uk-input" [ngClass]="{ 'uk-form-success': repStatus === 2, 'uk-form-danger': repStatus === 0 }" id="form-horizontal-text3" type="text" placeholder="nano_abc...123" #repInput>
+              
+              <div *ngIf="(representativeResults$ | async).length" [hidden]="!showRepresentatives" class="uk-animation-slide-down-small uk-width-1-1 uk-card uk-card-default uk-card-body uk-position-absolute" style="z-index: 15000">
+                <ul class="uk-nav uk-nav-default">
+                  <li class="uk-nav-header">Recommended Representatives</li>
+                  <li class="uk-nav-divider"></li>
+                  <li *ngFor="let rep of representativeResults$ | async">
+                    <a (click)="selectRepresentative(rep.id)">
+                      {{ rep.name }}
+                      <span *ngIf="rep.trusted" uk-icon="icon: star;" class="uk-text-success"></span>
+                      <span *ngIf="rep.warn" uk-icon="icon: warning;" class="uk-text-warning"></span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="uk-form-controls" *ngIf="representativeListMatch">
+            <div class="uk-inline uk-width-1-1">
+              <span class="uk-label uk-label-danger">{{ representativeListMatch }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <br>
+      <button *ngIf="blockTypeSelected === blockTypes[0]" class="uk-button uk-button-primary uk-text-center uk-width-1-1" type="button" style="margin-bottom: 20px;" (click)="generateSend()">Generate Send Block</button>
+      <button *ngIf="blockTypeSelected === blockTypes[1]" class="uk-button uk-button-primary uk-text-center uk-width-1-1" type="button" style="margin-bottom: 20px;" (click)="generateChange()">Generate Change Block</button>
+
+      <div class="uk-width-1-1 uk-text-center">
+        <img *ngIf="qrCodeImageBlock" [src]="qrCodeImageBlock" class="block-qr"><br />
+      </div>
+      <div *ngIf="blockHash" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
+        <span class="uk-text-small" uk-tooltip title="Block Hash" style="overflow-wrap: anywhere;">{{blockHash | squeeze}}</span>
+        <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+          <li><a ngxClipboard [cbContent]="blockHash" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
         </ul>
       </div>
     </div>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -147,13 +147,19 @@
             <div class="uk-card-body">
               <h3 class="uk-heading-divider uk-text-center">Remote Signing (Send or Change Rep)<span *ngIf="remoteVisible" id="remote" uk-icon="icon: shrink;" (click)="showRemote(remoteVisible)" uk-tooltip title="Start Remote Signing"></span><span *ngIf="!remoteVisible" id="remote" uk-icon="icon: expand;" (click)="showRemote(remoteVisible)" uk-tooltip title="Start Remote Signing"></span></h3>
               <div *ngIf="remoteVisible">
-                <div class="uk-form-horizontal">
+                <ol>
+                  <li>Generate a Nano block</li>
+                  <li>Scan the unsigned QR with a remote wallet (for example an offline Nault). Sign it using the methods provided.</li>
+                  <li><a routerLink="/qr-scan" routerLinkActive="active">Scan the signed QR code</a>. Then confirm to publish the block!</li>
+                </ol>
+
+                <span><strong>Block Type</strong></span><span uk-icon="icon: info;" uk-tooltip title="The block type to create for remote signing. Receiving can be done from the Recent Transactions below."></span><br>
+                <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="blocktype" value={{blockTypes[0]}} [(ngModel)]="blockTypeSelected"> {{blockTypes[0]}}</label>
+                <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="blocktype" value={{blockTypes[1]}} [(ngModel)]="blockTypeSelected"> {{blockTypes[1]}}</label>
+                <br><br>
+
+                <div *ngIf="blockTypeSelected === blockTypes[0]" class="uk-form-horizontal">
                   <div class="uk-margin">
-                    <ol>
-                      <li>Generate a Nano block</li>
-                      <li>Scan the unsigned QR with a remote wallet (for example an offline Nault). Sign it using the methods provided.</li>
-                      <li><a routerLink="/qr-scan" routerLinkActive="active">Scan the signed QR code</a>. Then confirm to publish the block!</li>
-                    </ol>
                     <label class="uk-form-label" for="form-horizontal-text2">To Account</label>
                     <div class="uk-form-controls">
                       <div class="uk-inline uk-width-1-1">
@@ -211,12 +217,45 @@
                           </div>
 
                         </div>
-
                       </div>
                     </div>
                   </div>
                 </div>
-                <button class="uk-button uk-button-primary uk-text-center uk-width-1-1" type="button" style="margin-bottom: 20px;" (click)="generateSend()">Generate Send Block</button>
+
+                <div *ngIf="blockTypeSelected === blockTypes[1]" class="uk-form-horizontal">
+                  <div class="uk-margin">
+                    <label class="uk-form-label" for="form-horizontal-text3">Representative</label>
+                    <div class="uk-form-controls">
+                      <div class="uk-inline uk-width-1-1">
+                        <span class="uk-form-icon uk-form-icon-flip" *ngIf="toAccountStatus === 0" uk-icon="icon: warning"></span>
+                        <span class="uk-form-icon uk-form-icon-flip"*ngIf="toAccountStatus === 2" uk-icon="icon: check"></span>
+                        <input (blur)="validateRepresentative()" (keyup)="searchRepresentatives()" (focus)="searchRepresentatives()" [(ngModel)]="representativeModel" class="uk-input" [ngClass]="{ 'uk-form-success': repStatus === 2, 'uk-form-danger': repStatus === 0 }" id="form-horizontal-text3" type="text" placeholder="nano_abc...123" #repInput>
+                        
+                        <div *ngIf="(representativeResults$ | async).length" [hidden]="!showRepresentatives" class="uk-animation-slide-down-small uk-width-1-1 uk-card uk-card-default uk-card-body uk-position-absolute" style="z-index: 15000">
+                          <ul class="uk-nav uk-nav-default">
+                            <li class="uk-nav-header">Recommended Representatives</li>
+                            <li class="uk-nav-divider"></li>
+                            <li *ngFor="let rep of representativeResults$ | async">
+                              <a (click)="selectRepresentative(rep.id)">
+                                {{ rep.name }}
+                                <span *ngIf="rep.trusted" uk-icon="icon: star;" class="uk-text-success"></span>
+                                <span *ngIf="rep.warn" uk-icon="icon: warning;" class="uk-text-warning"></span>
+                              </a>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="uk-form-controls" *ngIf="representativeListMatch">
+                      <div class="uk-inline uk-width-1-1">
+                        <span class="uk-label uk-label-danger">{{ representativeListMatch }}</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <br>
+                <button *ngIf="blockTypeSelected === blockTypes[0]" class="uk-button uk-button-primary uk-text-center uk-width-1-1" type="button" style="margin-bottom: 20px;" (click)="generateSend()">Generate Send Block</button>
+                <button *ngIf="blockTypeSelected === blockTypes[1]" class="uk-button uk-button-primary uk-text-center uk-width-1-1" type="button" style="margin-bottom: 20px;" (click)="generateChange()">Generate Change Block</button>
               </div>
             </div>
             <div *ngIf="remoteVisible">

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -151,7 +151,7 @@
                   <div class="uk-margin">
                     <ol>
                       <li>Generate a send block</li>
-                      <li>Scan the QR with a remote wallet (for example an offline Nault) to sign it using a wallet corresponding to the account above</li>
+                      <li>Scan the QR with a remote wallet (for example an offline Nault) to sign it using a wallet owning to the account above</li>
                       <li><a routerLink="/qr-scan" routerLinkActive="active">Scan the resulting QR code</a>. Then confirm to publish the block!</li>
                     </ol>
                     <label class="uk-form-label" for="form-horizontal-text2">To Account</label>

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -73,6 +73,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
   toAddressBook = '';
   toAccountStatus = null;
   repStatus = null;
+  qrString = null;
   qrCodeImageBlock = null;
   qrCodeImageBlockReceive = null;
   blockHash = null;
@@ -502,8 +503,8 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     };
 
     // Nano signing standard
-    let qrString = 'nanosign:{"block":' + JSON.stringify(blockData) + ',"previous":' + JSON.stringify(blockDataPrevious) + '}'
-    const qrCode = await QRCode.toDataURL(qrString, { errorCorrectionLevel: 'L', scale: 16 });
+    this.qrString = 'nanosign:{"block":' + JSON.stringify(blockData) + ',"previous":' + JSON.stringify(blockDataPrevious) + '}'
+    const qrCode = await QRCode.toDataURL(this.qrString, { errorCorrectionLevel: 'L', scale: 16 });
     this.qrCodeImageBlock = qrCode;
   }
 
@@ -550,11 +551,10 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     }
 
     // Nano signing standard
-    var qrString = null;
-    if (blockDataPrevious) qrString = 'nanosign:{"block":' + JSON.stringify(blockData) + ',"previous":' + JSON.stringify(blockDataPrevious) + '}';
-    else qrString = 'nanosign:{"block":' + JSON.stringify(blockData) + '}';
+    if (blockDataPrevious) this.qrString = 'nanosign:{"block":' + JSON.stringify(blockData) + ',"previous":' + JSON.stringify(blockDataPrevious) + '}';
+    else this.qrString = 'nanosign:{"block":' + JSON.stringify(blockData) + '}';
     
-    const qrCode = await QRCode.toDataURL(qrString, { errorCorrectionLevel: 'L', scale: 16 });
+    const qrCode = await QRCode.toDataURL(this.qrString, { errorCorrectionLevel: 'L', scale: 16 });
     this.qrCodeImageBlockReceive = qrCode;
 
     const UIkit = window['UIkit'];
@@ -601,9 +601,8 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     console.log("Block hash: " + this.blockHashReceive);
 
     // Nano signing standard
-    var qrString = null;
-    qrString = 'nanosign:{"block":' + JSON.stringify(blockData) + ',"previous":' + JSON.stringify(blockDataPrevious) + '}';
-    const qrCode = await QRCode.toDataURL(qrString, { errorCorrectionLevel: 'L', scale: 16 });
+    this.qrString = 'nanosign:{"block":' + JSON.stringify(blockData) + ',"previous":' + JSON.stringify(blockDataPrevious) + '}';
+    const qrCode = await QRCode.toDataURL(this.qrString, { errorCorrectionLevel: 'L', scale: 16 });
     this.qrCodeImageBlock = qrCode;
   }
 

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -472,7 +472,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
       link: jsonBlock.link,
     };
 
-    // Nano signing standard (just invented it with feedback from the nano foundation)
+    // Nano signing standard (invented with feedback from the nano foundation)
     let qrString = 'nanosign:{"block":' + JSON.stringify(blockData) + ',"previous":' + JSON.stringify(blockDataPrevious) + '}'
 
     const qrCode = await QRCode.toDataURL(qrString, { errorCorrectionLevel: 'M', scale: 8 });

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -441,6 +441,8 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     if (!isValid) return this.notifications.sendWarning(`To account address is not valid`);
     if (!this.accountID || !this.toAccountID) return this.notifications.sendWarning(`From and to account are required`);
 
+    this.qrCodeImageBlock = null;
+
     const from = await this.api.accountInfo(this.accountID);
     const to = await this.api.accountInfo(this.toAccountID);
     if (!from) return this.notifications.sendError(`From account not found`);
@@ -491,6 +493,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
       representative: jsonBlock.representative,
       balance: jsonBlock.balance,
       link: jsonBlock.link,
+      signature: jsonBlock.signature,
     };
 
     // Nano signing standard
@@ -500,6 +503,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
   }
 
   async generateReceive(pendingHash) {
+    this.qrCodeImageBlockReceive = null;
     const toAcct = await this.api.accountInfo(this.accountID);
 
     const openEquiv = !toAcct || !toAcct.frontier; // if open block
@@ -536,6 +540,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
         representative: jsonBlock.representative,
         balance: jsonBlock.balance,
         link: jsonBlock.link,
+        signature: jsonBlock.signature,
       };
     }
 
@@ -554,6 +559,8 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
 
   async generateChange() {
     if (!this.util.account.isValidAccount(this.representativeModel)) return this.notifications.sendError(`Not a valid representative account`);
+    this.qrCodeImageBlock = null;
+
     const account = await this.api.accountInfo(this.accountID);
 
     if (!account || !('frontier' in account)) return this.notifications.sendError(`Account must be opened first!`);
@@ -582,6 +589,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
       representative: jsonBlock.representative,
       balance: jsonBlock.balance,
       link: jsonBlock.link,
+      signature: jsonBlock.signature,
     };
     this.blockHashReceive = nanocurrency.hashBlock({account:blockData.account, link:blockData.link, previous:blockData.previous, representative: blockData.representative, balance: blockData.balance})
     console.log("Created block",blockData);

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -119,6 +119,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     this.addressBook.loadAddressBook();
 
     // populate representative list
+    if (!this.settings.settings.serverAPI) return;
     const verifiedReps = await this.ninja.recommendedRandomized();
 
     for (const representative of verifiedReps) {
@@ -147,6 +148,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     this.walletAccount = this.wallet.getWalletAccount(this.accountID);
     this.account = await this.api.accountInfo(this.accountID);
 
+    if (!this.account) return
     const knownRepresentative = this.repService.getRepresentative(this.account.representative);
     this.repLabel = knownRepresentative ? knownRepresentative.name : null;
 

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -96,6 +96,11 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     private nanoBlock: NanoBlockService) { }
 
   async ngOnInit() {
+    const params = this.router.snapshot.queryParams;
+    if ('sign' in params) {
+      this.remoteVisible = params.sign == 1 
+    }
+
     this.routerSub = this.route.events.subscribe(event => {
       if (event instanceof ChildActivationEnd) {
         this.loadAccountDetails(); // Reload the state when navigating to itself from the transactions page
@@ -604,6 +609,12 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
 
   showRemote(state:boolean) {
     this.remoteVisible = !state;
+  }
+
+  showRemoteModal() {
+    const UIkit = window['UIkit'];
+    var modal = UIkit.modal("#block-modal");
+    modal.show();
   }
 
   // End remote signing methods

--- a/src/app/components/address-book/address-book.component.ts
+++ b/src/app/components/address-book/address-book.component.ts
@@ -3,8 +3,7 @@ import {AddressBookService} from "../../services/address-book.service";
 import {WalletService} from "../../services/wallet.service";
 import {NotificationService} from "../../services/notification.service";
 import {ModalService} from "../../services/modal.service";
-import {ApiService} from "../../services/api.service";
-import {Router} from "@angular/router";
+import {UtilService} from "../../services/util.service";
 
 @Component({
   selector: 'app-address-book',
@@ -24,8 +23,7 @@ export class AddressBookComponent implements OnInit, AfterViewInit {
     private walletService: WalletService,
     private notificationService: NotificationService,
     public modal: ModalService,
-    private router: Router,
-    private nodeApi: ApiService) { }
+    private util: UtilService) { }
 
   async ngOnInit() {
     this.addressBookService.loadAddressBook();
@@ -65,8 +63,8 @@ export class AddressBookComponent implements OnInit, AfterViewInit {
     }
 
     // Make sure the address is valid
-    const valid = await this.nodeApi.validateAccountNumber(this.newAddressAccount);
-    if (!valid || valid.valid !== '1') return this.notificationService.sendWarning(`Account ID is not a valid account`);
+    const valid = this.util.account.isValidAccount(this.newAddressAccount);
+    if (!valid) return this.notificationService.sendWarning(`Account ID is not a valid account`);
 
     try {
       await this.addressBookService.saveAddress(this.newAddressAccount, this.newAddressName);

--- a/src/app/components/configure-app/configure-app.component.html
+++ b/src/app/components/configure-app/configure-app.component.html
@@ -295,7 +295,7 @@
             </div>
           </div>
 
-          <div class="uk-width-1-1">
+          <div class="uk-width-1-1" *ngIf="showServerValues() || showServerConfigs()">
             <div class="uk-form-horizontal">
               <div>
                 <label class="uk-form-label uk-text-right">Node Stats <span class="{{statsRefreshEnabled ? '':'node-stats-disabled'}}" id="node-stats" uk-icon="icon: refresh;" (click)="updateNodeStats(true)" uk-tooltip title="Can be used for troubleshooting. Click refresh to update."></span></label>

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -118,7 +118,7 @@ export class ConfigureAppComponent implements OnInit {
   serverAuth = null;
   minimumReceive = null;
 
-  showServerValues = () => this.selectedServer && this.selectedServer !== 'random';
+  showServerValues = () => this.selectedServer && this.selectedServer !== 'random' && this.selectedServer !== 'offline';
   showServerConfigs = () => this.selectedServer && this.selectedServer === 'custom';
 
   nodeBlockCount = null;
@@ -149,7 +149,7 @@ export class ConfigureAppComponent implements OnInit {
   }
 
   async updateNodeStats(refresh=false) {
-    if ((this.serverAPIUpdated != this.appSettings.settings.serverAPI && this.selectedServer === 'random') || (refresh && !this.statsRefreshEnabled)) return
+    if ((this.serverAPIUpdated != this.appSettings.settings.serverAPI && this.selectedServer === 'random') || (refresh && !this.statsRefreshEnabled) || this.selectedServer === 'offline') return
     this.statsRefreshEnabled = false;
     try {
       let blockCount = await this.api.blockCount()

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -250,8 +250,8 @@ export class ConfigureAppComponent implements OnInit {
     const reloadPending = this.appSettings.settings.minimumReceive != this.minimumReceive || (pendingOption !== 'manual' && pendingOption != this.appSettings.settings.pendingOption);
 
     if (this.defaultRepresentative && this.defaultRepresentative.length) {
-      const valid = await this.api.validateAccountNumber(this.defaultRepresentative);
-      if (!valid || valid.valid !== '1') {
+      const valid = this.util.account.isValidAccount(this.defaultRepresentative);
+      if (!valid) {
         return this.notifications.sendWarning(`Default representative is not a valid account`);
       }
     }

--- a/src/app/components/manage-representatives/manage-representatives.component.ts
+++ b/src/app/components/manage-representatives/manage-representatives.component.ts
@@ -8,7 +8,7 @@ import {ModalService} from "../../services/modal.service";
 import {ApiService} from "../../services/api.service";
 import {Router} from "@angular/router";
 import {RepresentativeService} from "../../services/representative.service";
-
+import {UtilService} from "../../services/util.service";
 
 @Component({
   selector: 'app-manage-representatives',
@@ -36,13 +36,10 @@ export class ManageRepresentativesComponent implements OnInit, AfterViewInit {
 
   constructor(
     private api: ApiService,
-    private addressBookService: AddressBookService,
-    private walletService: WalletService,
     private notificationService: NotificationService,
     public modal: ModalService,
     private repService: RepresentativeService,
-    private router: Router,
-    private nodeApi: ApiService) { }
+    private util: UtilService) { }
 
   async ngOnInit() {
     this.repService.loadRepresentativeList();
@@ -70,8 +67,8 @@ export class ManageRepresentativesComponent implements OnInit, AfterViewInit {
     this.newRepAccount = this.newRepAccount.replace(/ /g, ''); // Remove spaces
 
     // Make sure the address is valid
-    const valid = await this.nodeApi.validateAccountNumber(this.newRepAccount);
-    if (!valid || valid.valid !== '1') return this.notificationService.sendWarning(`Account ID is not a valid account`);
+    const valid = this.util.account.isValidAccount(this.newRepAccount);
+    if (!valid) return this.notificationService.sendWarning(`Account ID is not a valid account`);
 
     try {
       await this.repService.saveRepresentative(this.newRepAccount, this.newRepName, this.newRepTrusted, this.newRepWarn);

--- a/src/app/components/qr-scan/qr-scan.component.ts
+++ b/src/app/components/qr-scan/qr-scan.component.ts
@@ -108,6 +108,7 @@ export class QrScanComponent implements OnInit {
               p_representative: data.previous.representative,
               p_balance: data.previous.balance,
               p_link: data.previous.link,
+              p_signature: data.previous.signature,
             }}
           }
           this.router.navigate(['sign'], { queryParams: paramsSign});
@@ -195,7 +196,8 @@ export class QrScanComponent implements OnInit {
         this.util.nano.isValidHash(data.block.previous) &&
         data.previous ? this.util.nano.isValidHash(data.previous.previous):true &&
         this.util.nano.isValidHash(data.block.link) &&
-        data.previous ? this.util.nano.isValidHash(data.previous.link):true)
+        data.previous ? this.util.nano.isValidHash(data.previous.link):true &&
+        data.previous ? this.util.nano.isValidSignature(data.previous.signature):true)
     }
     catch (error) {
       return false

--- a/src/app/components/remote-signing/remote-signing.component.html
+++ b/src/app/components/remote-signing/remote-signing.component.html
@@ -8,22 +8,22 @@
           <div class="uk-card-body">
             <p><strong>Remote signing allows you to transact on the Nano network with extra security.</strong></p>
             <ol>
-              <li>Create a block <strong>online</strong> using the latest information from the network. No login needed.</li>
+              <li>Create a block <strong>online</strong> using the latest information from the network.</li>
               <li>Sign the block hash on an <strong>offline</strong> device using a private key corresponding to the account from step 1.</li>
               <li>Embed the signature and process the final block <strong>online</strong>.</li>
             </ol>
             <p>This way the private key avoid any exposure to the Internet and only non sensitive data is tranferred between the devices.</p>
 
             <h3>STEP 1 (Online Device)</h3>
-            <p><strong>Use an account in "watch-only" mode. Create a SEND, CHANGE or RECEIVE block.</strong><br>
-              An incoming transaction need to be present to create a RECEIVE.</p>
+            <p><strong>Start with an account in "watch-only" mode. No login is needed.</strong><br>
+              Remote Signing will be enabled for you to create new blocks.</p>
             <div class="uk-inline uk-width-1-1">
               <div class="uk-grid-large" uk-grid>
                 <div class="uk-width-expand@m uk-width-1-1">
                   <input (keyup)="validateDestination()" [(ngModel)]="toAccountID" class="uk-input" [ngClass]="{ 'uk-form-success': toAccountStatus === 1, 'uk-form-danger': toAccountStatus === 0 }" type="text" placeholder="Account to create a block for" autocomplete="off">
                 </div>
                 <div class="uk-width-1-6@m uk-width-1-1">
-                  <a class="uk-button uk-button-primary" routerLink="{{toAccountID ? '/account/'+toAccountID:''}}" routerLinkActive="active">GO</a>
+                  <a class="uk-button uk-button-primary" routerLink="{{toAccountID ? '/account/'+toAccountID:''}}" [queryParams]="{ sign: 1 }" routerLinkActive="active">GO</a>
                 </div>
               </div>
             </div>

--- a/src/app/components/remote-signing/remote-signing.component.html
+++ b/src/app/components/remote-signing/remote-signing.component.html
@@ -1,0 +1,44 @@
+<div uk-grid>
+  <div class="uk-width-1-1">
+    <h2>Remote Signing</h2>
+
+    <div uk-grid class="uk-animation-slide-left-small">
+      <div class="uk-width-1-1">
+        <div class="uk-card uk-card-default">
+          <div class="uk-card-body">
+            <p><strong>Remote signing allows you to transact on the Nano network with extra security.</strong></p>
+            <ol>
+              <li>Create a block <strong>online</strong> using the latest information from the network. No login needed.</li>
+              <li>Sign the block hash on an <strong>offline</strong> device using a private key corresponding to the account from step 1.</li>
+              <li>Embed the signature and process the final block <strong>online</strong>.</li>
+            </ol>
+            <p>This way the private key avoid any exposure to the Internet and only non sensitive data is tranferred between the devices.</p>
+
+            <h3>STEP 1 (Online Device)</h3>
+            <p><strong>Use an account in "watch-only" mode. Create a SEND, CHANGE or RECEIVE block.</strong><br>
+              An incoming transaction need to be present to create a RECEIVE.</p>
+            <div class="uk-inline uk-width-1-1">
+              <div class="uk-grid-large" uk-grid>
+                <div class="uk-width-expand@m uk-width-1-1">
+                  <input (keyup)="validateDestination()" [(ngModel)]="toAccountID" class="uk-input" [ngClass]="{ 'uk-form-success': toAccountStatus === 1, 'uk-form-danger': toAccountStatus === 0 }" type="text" placeholder="Account to create a block for" autocomplete="off">
+                </div>
+                <div class="uk-width-1-6@m uk-width-1-1">
+                  <a class="uk-button uk-button-primary" routerLink="{{toAccountID ? '/account/'+toAccountID:''}}" routerLinkActive="active">GO</a>
+                </div>
+              </div>
+            </div>
+
+            <h3>STEP 2 (Offline Device)</h3>
+            <p><strong><a routerLink="/qr-scan" routerLinkActive="active">Scan the unsigned QR code</a> from Step 1.</strong><br>
+              Confirm and Sign it using any of the methods provided. Seed, Mnemonic, Private key or Ledger hardware wallet. Proof of Work is optional.</p>
+
+            <h3>STEP 3 (Online Device)</h3>
+            <p><strong><a routerLink="/qr-scan" routerLinkActive="active">Scan the signed QR code</a> from Step 2.</strong><br>
+              Confirm and Send the block to the live network! Proof of Work will be made if not done in Step 2.</p>
+          </div>
+        </div>
+      </div>
+  </div>
+</div>
+
+

--- a/src/app/components/remote-signing/remote-signing.component.html
+++ b/src/app/components/remote-signing/remote-signing.component.html
@@ -26,7 +26,8 @@
             </div>
 
             <h4>STEP 2 - Sign Block (Offline Device)</h4>
-            <p><a routerLink="/qr-scan" routerLinkActive="active">Scan the unsigned QR code</a> from Step 1 <strong>OR</strong> paste the block below. Sign it using a key owning the account from step 1.</p>
+            <p><a routerLink="/qr-scan" routerLinkActive="active">Scan the unsigned QR code</a> from Step 1 <strong>OR</strong> paste the block below. Sign it using a key owning the account from step 1.<br>
+            Nault can optionally be set in Offline Mode from the <a routerLink="/configure-app" routerLinkActive="active">Server Configuration</a> to avoid network notifications.</p>
             
             <div class="uk-form-horizontal">
               <div class="uk-margin">

--- a/src/app/components/remote-signing/remote-signing.component.html
+++ b/src/app/components/remote-signing/remote-signing.component.html
@@ -15,24 +15,47 @@
 
             <h3>STEP 1 (Online Device)</h3>
             <p><strong>Start with an account in "watch-only" mode. No login is needed.</strong></p>
+
             <div class="uk-inline uk-width-1-1">
               <div class="uk-grid-large" uk-grid>
                 <div class="uk-width-expand@m uk-width-1-1">
                   <input (keyup)="validateDestination()" [(ngModel)]="toAccountID" class="uk-input" [ngClass]="{ 'uk-form-success': toAccountStatus === 1, 'uk-form-danger': toAccountStatus === 0 }" type="text" placeholder="Account to create a block for" autocomplete="off">
                 </div>
                 <div class="uk-width-1-6@m uk-width-1-1">
-                  <a class="uk-button uk-button-primary" routerLink="{{toAccountID ? '/account/'+toAccountID:''}}" [queryParams]="{ sign: 1 }" routerLinkActive="active">GO</a>
+                  <button class="uk-button uk-button-primary" (click)="start()">CREATE</button>
                 </div>
               </div>
             </div>
 
             <h3>STEP 2 (Offline Device)</h3>
-            <p><strong><a routerLink="/qr-scan" routerLinkActive="active">Scan the unsigned QR code</a> from Step 1.</strong><br>
-              Confirm and Sign it using any of the methods provided. Seed, Mnemonic, Private key or Ledger hardware wallet. Proof of Work is optional.</p>
+            <p><strong><a routerLink="/qr-scan" routerLinkActive="active">Scan the unsigned QR code</a> from Step 1 OR paste the block text below.</strong></p>
+
+            <div class="uk-inline uk-width-1-1">
+              <div class="uk-grid-large" uk-grid>
+                <div class="uk-width-expand@m uk-width-1-1">
+                  <input (keyup)="validateUnsigned(unsignedBlock)" [(ngModel)]="unsignedBlock" class="uk-input" [ngClass]="{ 'uk-form-success': unsignedStatus === 1, 'uk-form-danger': unsignedStatus === 0 }" type="text" placeholder="Unsigned block from step 1 as raw text" autocomplete="off">
+                </div>
+                <div class="uk-width-1-6@m uk-width-1-1">
+                  <button class="uk-button uk-button-primary" (click)="navigateBlock(unsignedBlock)">SIGN</button>
+                </div>
+              </div>
+            </div>
+
+            
 
             <h3>STEP 3 (Online Device)</h3>
-            <p><strong><a routerLink="/qr-scan" routerLinkActive="active">Scan the signed QR code</a> from Step 2.</strong><br>
-              Confirm and Send the block to the live network! Proof of Work will be made if not done in Step 2.</p>
+            <p><strong><a routerLink="/qr-scan" routerLinkActive="active">Scan the signed QR code</a> from Step 2 OR paste the block text below.</strong></p>
+
+            <div class="uk-inline uk-width-1-1">
+              <div class="uk-grid-large" uk-grid>
+                <div class="uk-width-expand@m uk-width-1-1">
+                  <input (keyup)="validateSigned(signedBlock)" [(ngModel)]="signedBlock" class="uk-input" [ngClass]="{ 'uk-form-success': signedStatus === 1, 'uk-form-danger': signedStatus === 0 }" type="text" placeholder="Signed block from step 2 as raw text" autocomplete="off">
+                </div>
+                <div class="uk-width-1-6@m uk-width-1-1">
+                  <button class="uk-button uk-button-primary" (click)="navigateBlock(signedBlock)">PROCESS</button>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/components/remote-signing/remote-signing.component.html
+++ b/src/app/components/remote-signing/remote-signing.component.html
@@ -7,54 +7,56 @@
         <div class="uk-card uk-card-default">
           <div class="uk-card-body">
             <p><strong>An extremely secure way of transacting on the Nano network without exposing your private keys to the Internet, ensuring only non-sensitive data is transferred between devices.</strong></p>
-            <ol>
-              <li>Create a block <strong>online</strong> using the latest information from the network.</li>
-              <li>Sign the block hash on an <strong>offline</strong> device using a private key corresponding to the account from step 1.</li>
-              <li>Return the signature and process the final block <strong>online</strong>.</li>
-            </ol>
 
-            <h3>STEP 1 (Online Device)</h3>
-            <p><strong>Start with an account in "watch-only" mode. No login is needed.</strong></p>
+            <h4>STEP 1 - Create Block (Online Device)</h4>
+            <p>Create a SEND, RECEIVE or CHANGE block from a "watch-only" account. No login is needed.</p>
 
-            <div class="uk-inline uk-width-1-1">
-              <div class="uk-grid-large" uk-grid>
-                <div class="uk-width-expand@m uk-width-1-1">
-                  <input (keyup)="validateDestination()" [(ngModel)]="toAccountID" class="uk-input" [ngClass]="{ 'uk-form-success': toAccountStatus === 1, 'uk-form-danger': toAccountStatus === 0 }" type="text" placeholder="Account to create a block for" autocomplete="off">
-                </div>
-                <div class="uk-width-1-6@m uk-width-1-1">
-                  <button class="uk-button uk-button-primary" (click)="start()">CREATE</button>
+            <div class="uk-form-horizontal">
+              <div class="uk-margin">
+                <label class="uk-form-label" for="form-horizontal-text2">Account to create a block for</label>
+                <div class="uk-form-controls">
+                  <div class="uk-inline uk-width-1-1">
+                    <input (keyup)="validateDestination()" (keyup.enter)="start()" [(ngModel)]="toAccountID" class="uk-input" [ngClass]="{ 'uk-form-success': toAccountStatus === 1, 'uk-form-danger': toAccountStatus === 0 }" type="text" placeholder="nano_abc..123" autocomplete="off">
+                  </div>
                 </div>
               </div>
             </div>
-
-            <h3>STEP 2 (Offline Device)</h3>
-            <p><strong><a routerLink="/qr-scan" routerLinkActive="active">Scan the unsigned QR code</a> from Step 1 OR paste the block text below.</strong></p>
-
             <div class="uk-inline uk-width-1-1">
-              <div class="uk-grid-large" uk-grid>
-                <div class="uk-width-expand@m uk-width-1-1">
-                  <input (keyup)="validateUnsigned(unsignedBlock)" [(ngModel)]="unsignedBlock" class="uk-input" [ngClass]="{ 'uk-form-success': unsignedStatus === 1, 'uk-form-danger': unsignedStatus === 0 }" type="text" placeholder="Unsigned block from step 1 as raw text" autocomplete="off">
-                </div>
-                <div class="uk-width-1-6@m uk-width-1-1">
-                  <button class="uk-button uk-button-primary" (click)="navigateBlock(unsignedBlock)">SIGN</button>
-                </div>
-              </div>
+              <button class="uk-button uk-button-primary uk-width-1-6@m uk-width-1-1" (click)="start()">CREATE</button>
             </div>
 
+            <h4>STEP 2 - Sign Block (Offline Device)</h4>
+            <p><a routerLink="/qr-scan" routerLinkActive="active">Scan the unsigned QR code</a> from Step 1 <strong>OR</strong> paste the block below. Sign it using a key owning the account from step 1.</p>
             
-
-            <h3>STEP 3 (Online Device)</h3>
-            <p><strong><a routerLink="/qr-scan" routerLinkActive="active">Scan the signed QR code</a> from Step 2 OR paste the block text below.</strong></p>
-
-            <div class="uk-inline uk-width-1-1">
-              <div class="uk-grid-large" uk-grid>
-                <div class="uk-width-expand@m uk-width-1-1">
-                  <input (keyup)="validateSigned(signedBlock)" [(ngModel)]="signedBlock" class="uk-input" [ngClass]="{ 'uk-form-success': signedStatus === 1, 'uk-form-danger': signedStatus === 0 }" type="text" placeholder="Signed block from step 2 as raw text" autocomplete="off">
-                </div>
-                <div class="uk-width-1-6@m uk-width-1-1">
-                  <button class="uk-button uk-button-primary" (click)="navigateBlock(signedBlock)">PROCESS</button>
+            <div class="uk-form-horizontal">
+              <div class="uk-margin">
+                <label class="uk-form-label" for="form-horizontal-text2">Unsigned block from step 1</label>
+                <div class="uk-form-controls">
+                  <div class="uk-inline uk-width-1-1">
+                    <input (keyup)="validateUnsigned(unsignedBlock)" (keyup.enter)="navigateBlock(unsignedBlock)" [(ngModel)]="unsignedBlock" class="uk-input" [ngClass]="{ 'uk-form-success': unsignedStatus === 1, 'uk-form-danger': unsignedStatus === 0 }" type="text" placeholder="nanosign:{abc..}" autocomplete="off">
+                  </div>
                 </div>
               </div>
+            </div>
+            <div class="uk-inline uk-width-1-1">
+              <button class="uk-button uk-button-primary uk-width-1-6@m uk-width-1-1" (click)="navigateBlock(unsignedBlock)">SIGN</button>
+            </div>
+
+            <h4>STEP 3 - Process Block (Online Device)</h4>
+            <p><a routerLink="/qr-scan" routerLinkActive="active">Scan the signed QR code</a> from Step 2 <strong>OR</strong> paste the block below. Confirm and send it to the live network!</p>
+
+            <div class="uk-form-horizontal">
+              <div class="uk-margin">
+                <label class="uk-form-label" for="form-horizontal-text2">Signed block from step 2</label>
+                <div class="uk-form-controls">
+                  <div class="uk-inline uk-width-1-1">
+                    <input (keyup)="validateSigned(signedBlock)" (keyup.enter)="navigateBlock(signedBlock)" [(ngModel)]="signedBlock" class="uk-input" [ngClass]="{ 'uk-form-success': signedStatus === 1, 'uk-form-danger': signedStatus === 0 }" type="text" placeholder="nanoprocess:{abc..}" autocomplete="off">
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="uk-inline uk-width-1-1">
+              <button class="uk-button uk-button-primary uk-width-1-6@m uk-width-1-1" (click)="navigateBlock(signedBlock)">PROCESS</button>
             </div>
           </div>
         </div>

--- a/src/app/components/remote-signing/remote-signing.component.html
+++ b/src/app/components/remote-signing/remote-signing.component.html
@@ -6,17 +6,15 @@
       <div class="uk-width-1-1">
         <div class="uk-card uk-card-default">
           <div class="uk-card-body">
-            <p><strong>Remote signing allows you to transact on the Nano network with extra security.</strong></p>
+            <p><strong>An extremely secure way of transacting on the Nano network without exposing your private keys to the Internet, ensuring only non-sensitive data is transferred between devices.</strong></p>
             <ol>
               <li>Create a block <strong>online</strong> using the latest information from the network.</li>
               <li>Sign the block hash on an <strong>offline</strong> device using a private key corresponding to the account from step 1.</li>
-              <li>Embed the signature and process the final block <strong>online</strong>.</li>
+              <li>Return the signature and process the final block <strong>online</strong>.</li>
             </ol>
-            <p>This way the private key avoid any exposure to the Internet and only non sensitive data is tranferred between the devices.</p>
 
             <h3>STEP 1 (Online Device)</h3>
-            <p><strong>Start with an account in "watch-only" mode. No login is needed.</strong><br>
-              Remote Signing will be enabled for you to create new blocks.</p>
+            <p><strong>Start with an account in "watch-only" mode. No login is needed.</strong></p>
             <div class="uk-inline uk-width-1-1">
               <div class="uk-grid-large" uk-grid>
                 <div class="uk-width-expand@m uk-width-1-1">

--- a/src/app/components/remote-signing/remote-signing.component.spec.ts
+++ b/src/app/components/remote-signing/remote-signing.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RemoteSigningComponent } from './remote-signing.component';
+
+describe('RemoteSigningComponent', () => {
+  let component: RemoteSigningComponent;
+  let fixture: ComponentFixture<RemoteSigningComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ RemoteSigningComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RemoteSigningComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/remote-signing/remote-signing.component.ts
+++ b/src/app/components/remote-signing/remote-signing.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import {UtilService} from "../../services/util.service";
-
-const nacl = window['nacl'];
+import { Router } from "@angular/router";
+import { NotificationService } from "../../services/notification.service";
+import { RemoteSignService } from "../../services/remote-sign.service";
 
 @Component({
   selector: 'app-send',
@@ -11,8 +12,16 @@ const nacl = window['nacl'];
 export class RemoteSigningComponent implements OnInit {
   toAccountID: string = '';
   toAccountStatus:number = null;
+  unsignedBlock: string = '';
+  signedBlock: string = '';
+  unsignedStatus:number = null;
+  signedStatus:number = null;
+
   constructor(
     private util: UtilService,
+    private router: Router,
+    private notifcationService: NotificationService,
+    private remoteSignService: RemoteSignService,
     ) { }
 
   async ngOnInit() {
@@ -20,7 +29,69 @@ export class RemoteSigningComponent implements OnInit {
   }
 
   validateDestination() {
-    if (this.util.account.isValidAccount(this.toAccountID)) this.toAccountStatus = 1
-    else this.toAccountStatus = 0
+    if (this.util.account.isValidAccount(this.toAccountID)) {
+      this.toAccountStatus = 1
+      return true
+    }
+    else {
+      this.toAccountStatus = 0
+      return false
+    }
+  }
+
+  validateUnsigned(string) {
+    var url = null;
+    if (string.startsWith('nanosign:')) {
+      url = new URL(string);
+    }
+    if (url && this.remoteSignService.checkSignBlock(url.pathname)) {
+      this.unsignedStatus = 1
+    }
+    else {
+      this.unsignedStatus = 0
+    }
+  }
+
+  validateSigned(string) {
+    var url = null;
+    if (string.startsWith('nanoprocess:')) {
+      url = new URL(string);
+    }
+    if (url && this.remoteSignService.checkSignBlock(url.pathname) && this.remoteSignService.checkProcessBlock(url.pathname)) {
+      this.signedStatus = 1
+    }
+    else {
+      this.signedStatus = 0
+    }
+  }
+
+  start() {
+    if (this.validateDestination()) {
+      this.router.navigate(['account', this.toAccountID], { queryParams: {sign:1}});
+    }
+    else {
+      this.notifcationService.sendWarning('Not a valid account format!')
+    }
+  }
+
+  navigateBlock(block) {
+    var badScheme = false;
+
+    if (block.startsWith('nanosign:') || block.startsWith('nanoprocess:')) {
+      var url = new URL(block);
+      if (url.protocol === 'nanosign:') {
+        this.remoteSignService.navigateSignBlock(url);
+      }
+      else if (url.protocol === 'nanoprocess:') {
+        this.remoteSignService.navigateProcessBlock(url);
+      }
+      else {
+        badScheme = true;
+      }
+    }
+    else {
+      badScheme = true;
+    }
+    if (badScheme) this.notifcationService.sendWarning('Not a recognized block format!', { length: 5000 })
   }
 }

--- a/src/app/components/remote-signing/remote-signing.component.ts
+++ b/src/app/components/remote-signing/remote-signing.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit } from '@angular/core';
+import {UtilService} from "../../services/util.service";
+
+const nacl = window['nacl'];
+
+@Component({
+  selector: 'app-send',
+  templateUrl: './remote-signing.component.html',
+  styleUrls: ['./remote-signing.component.css']
+})
+export class RemoteSigningComponent implements OnInit {
+  toAccountID: string = '';
+  toAccountStatus:number = null;
+  constructor(
+    private util: UtilService,
+    ) { }
+
+  async ngOnInit() {
+
+  }
+
+  validateDestination() {
+    if (this.util.account.isValidAccount(this.toAccountID)) this.toAccountStatus = 1
+    else this.toAccountStatus = 0
+  }
+}

--- a/src/app/components/representatives/representatives.component.ts
+++ b/src/app/components/representatives/representatives.component.ts
@@ -1,5 +1,4 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {HttpClient} from "@angular/common/http";
 import {ActivatedRoute} from "@angular/router";
 
 import BigNumber from "bignumber.js";

--- a/src/app/components/representatives/representatives.component.ts
+++ b/src/app/components/representatives/representatives.component.ts
@@ -55,7 +55,6 @@ export class RepresentativesComponent implements OnInit {
     private notifications: NotificationService,
     private nanoBlock: NanoBlockService,
     private util: UtilService,
-    private http: HttpClient,
     private representativeService: RepresentativeService,
     public settings: AppSettingsService) { }
 
@@ -220,8 +219,8 @@ export class RepresentativesComponent implements OnInit {
 
     this.changingRepresentatives = true;
 
-    const valid = await this.api.validateAccountNumber(newRep);
-    if (!valid || valid.valid !== '1') {
+    const valid = this.util.account.isValidAccount(newRep);
+    if (!valid) {
       this.changingRepresentatives = false;
       return this.notifications.sendWarning(`Representative is not a valid account`);
     }

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -168,8 +168,8 @@ export class SendComponent implements OnInit {
   }
 
   async sendTransaction() {
-    const isValid = await this.nodeApi.validateAccountNumber(this.toAccountID);
-    if (!isValid || isValid.valid == '0') return this.notificationService.sendWarning(`To account address is not valid`);
+    const isValid = this.util.account.isValidAccount(this.toAccountID);
+    if (!isValid) return this.notificationService.sendWarning(`To account address is not valid`);
     if (!this.fromAccountID || !this.toAccountID) return this.notificationService.sendWarning(`From and to account are required`);
 
     const from = await this.nodeApi.accountInfo(this.fromAccountID);

--- a/src/app/components/sign/sign.component.css
+++ b/src/app/components/sign/sign.component.css
@@ -1,0 +1,32 @@
+.confirm-title {
+  font-weight: bolder;
+  display: block;
+  font-size: 24px;
+}
+
+.confirm-currency {
+  font-weight: bolder;
+  display: block;
+  font-size: 20px;
+}
+
+.confirm-subtitle {
+  display: block;
+  font-size: 10px;
+}
+
+
+@media (max-width: 12450px) {
+  .br-spacer {
+    display: block;
+  }
+}
+@media (max-width: 959px) {
+  .br-spacer {
+    display: none;
+  }
+}
+
+.uk-dropdown-spacing {
+  padding: 5px 0;
+}

--- a/src/app/components/sign/sign.component.css
+++ b/src/app/components/sign/sign.component.css
@@ -30,3 +30,14 @@
 .uk-dropdown-spacing {
   padding: 5px 0;
 }
+
+.block-qr {
+  margin:auto;
+  max-width: 600px;
+}
+
+@media only screen and (max-width: 1200px) {
+  .block-qr {
+      max-width: 1200px;
+  }
+}

--- a/src/app/components/sign/sign.component.css
+++ b/src/app/components/sign/sign.component.css
@@ -41,3 +41,19 @@
       max-width: 1200px;
   }
 }
+
+.modal-qr {
+  width: 80%;
+  max-width: 650px !important;
+  padding: 20px 0 0 0;
+}
+
+@media only screen and (max-width: 1200px) {
+  .modal-qr {
+      width: 100%;
+      max-width: 1200px !important;
+  }
+  .modal-qr-body {
+      padding: 30px 5px;
+  }
+}

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -1,40 +1,45 @@
 <div uk-grid>
   <div class="uk-width-1-1">
-    <h2>Sign Nano Block</h2>
+    <h2 *ngIf="shouldSign">Sign Nano Block</h2>
+    <h2 *ngIf="!shouldSign">Process Nano Block</h2>
 
     <!-- Confirmation Panel -->
     <div uk-grid *ngIf="activePanel == 'confirm'" class="uk-animation-slide-left">
       <div class="uk-width-1-1">
         <div class="uk-card uk-card-default uk-width-1-1 uk-text-center">
-          <span *ngIf="!qrCodeImageBlock" style="display: block; padding-top: 8px;">You are about to sign a block to {{txTypeMessage}}</span>
-          <span *ngIf="qrCodeImageBlock" style="display: block; padding-top: 8px;">You have signed a block to {{txTypeMessage}}</span>
+          <span *ngIf="!qrCodeImageBlock && shouldSign" style="display: block; padding-top: 8px;">You are about to sign a block to {{txTypeMessage}}</span>
+          <span *ngIf="qrCodeImageBlock && shouldSign" style="display: block; padding-top: 8px;">You have signed a block to {{txTypeMessage}}</span>
+          <span *ngIf="!blockProcessed && !shouldSign" style="display: block; padding-top: 8px;">You are about to {{txTypeMessage}}</span>
+          <span *ngIf="blockProcessed && !shouldSign" style="display: block; padding-top: 8px;">You have processed a block to {{txTypeMessage}}</span>
           <span *ngIf="txType != txTypes.change" style="display:block; font-size: 32px;">{{ rawAmount | rai: 'mnano' }}</span>
           <span *ngIf="txType == txTypes.change" style="display:block; font-size: 20px;">{{ currentBlock.representative }}</span>
         </div>
         <br>
-        <div uk-grid *ngIf="fromAccountID && toAccountID">
+        <div uk-grid>
           <div class="uk-width-1-2@m">
             <div class="uk-card uk-card-default">
-              <div class="uk-card-header uk-text-left" style="padding: 20px 20px;">
-
+              <div class="uk-card-header uk-text-left" style="padding: 20px 20px; line-height: 22px;">
                 <span class="confirm-title uk-text-truncate">
                   <div *ngIf="fromAddressBook">
-                    <span class="confirm-title">{{ fromAddressBook }}</span>
+                    <span class="confirm-title">{{ fromAddressBook}}</span>
                     <span class="confirm-subtitle">From Account</span>
-                    <span class="uk-text-small uk-text-truncate" title="{{fromAccountID}}">{{ fromAccountID }}</span>
+                    <span class="uk-text-small uk-text-truncate" title="{{fromAccountID}}">{{ fromAccountID || 'N/A' }}</span>
                   </div>
                   <div *ngIf="!fromAddressBook">
-                    <span class="confirm-title uk-text-truncate" title="{{fromAccountID}}">{{ fromAccountID }}</span>
+                    <span class="confirm-title uk-text-truncate" title="{{fromAccountID}}">{{ fromAccountID || 'N/A' }}</span>
                     <span class="confirm-subtitle">From Account</span>
                     <br class="br-spacer" />
                   </div>
                 </span>
+                <ul class="uk-iconnav">
+                  <li><a ngxClipboard [cbContent]="fromAccountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
+                </ul>
               </div>
               <div class="uk-card-body" style="padding: 20px 20px;">
                 <div uk-grid>
                   <div class="uk-width-1-2 uk-text-muted">
-                    <span class="confirm-currency">{{ fromAccountBalance || 0 | rai: 'mnano'}}</span>
-                    <span class="confirm-subtitle">Current Balance</span>
+                    <span class="confirm-currency">{{ fromAccountBalance ? (fromAccountBalance | rai: 'mnano'): 'N/A'}}</span>
+                    <span class="confirm-subtitle">Balance when block was created</span>
                   </div>
                   <div class="uk-width-1-2 uk-text-right">
                     <span class="confirm-currency uk-text-danger">-{{ rawAmount | rai: 'mnano' }}</span>
@@ -46,26 +51,29 @@
 
           <div class="uk-width-1-2@m">
             <div class="uk-card uk-card-default">
-              <div class="uk-card-header uk-text-right" style="padding: 20px 20px;">
+              <div class="uk-card-header uk-text-right" style="padding: 20px 20px; line-height: 22px;">
 
                 <span class="confirm-title uk-text-truncate">
                   <div *ngIf="toAddressBook">
                     <span class="confirm-title">{{ toAddressBook }}</span>
                     <span class="confirm-subtitle">To Account</span>
-                    <span class="uk-text-small uk-text-truncate" title="{{toAccountID}}">{{ toAccountID }}</span>
+                    <span class="uk-text-small uk-text-truncate" title="{{toAccountID}}">{{ toAccountID || 'N/A'}}</span>
                   </div>
                   <div *ngIf="!toAddressBook">
-                    <span class="confirm-title uk-text-truncate" title="{{toAccountID}}">{{ toAccountID }}</span>
+                    <span class="confirm-title uk-text-truncate" title="{{toAccountID}}">{{ toAccountID || 'N/A' }}</span>
                     <span class="confirm-subtitle">To Account</span>
                     <br class="br-spacer" />
                   </div>
                 </span>
+                <ul class="uk-iconnav">
+                <li><a ngxClipboard [cbContent]="toAccountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
+                </ul>
               </div>
               <div class="uk-card-body" style="padding: 20px 20px;">
                 <div uk-grid>
                   <div class="uk-width-1-2 uk-text-muted">
-                    <span class="confirm-currency">{{ toAccountBalance || 0 | rai: 'mnano'}}</span>
-                    <span class="confirm-subtitle">Current Balance</span>
+                    <span class="confirm-currency">{{ toAccountBalance ? (toAccountBalance | rai: 'mnano'): 'N/A' }}</span>
+                    <span class="confirm-subtitle">Balance when block was created</span>
                   </div>
                   <div class="uk-width-1-2 uk-text-right">
                     <span class="confirm-currency uk-text-success">+{{ rawAmount | rai: 'mnano' }}</span>
@@ -77,7 +85,7 @@
         </div>
         <br>
 
-        <div *ngIf="!qrCodeImageBlock" class="uk-card uk-card-default uk-width-1-1" style="padding: 20px 20px;">
+        <div *ngIf="!qrCodeImageBlock && shouldSign" class="uk-card uk-card-default uk-width-1-1" style="padding: 20px 20px;">
           <span><strong>Signing Method</strong></span><span uk-icon="icon: info;" uk-tooltip title="The block is signed with a private key. If using the build-in wallet, it first needs to be created using any of the available methods."></span><br>
           <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="signtype" value={{signTypes[0]}} [(ngModel)]="signTypeSelected" (change)="signTypeChange()"> {{signTypes[0]}}</label>
           <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="signtype" value={{signTypes[1]}} [(ngModel)]="signTypeSelected" (change)="signTypeChange()"> {{signTypes[1]}}</label>
@@ -148,17 +156,34 @@
         </div>
         <br>
 
-        <div *ngIf="!qrCodeImageBlock" uk-grid>
+        <div *ngIf="processedHash" class="uk-card uk-card-default uk-width-1-1 uk-text-center" style="padding: 20px 20px;">
+          <div class="uk-visible-toggle">
+            <div uk-grid class="uk-width-auto">
+              <div class="uk-width-expand uk-text-truncate">
+                <span class="uk-text-success">Successfully processed block: </span><a [routerLink]="'/transaction/' + processedHash" class="uk-link-text" title="View Block Details" uk-tooltip>{{ processedHash }}</a>
+              </div>
+              <div class="uk-width-auto" style="padding-left: 10px;">
+                <ul class="uk-hidden-hover uk-iconnav">
+                  <li><a ngxClipboard [cbContent]="processedHash" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Block Hash" uk-tooltip></a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div *ngIf="!qrCodeImageBlock && !processedHash" uk-grid>
           <div class="uk-width-1-2@s">
             <a class="uk-button uk-button-danger uk-width-1-1" routerLink="/qr-scan" routerLinkActive="active">Cancel</a>
           </div>
           <div class="uk-width-1-2@s">
-            <button *ngIf="!confirmingTransaction" class="uk-button uk-button-primary uk-width-1-1" (click)="confirmTransaction()">Confirm & Sign</button>
-            <button *ngIf="confirmingTransaction" class="uk-button uk-button-primary uk-disabled uk-width-1-1"><span class="uk-margin-right" uk-spinner></span> Loading</button>
+            <button *ngIf="!confirmingTransaction && shouldSign" class="uk-button uk-button-primary uk-width-1-1" (click)="confirmTransaction()">Confirm & Sign</button>
+            <button *ngIf="confirmingTransaction && shouldSign" class="uk-button uk-button-primary uk-disabled uk-width-1-1"><span class="uk-margin-right" uk-spinner></span> Loading</button>
+            <button *ngIf="!confirmingTransaction && !shouldSign" class="uk-button uk-button-primary uk-width-1-1" (click)="confirmBlock()">Confirm & Process</button>
+            <button *ngIf="confirmingTransaction && !shouldSign" class="uk-button uk-button-primary uk-disabled uk-width-1-1"><span class="uk-margin-right" uk-spinner></span> Loading</button>
           </div>
         </div>
 
-        <div *ngIf="qrCodeImageBlock" class="uk-text-center">
+        <div *ngIf="qrCodeImageBlock && shouldSign" class="uk-text-center">
           <span><strong>Scan the QR in an online Nault (or compatible wallet) to process the block</strong></span><br><br>
           <div class="uk-width-1-1@s uk-width-3-4@m uk-width-1-2@l uk-text-center block-qr">
             <img *ngIf="qrCodeImageBlock" [src]="qrCodeImageBlock"><br />

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -6,8 +6,10 @@
     <div uk-grid *ngIf="activePanel == 'confirm'" class="uk-animation-slide-left">
       <div class="uk-width-1-1">
         <div class="uk-card uk-card-default uk-width-1-1 uk-text-center">
-          <span style="display: block; padding-top: 8px;">You are about to sign a block to send</span>
-          <span style="display:block; font-size: 32px;">{{ rawAmount | rai: 'mnano' }}</span>
+          <span *ngIf="!qrCodeImageBlock" style="display: block; padding-top: 8px;">You are about to sign a block to {{txTypeMessage}}</span>
+          <span *ngIf="qrCodeImageBlock" style="display: block; padding-top: 8px;">You have signed a block to {{txTypeMessage}}</span>
+          <span *ngIf="txType != txTypes.change" style="display:block; font-size: 32px;">{{ rawAmount | rai: 'mnano' }}</span>
+          <span *ngIf="txType == txTypes.change" style="display:block; font-size: 20px;">{{ currentBlock.representative }}</span>
         </div>
         <br>
         <div uk-grid *ngIf="fromAccountID && toAccountID">
@@ -19,10 +21,10 @@
                   <div *ngIf="fromAddressBook">
                     <span class="confirm-title">{{ fromAddressBook }}</span>
                     <span class="confirm-subtitle">From Account</span>
-                    <span class="uk-text-small uk-text-truncate">{{ fromAccountID }}</span>
+                    <span class="uk-text-small uk-text-truncate" title="{{fromAccountID}}">{{ fromAccountID }}</span>
                   </div>
                   <div *ngIf="!fromAddressBook">
-                    <span class="confirm-title uk-text-truncate">{{ fromAccountID }}</span>
+                    <span class="confirm-title uk-text-truncate" title="{{fromAccountID}}">{{ fromAccountID }}</span>
                     <span class="confirm-subtitle">From Account</span>
                     <br class="br-spacer" />
                   </div>
@@ -50,10 +52,10 @@
                   <div *ngIf="toAddressBook">
                     <span class="confirm-title">{{ toAddressBook }}</span>
                     <span class="confirm-subtitle">To Account</span>
-                    <span class="uk-text-small uk-text-truncate">{{ toAccountID }}</span>
+                    <span class="uk-text-small uk-text-truncate" title="{{toAccountID}}">{{ toAccountID }}</span>
                   </div>
                   <div *ngIf="!toAddressBook">
-                    <span class="confirm-title uk-text-truncate">{{ toAccountID }}</span>
+                    <span class="confirm-title uk-text-truncate" title="{{toAccountID}}">{{ toAccountID }}</span>
                     <span class="confirm-subtitle">To Account</span>
                     <br class="br-spacer" />
                   </div>
@@ -75,35 +77,102 @@
         </div>
         <br>
 
-        <div class="uk-card uk-card-default uk-width-1-1" style="padding: 20px 20px;">
-          <span><strong>Signing Method</strong></span><br>
-          <input type="radio" value="wallet" name="method" ngModel> Nault Wallet
-          <input type="radio" value="seed" name="method" ngModel> Seed+Index
-          <input type="radio" value="key" name="method" ngModel> Private key
+        <div *ngIf="!qrCodeImageBlock" class="uk-card uk-card-default uk-width-1-1" style="padding: 20px 20px;">
+          <span><strong>Signing Method</strong></span><span uk-icon="icon: info;" uk-tooltip title="The block is signed with a private key. If using the build-in wallet, it first needs to be created using any of the available methods."></span><br>
+          <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="signtype" value={{signTypes[0]}} [(ngModel)]="signTypeSelected" (change)="signTypeChange()"> {{signTypes[0]}}</label>
+          <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="signtype" value={{signTypes[1]}} [(ngModel)]="signTypeSelected" (change)="signTypeChange()"> {{signTypes[1]}}</label>
+          <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="signtype" value={{signTypes[2]}} [(ngModel)]="signTypeSelected" (change)="signTypeChange()"> {{signTypes[2]}}</label>
+          <br><br>
+          <span><strong>Proof of Work</strong></span><span uk-icon="icon: info;" uk-tooltip title="Proof of Work (PoW) can be optionally generated now and included in the block, or it will be added for you before the block is published."></span><br>
+          <label class="uk-margin-medium-right"><input class="uk-checkbox" type="checkbox" name="pow" value='pow' [(ngModel)]="shouldGenWork" (change)="powChange()"> Include</label><br><br>
+
+          <!-- Seed and index-->
+          <div *ngIf="signTypeSelected === signTypes[1]">
+            <div class="uk-width-1-1 narrow-div">
+              <div class="uk-form-horizontal">
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="source-wallet">Signing Wallet <span uk-icon="icon: info;" uk-tooltip title="The seed or mnemonic that contains the account you are signing for."></span></label>
+                  <div class="uk-form-controls">
+                    <div uk-grid>
+                      <div class="uk-width-1-1">
+                        <div class="uk-inline uk-width-1-1">
+                          <input [(ngModel)]="sourceSecret" class="uk-input uk-margin-small-bottom {{validSeed ? '':'uk-form-danger'}}" id="source-wallet" type="text" (ngModelChange)="seedChange(sourceSecret)" placeholder="Nano seed, bip39 seed or 24-word passphrase" autocomplete="off">
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="uk-width-1-1 narrow-div">
+              <div class="uk-form-horizontal">
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="start-index">Account Index <span uk-icon="icon: info;" uk-tooltip title="The index at where the account you are signing for is located in the seed. Maximum 4,294,967,295."></span></label>
+                  <div class="uk-form-controls">
+                    <div class="uk-inline uk-width-1-1">
+                      <input [(ngModel)]="index" class="uk-input uk-margin-small-bottom {{validIndex ? '':'uk-form-danger'}}" id="start-index" type="text" maxLength="10" (ngModelChange)="indexChange(index)" placeholder="0 to 4294967295" autocomplete="off">
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- END Seed and index-->
+
+          <!-- Private key-->
+          <div *ngIf="signTypeSelected === signTypes[2]">
+            <div class="uk-width-1-1 narrow-div">
+              <div class="uk-form-horizontal">
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="source-wallet">Private Key <span uk-icon="icon: info;" uk-tooltip title="The private key that derive the account you are signing for."></span></label>
+                  <div class="uk-form-controls">
+                    <div uk-grid>
+                      <div class="uk-width-1-1">
+                        <div class="uk-inline uk-width-1-1">
+                          <input [(ngModel)]="sourcePriv" class="uk-input uk-margin-small-bottom {{validPrivkey ? '':'uk-form-danger'}}" id="source-wallet" type="text" (ngModelChange)="privkeyChange(sourcePriv)" placeholder="Private key or Expanded private key" autocomplete="off">
+                          <label><input class="uk-checkbox" type="checkbox" name="expanded" value='expanded' [(ngModel)]="privateKeyExpanded" (change)="privkeyChange(sourcePriv)"> Expanded private key</label><span uk-icon="icon: info;" uk-tooltip title="If using a 64 or 128 char expanded key."></span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- END Private key-->
+
+          <span class="uk-text-danger">{{signatureMessage}}</span>
+          <span class="uk-text-success">{{signatureMessageSuccess}}</span>
+
         </div>
         <br>
 
-        <div uk-grid>
+        <div *ngIf="!qrCodeImageBlock" uk-grid>
           <div class="uk-width-1-2@s">
-            <button (click)="activePanel = 'cancel'" class="uk-button uk-button-danger uk-width-1-1">Cancel</button>
+            <a class="uk-button uk-button-danger uk-width-1-1" routerLink="/qr-scan" routerLinkActive="active">Cancel</a>
           </div>
           <div class="uk-width-1-2@s">
             <button *ngIf="!confirmingTransaction" class="uk-button uk-button-primary uk-width-1-1" (click)="confirmTransaction()">Confirm & Sign</button>
             <button *ngIf="confirmingTransaction" class="uk-button uk-button-primary uk-disabled uk-width-1-1"><span class="uk-margin-right" uk-spinner></span> Loading</button>
           </div>
         </div>
-      </div>
-    </div>
-    <!-- End Confirmation Panel -->
 
-
-    <div uk-grid *ngIf="activePanel == 'cancel'" class="uk-animation-slide-left">
-      <div class="uk-width-1-1">
-        <div class="uk-card uk-card-default uk-width-1-1 uk-text-center">
-          <span style="display: block; padding-top: 8px;">Block signing cancelled!<br/></span>
+        <div *ngIf="qrCodeImageBlock" class="uk-text-center">
+          <span><strong>Scan the QR in an online Nault (or compatible wallet) to process the block</strong></span><br><br>
+          <div class="uk-width-1-1@s uk-width-3-4@m uk-width-1-2@l uk-text-center block-qr">
+            <img *ngIf="qrCodeImageBlock" [src]="qrCodeImageBlock"><br />
+          </div>
+          <div *ngIf="currentBlock.signature" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
+            <span class="uk-text-small" uk-tooltip title="Signature" style="overflow-wrap: anywhere;">{{currentBlock.signature | squeeze}}</span>
+            <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+              <li><a ngxClipboard [cbContent]="currentBlock.signature" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
+    <!-- End Confirmation Panel -->
 
     <div uk-grid *ngIf="activePanel == 'error'" class="uk-animation-slide-left">
       <div class="uk-width-1-1">

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -1,0 +1,119 @@
+<div uk-grid>
+  <div class="uk-width-1-1">
+    <h2>Sign Nano Block</h2>
+
+    <!-- Confirmation Panel -->
+    <div uk-grid *ngIf="activePanel == 'confirm'" class="uk-animation-slide-left">
+      <div class="uk-width-1-1">
+        <div class="uk-card uk-card-default uk-width-1-1 uk-text-center">
+          <span style="display: block; padding-top: 8px;">You are about to sign a block to send</span>
+          <span style="display:block; font-size: 32px;">{{ rawAmount | rai: 'mnano' }}</span>
+        </div>
+        <br>
+        <div uk-grid *ngIf="fromAccountID && toAccountID">
+          <div class="uk-width-1-2@m">
+            <div class="uk-card uk-card-default">
+              <div class="uk-card-header uk-text-left" style="padding: 20px 20px;">
+
+                <span class="confirm-title uk-text-truncate">
+                  <div *ngIf="fromAddressBook">
+                    <span class="confirm-title">{{ fromAddressBook }}</span>
+                    <span class="confirm-subtitle">From Account</span>
+                    <span class="uk-text-small uk-text-truncate">{{ fromAccountID }}</span>
+                  </div>
+                  <div *ngIf="!fromAddressBook">
+                    <span class="confirm-title uk-text-truncate">{{ fromAccountID }}</span>
+                    <span class="confirm-subtitle">From Account</span>
+                    <br class="br-spacer" />
+                  </div>
+                </span>
+              </div>
+              <div class="uk-card-body" style="padding: 20px 20px;">
+                <div uk-grid>
+                  <div class="uk-width-1-2 uk-text-muted">
+                    <span class="confirm-currency">{{ fromAccountBalance || 0 | rai: 'mnano'}}</span>
+                    <span class="confirm-subtitle">Current Balance</span>
+                  </div>
+                  <div class="uk-width-1-2 uk-text-right">
+                    <span class="confirm-currency uk-text-danger">-{{ rawAmount | rai: 'mnano' }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="uk-width-1-2@m">
+            <div class="uk-card uk-card-default">
+              <div class="uk-card-header uk-text-right" style="padding: 20px 20px;">
+
+                <span class="confirm-title uk-text-truncate">
+                  <div *ngIf="toAddressBook">
+                    <span class="confirm-title">{{ toAddressBook }}</span>
+                    <span class="confirm-subtitle">To Account</span>
+                    <span class="uk-text-small uk-text-truncate">{{ toAccountID }}</span>
+                  </div>
+                  <div *ngIf="!toAddressBook">
+                    <span class="confirm-title uk-text-truncate">{{ toAccountID }}</span>
+                    <span class="confirm-subtitle">To Account</span>
+                    <br class="br-spacer" />
+                  </div>
+                </span>
+              </div>
+              <div class="uk-card-body" style="padding: 20px 20px;">
+                <div uk-grid>
+                  <div class="uk-width-1-2 uk-text-muted">
+                    <span class="confirm-currency">{{ toAccountBalance || 0 | rai: 'mnano'}}</span>
+                    <span class="confirm-subtitle">Current Balance</span>
+                  </div>
+                  <div class="uk-width-1-2 uk-text-right">
+                    <span class="confirm-currency uk-text-success">+{{ rawAmount | rai: 'mnano' }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <br>
+
+        <div class="uk-card uk-card-default uk-width-1-1" style="padding: 20px 20px;">
+          <span><strong>Signing Method</strong></span><br>
+          <input type="radio" value="wallet" name="method" ngModel> Nault Wallet
+          <input type="radio" value="seed" name="method" ngModel> Seed+Index
+          <input type="radio" value="key" name="method" ngModel> Private key
+        </div>
+        <br>
+
+        <div uk-grid>
+          <div class="uk-width-1-2@s">
+            <button (click)="activePanel = 'cancel'" class="uk-button uk-button-danger uk-width-1-1">Cancel</button>
+          </div>
+          <div class="uk-width-1-2@s">
+            <button *ngIf="!confirmingTransaction" class="uk-button uk-button-primary uk-width-1-1" (click)="confirmTransaction()">Confirm & Sign</button>
+            <button *ngIf="confirmingTransaction" class="uk-button uk-button-primary uk-disabled uk-width-1-1"><span class="uk-margin-right" uk-spinner></span> Loading</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- End Confirmation Panel -->
+
+
+    <div uk-grid *ngIf="activePanel == 'cancel'" class="uk-animation-slide-left">
+      <div class="uk-width-1-1">
+        <div class="uk-card uk-card-default uk-width-1-1 uk-text-center">
+          <span style="display: block; padding-top: 8px;">Block signing cancelled!<br/></span>
+        </div>
+      </div>
+    </div>
+
+    <div uk-grid *ngIf="activePanel == 'error'" class="uk-animation-slide-left">
+      <div class="uk-width-1-1">
+        <div class="uk-card uk-card-default uk-width-1-1 uk-text-center">
+          <span style="display: block; padding-top: 8px;">The provided block info is not valid.<br/>Please refer to any error message below.<br/></span>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -21,7 +21,7 @@
               <div class="uk-card-header uk-text-left" style="padding: 20px 20px; line-height: 22px;">
                 <span class="confirm-title uk-text-truncate">
                   <div *ngIf="fromAddressBook">
-                    <span class="confirm-title">{{ fromAddressBook}}</span>
+                    <span class="confirm-title">{{ fromAddressBook }}</span>
                     <span class="confirm-subtitle">From Account</span>
                     <span class="uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
                   </div>
@@ -57,10 +57,10 @@
                   <div *ngIf="toAddressBook">
                     <span class="confirm-title">{{ toAddressBook }}</span>
                     <span class="confirm-subtitle">To Account</span>
-                    <span class="uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="toAccountID"></app-nano-account-id></span>
+                    <span class="uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
                   </div>
-                  <div *ngIf="!fromAddressBook">
-                    <span class="confirm-title uk-text-truncate"><app-nano-account-id [accountID]="toAccountID"></app-nano-account-id></span>
+                  <div *ngIf="!toAddressBook">
+                    <span class="confirm-title uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
                     <span class="confirm-subtitle">To Account</span>
                     <br class="br-spacer" />
                   </div>
@@ -85,7 +85,7 @@
         </div>
         <br>
 
-        <div *ngIf="!qrCodeImageBlock && shouldSign" class="uk-card uk-card-default uk-width-1-1" style="padding: 20px 20px;">
+        <div *ngIf="shouldSign" class="uk-card uk-card-default uk-width-1-1" style="padding: 20px 20px;">
           <span><strong>Signing Method</strong></span><span uk-icon="icon: info;" uk-tooltip title="The block is signed with a private key. If using the build-in wallet, it first needs to be created using any of the available methods."></span><br>
           <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="signtype" value={{signTypes[0]}} [(ngModel)]="signTypeSelected" (change)="signTypeChange()"> {{signTypes[0]}}</label>
           <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="signtype" value={{signTypes[1]}} [(ngModel)]="signTypeSelected" (change)="signTypeChange()"> {{signTypes[1]}}</label>
@@ -169,9 +169,12 @@
               </div>
             </div>
           </div>
+
+          <br>
+          <a *ngIf="processedHash" [routerLink]="'/account/' + signatureAccount" [queryParams]="{ sign: 1 }" class="uk-button uk-button-primary uk-width-auto" title="Account detail view" uk-tooltip>Account Detail View</a>
         </div>
 
-        <div *ngIf="!qrCodeImageBlock && !processedHash" uk-grid>
+        <div *ngIf="!processedHash" uk-grid>
           <div class="uk-width-1-2@s">
             <a class="uk-button uk-button-danger uk-width-1-1" routerLink="/qr-scan" routerLinkActive="active">Cancel</a>
           </div>
@@ -180,19 +183,6 @@
             <button *ngIf="confirmingTransaction && shouldSign" class="uk-button uk-button-primary uk-disabled uk-width-1-1"><span class="uk-margin-right" uk-spinner></span> Loading</button>
             <button *ngIf="!confirmingTransaction && !shouldSign" class="uk-button uk-button-primary uk-width-1-1" (click)="confirmBlock()">Confirm & Process</button>
             <button *ngIf="confirmingTransaction && !shouldSign" class="uk-button uk-button-primary uk-disabled uk-width-1-1"><span class="uk-margin-right" uk-spinner></span> Loading</button>
-          </div>
-        </div>
-
-        <div *ngIf="qrCodeImageBlock && shouldSign" class="uk-text-center">
-          <span><strong>Scan the QR in an online Nault (or compatible wallet) to process the block</strong></span><br><br>
-          <div class="uk-width-1-1@s uk-width-3-4@m uk-width-1-2@l uk-text-center block-qr">
-            <img *ngIf="qrCodeImageBlock" [src]="qrCodeImageBlock"><br />
-          </div>
-          <div *ngIf="currentBlock.signature" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
-            <span class="uk-text-small" uk-tooltip title="Signature" style="overflow-wrap: anywhere;">{{currentBlock.signature | squeeze}}</span>
-            <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
-              <li><a ngxClipboard [cbContent]="currentBlock.signature" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
-            </ul>
           </div>
         </div>
       </div>
@@ -207,6 +197,28 @@
       </div>
     </div>
 
+  </div>
+</div>
+
+<!-- Modal for result QR -->
+<div id="signed-modal" uk-modal>
+  <div class="uk-modal-dialog uk-modal-body modal-qr">
+    <button class="uk-modal-close-default" type="button" uk-close></button>
+    <div class="uk-modal-header">
+        <h2 class="uk-modal-title">Signed Block</h2>
+    </div>
+    <div class="uk-modal-body modal-qr-body">
+      <p>Scan the QR in an online Nault (or compatible wallet) to process the block</p>
+      <div class="uk-width-1-1 uk-text-center">
+        <img *ngIf="qrCodeImageBlock" [src]="qrCodeImageBlock"><br />
+      </div>
+      <div *ngIf="currentBlock.signature" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
+        <span class="uk-text-small" uk-tooltip title="Signature" style="overflow-wrap: anywhere;">{{currentBlock.signature | squeeze}}</span>
+        <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+          <li><a ngxClipboard [cbContent]="currentBlock.signature" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
+        </ul>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -208,15 +208,21 @@
         <h2 class="uk-modal-title">Signed Block</h2>
     </div>
     <div class="uk-modal-body modal-qr-body">
-      <p>Scan the QR in an online Nault (or compatible wallet) to process the block</p>
-      <div class="uk-width-1-1 uk-text-center">
-        <img *ngIf="qrCodeImageBlock" [src]="qrCodeImageBlock"><br />
-      </div>
+      <p><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the signed QR with an online Nault, or copy the "Signed Block" to <a routerLink="/remote-signing" routerLinkActive="active">Step 3</a>.</p>
+      
       <div *ngIf="currentBlock.signature" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
-        <span class="uk-text-small" uk-tooltip title="Signature" style="overflow-wrap: anywhere;">{{currentBlock.signature | squeeze}}</span>
+        <span class="uk-text-small" uk-tooltip title="Signed block string to be copied to remote device" style="overflow-wrap: anywhere;"><strong>Signed Block</strong></span>
+        <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+          <li><a ngxClipboard [cbContent]="qrString" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
+        </ul>
+        <span class="uk-text-small" uk-tooltip title="Signature to be embedded into the final block" style="overflow-wrap: anywhere; margin-left: 50px;"><strong>Signature</strong></span>
         <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
           <li><a ngxClipboard [cbContent]="currentBlock.signature" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
         </ul>
+      </div>
+
+      <div class="uk-width-1-1 uk-text-center">
+        <img *ngIf="qrCodeImageBlock" [src]="qrCodeImageBlock"><br />
       </div>
     </div>
   </div>

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -208,7 +208,7 @@
         <h2 class="uk-modal-title">Signed Block</h2>
     </div>
     <div class="uk-modal-body modal-qr-body">
-      <p><a routerLink="/qr-scan" routerLinkActive="active">Scan</a> the signed QR with an online Nault, or copy the "Signed Block" to <a routerLink="/remote-signing" routerLinkActive="active">Step 3</a>.</p>
+      <p><a routerLink="/qr-scan" routerLinkActive="active" class="uk-modal-close">Scan</a> the signed QR with an online Nault, or copy the "Signed Block" to <a routerLink="/remote-signing" routerLinkActive="active" class="uk-modal-close">Step 3</a>.</p>
       
       <div *ngIf="currentBlock.signature" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
         <span class="uk-text-small" uk-tooltip title="Signed block string to be copied to remote device" style="overflow-wrap: anywhere;"><strong>Signed Block</strong></span>

--- a/src/app/components/sign/sign.component.spec.ts
+++ b/src/app/components/sign/sign.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SignComponent } from './sign.component';
+
+describe('SignComponent', () => {
+  let component: SignComponent;
+  let fixture: ComponentFixture<SignComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SignComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SignComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/sign/sign.component.ts
+++ b/src/app/components/sign/sign.component.ts
@@ -52,6 +52,7 @@ export class SignComponent implements OnInit {
   signatureMessageSuccess: string = '';
   walletAccount = null;
   nullBlock = '0000000000000000000000000000000000000000000000000000000000000000';
+  qrString = null;
   qrCodeImage = null;
   qrCodeImageBlock = null;
   validSeed = false;
@@ -313,11 +314,10 @@ export class SignComponent implements OnInit {
     try {
       this.clean(block)
       if (this.previousBlock) this.clean(this.previousBlock)
-      var qrString = null;
-      if (this.previousBlock) qrString = 'nanoprocess:{"block":' + JSON.stringify(block) + ',"previous":' + JSON.stringify(this.previousBlock) + '}';
-      else qrString = 'nanoprocess:{"block":' + JSON.stringify(block) + '}';
+      if (this.previousBlock) this.qrString = 'nanoprocess:{"block":' + JSON.stringify(block) + ',"previous":' + JSON.stringify(this.previousBlock) + '}';
+      else this.qrString = 'nanoprocess:{"block":' + JSON.stringify(block) + '}';
 
-      const qrCode = await QRCode.toDataURL(qrString, { errorCorrectionLevel: 'L', scale: 16 });
+      const qrCode = await QRCode.toDataURL(this.qrString, { errorCorrectionLevel: 'L', scale: 16 });
       this.qrCodeImageBlock = qrCode;
 
       const UIkit = window['UIkit'];

--- a/src/app/components/sign/sign.component.ts
+++ b/src/app/components/sign/sign.component.ts
@@ -1,0 +1,183 @@
+import { Component, OnInit } from '@angular/core';
+import BigNumber from "bignumber.js";
+import {AddressBookService} from "../../services/address-book.service";
+import {BehaviorSubject} from "rxjs";
+import {WalletService} from "../../services/wallet.service";
+import {NotificationService} from "../../services/notification.service";
+import {UtilService} from "../../services/util.service";
+import {WorkPoolService} from "../../services/work-pool.service";
+import {AppSettingsService} from "../../services/app-settings.service";
+import {ActivatedRoute} from "@angular/router";
+import {NanoBlockService} from "../../services/nano-block.service";
+import * as nanocurrency from 'nanocurrency';
+
+export interface Block {
+  account: string;
+  previous: string;
+  representative: string;
+  balance: BigNumber;
+  link: string;
+}
+
+export enum TxType {"send", "receive"};
+
+@Component({
+  selector: 'app-sign',
+  templateUrl: './sign.component.html',
+  styleUrls: ['./sign.component.css']
+})
+
+export class SignComponent implements OnInit {
+  activePanel = 'error';
+
+  accounts = this.walletService.wallet.accounts;
+  addressBookResults$ = new BehaviorSubject([]);
+  showAddressBook = false;
+  addressBookMatch = '';
+
+  amount = null;
+  rawAmount: BigNumber = new BigNumber(0);
+  fromAccountID: any = '';
+  fromAccountBalance: BigNumber = null
+  fromAddressBook = '';
+  toAccountID: string = '';
+  toAccountBalance: BigNumber = null
+  toAddressBook = '';
+  toAccountStatus = null;
+  currentBlock: Block = null;
+  previousBlock: Block = null;
+  txType: TxType = null;
+  confirmingTransaction = false;
+  shouldGenWork = false;
+
+  constructor(
+    private router: ActivatedRoute,
+    private walletService: WalletService,
+    private addressBookService: AddressBookService,
+    private notificationService: NotificationService,
+    private nanoBlock: NanoBlockService,
+    private workPool: WorkPoolService,
+    public settings: AppSettingsService,
+    private util: UtilService) { }
+
+  async ngOnInit() {
+    const params = this.router.snapshot.queryParams;
+    console.log(params);
+    
+    if ('n_account' in params && 'n_previous' in params && 'n_representative' in params && 'n_balance' in params && 'n_link' in params &&
+    'p_account' in params && 'p_previous' in params && 'p_representative' in params && 'p_balance' in params && 'p_link' in params) {
+      this.currentBlock = {'account': params.n_account, 'previous': params.n_previous, 'representative': params.n_representative, 'balance': new BigNumber(params.n_balance), 'link': params.n_link};
+      this.previousBlock = {'account': params.p_account, 'previous': params.p_previous, 'representative': params.p_representative, 'balance': new BigNumber(params.p_balance), 'link': params.p_link};
+
+      // check if both new block and previous block hashes matches (balances has not been tampered with) and have valid parameters
+      if (this.verifyBlocks(this.currentBlock, this.previousBlock)) {
+        if (this.previousBlock.balance.gte(this.currentBlock.balance)) {
+          // it's a send block
+          if (this.previousBlock.balance.gt(this.currentBlock.balance)) {
+            this.txType = TxType.send;
+            this.rawAmount = (this.previousBlock.balance.minus(this.currentBlock.balance));
+            this.fromAccountID = this.currentBlock.account;
+            this.toAccountID = nanocurrency.deriveAddress(this.currentBlock.link,{useNanoPrefix: true});
+            this.fromAccountBalance = this.previousBlock.balance;
+            // sending to itself
+            if (this.fromAccountID === this.toAccountID) {
+              this.toAccountBalance = this.fromAccountBalance;
+            }
+            console.log(this.fromAccountID)
+            console.log(this.toAccountID)
+          }
+          else  {
+            this.notificationService.sendError(`From account does not have enough NANO`, {length: 0})
+            return
+          }
+        }
+        // it's a receive block
+        else {
+          this.txType = TxType.receive;
+          this.rawAmount = (this.currentBlock.balance.minus(this.previousBlock.balance));
+          this.fromAccountID = nanocurrency.deriveAddress(this.currentBlock.link,{useNanoPrefix: true});
+          this.toAccountID = this.currentBlock.account;
+          this.toAccountBalance = this.previousBlock.balance;
+            // sending to itself
+          if (this.fromAccountID === this.toAccountID) {
+            this.fromAccountBalance = this.toAccountBalance;
+          }
+        }
+        this.amount = this.util.nano.rawToMnano(this.rawAmount).toString(10);
+        this.prepareTransaction()
+      }
+      else {
+        return
+      }
+    }
+    else {
+      this.notificationService.sendError(`Incorrect parameters provided for signing!`, {length: 0})
+      return
+    }
+
+    this.addressBookService.loadAddressBook();
+  }
+
+  verifyBlocks(currentBlock:Block, previousBlock:Block) {
+    var previousHash = null;
+    if (nanocurrency.checkAddress(currentBlock.account) &&
+      nanocurrency.checkAddress(previousBlock.account) &&
+      nanocurrency.checkAddress(currentBlock.representative) &&
+      nanocurrency.checkAddress(previousBlock.representative) &&
+      nanocurrency.checkAmount(currentBlock.balance.toString(10)) &&
+      nanocurrency.checkAmount(previousBlock.balance.toString(10)) &&
+      nanocurrency.checkHash(currentBlock.previous) &&
+      nanocurrency.checkHash(previousBlock.previous) &&
+      nanocurrency.checkHash(currentBlock.link) &&
+      nanocurrency.checkHash(previousBlock.link))
+    {
+      previousHash = nanocurrency.hashBlock({account:previousBlock.account, link:previousBlock.link, previous:previousBlock.previous, representative: previousBlock.representative, balance: previousBlock.balance.toString(10)});
+      if (!currentBlock.previous || previousHash !== currentBlock.previous) {
+        this.notificationService.sendError(`The hash of the previous block does not match the frontier in the new block!`, {length: 0})
+      }
+    }
+    else {
+      this.notificationService.sendError(`The provided blocks contain invalid values!`, {length: 0})
+    }
+    return currentBlock.previous && previousHash === currentBlock.previous 
+  }
+
+  searchAddressBook() {
+    this.showAddressBook = true;
+    const search = this.toAccountID || '';
+    const addressBook = this.addressBookService.addressBook;
+
+    const matches = addressBook
+      .filter(a => a.name.toLowerCase().indexOf(search.toLowerCase()) !== -1)
+      .slice(0, 5);
+
+    this.addressBookResults$.next(matches);
+  }
+
+  async prepareTransaction() {
+    this.fromAddressBook = this.addressBookService.getAccountName(this.fromAccountID);
+    this.toAddressBook = this.addressBookService.getAccountName(this.toAccountID);
+
+    this.activePanel = 'confirm';
+    // Start precopmuting the work...
+    if (this.shouldGenWork) {
+      this.workPool.addWorkToCache(this.previousBlock.previous);
+    }
+  }
+
+  async confirmTransaction() {
+    var work = null;
+    //const walletAccount = this.walletService.wallet.accounts.find(a => a.id == this.fromAccountID);
+    //if (!walletAccount) throw new Error(`Unable to find sending account in wallet`);
+    //if (this.walletService.walletIsLocked()) return this.notificationService.sendWarning(`Wallet must be unlocked`);
+
+    this.confirmingTransaction = true;
+    if (this.shouldGenWork) {
+      if (!this.workPool.workExists(this.previousBlock.previous)) {
+        this.notificationService.sendInfo(`Generating Proof of Work...`);
+      }
+      work = await this.workPool.getWork(this.previousBlock.previous);
+    }
+    this.confirmingTransaction = false;
+  }
+}

--- a/src/app/components/sign/sign.component.ts
+++ b/src/app/components/sign/sign.component.ts
@@ -319,6 +319,10 @@ export class SignComponent implements OnInit {
 
       const qrCode = await QRCode.toDataURL(qrString, { errorCorrectionLevel: 'L', scale: 16 });
       this.qrCodeImageBlock = qrCode;
+
+      const UIkit = window['UIkit'];
+      var modal = UIkit.modal("#signed-modal");
+      modal.show();
     }
     catch (error) {
       this.confirmingTransaction = false;

--- a/src/app/components/sign/sign.component.ts
+++ b/src/app/components/sign/sign.component.ts
@@ -8,18 +8,12 @@ import {UtilService} from "../../services/util.service";
 import {WorkPoolService} from "../../services/work-pool.service";
 import {AppSettingsService} from "../../services/app-settings.service";
 import {ActivatedRoute} from "@angular/router";
-import {NanoBlockService} from "../../services/nano-block.service";
-import * as nanocurrency from 'nanocurrency';
+import {NanoBlockService, StateBlock, TxType} from "../../services/nano-block.service";
+import * as QRCode from 'qrcode';
+import * as bip39 from 'bip39'
+import * as bip39Wallet from 'nanocurrency-web'
 
-export interface Block {
-  account: string;
-  previous: string;
-  representative: string;
-  balance: BigNumber;
-  link: string;
-}
-
-export enum TxType {"send", "receive"};
+const INDEX_MAX = 4294967295;
 
 @Component({
   selector: 'app-sign',
@@ -34,7 +28,6 @@ export class SignComponent implements OnInit {
   addressBookResults$ = new BehaviorSubject([]);
   showAddressBook = false;
   addressBookMatch = '';
-
   amount = null;
   rawAmount: BigNumber = new BigNumber(0);
   fromAccountID: any = '';
@@ -44,11 +37,30 @@ export class SignComponent implements OnInit {
   toAccountBalance: BigNumber = null
   toAddressBook = '';
   toAccountStatus = null;
-  currentBlock: Block = null;
-  previousBlock: Block = null;
+  currentBlock: StateBlock = null;
+  previousBlock: StateBlock = null;
   txType: TxType = null;
+  txTypes = TxType; //to access enum in html
+  txTypeMessage:string = '';
   confirmingTransaction = false;
   shouldGenWork = false;
+  signTypes: string[] = ['Internal Wallet or Ledger', 'Seed or Mnemonic+Index', 'Private Key'];
+  signTypeSelected: string = this.signTypes[0];
+  signatureAccount: string = '';
+  signatureMessage: string = '';
+  signatureMessageSuccess: string = '';
+  walletAccount = null;
+  nullBlock = '0000000000000000000000000000000000000000000000000000000000000000';
+  qrCodeImage = null;
+  qrCodeImageBlock = null;
+  validSeed = false;
+  validIndex = true;
+  validPrivkey = false;
+  sourceSecret = '';
+  sourcePriv = '';
+  index = '0';
+  privateKey = null; // the final private key to sign with if using manual entry
+  privateKeyExpanded = false; // if a private key is provided manually and it's expanded 128 char
 
   constructor(
     private router: ActivatedRoute,
@@ -66,42 +78,62 @@ export class SignComponent implements OnInit {
     
     if ('n_account' in params && 'n_previous' in params && 'n_representative' in params && 'n_balance' in params && 'n_link' in params &&
     'p_account' in params && 'p_previous' in params && 'p_representative' in params && 'p_balance' in params && 'p_link' in params) {
-      this.currentBlock = {'account': params.n_account, 'previous': params.n_previous, 'representative': params.n_representative, 'balance': new BigNumber(params.n_balance), 'link': params.n_link};
-      this.previousBlock = {'account': params.p_account, 'previous': params.p_previous, 'representative': params.p_representative, 'balance': new BigNumber(params.p_balance), 'link': params.p_link};
+      this.currentBlock = {'account': params.n_account, 'previous': params.n_previous, 'representative': params.n_representative, 'balance': params.n_balance, 'link': params.n_link, signature: null, work: null};
+      this.previousBlock = {'account': params.p_account, 'previous': params.p_previous, 'representative': params.p_representative, 'balance': params.p_balance, 'link': params.p_link, signature: null, work: null};
 
       // check if both new block and previous block hashes matches (balances has not been tampered with) and have valid parameters
       if (this.verifyBlocks(this.currentBlock, this.previousBlock)) {
-        if (this.previousBlock.balance.gte(this.currentBlock.balance)) {
-          // it's a send block
-          if (this.previousBlock.balance.gt(this.currentBlock.balance)) {
-            this.txType = TxType.send;
-            this.rawAmount = (this.previousBlock.balance.minus(this.currentBlock.balance));
-            this.fromAccountID = this.currentBlock.account;
-            this.toAccountID = nanocurrency.deriveAddress(this.currentBlock.link,{useNanoPrefix: true});
-            this.fromAccountBalance = this.previousBlock.balance;
-            // sending to itself
-            if (this.fromAccountID === this.toAccountID) {
-              this.toAccountBalance = this.fromAccountBalance;
-            }
-            console.log(this.fromAccountID)
-            console.log(this.toAccountID)
-          }
-          else  {
-            this.notificationService.sendError(`From account does not have enough NANO`, {length: 0})
-            return
+        // it's a send block
+        if (new BigNumber(this.previousBlock.balance).gt(new BigNumber(this.currentBlock.balance))) {
+          this.txType = TxType.send;
+          this.txTypeMessage = 'send';
+          this.rawAmount = new BigNumber(this.previousBlock.balance).minus(new BigNumber(this.currentBlock.balance));
+          this.fromAccountID = this.currentBlock.account;
+          this.toAccountID = this.util.account.getPublicAccountID(this.util.hex.toUint8(this.currentBlock.link));
+          this.fromAccountBalance = new BigNumber(this.previousBlock.balance);
+          // sending to itself
+          if (this.fromAccountID === this.toAccountID) {
+            this.toAccountBalance = this.fromAccountBalance;
           }
         }
-        // it's a receive block
-        else {
-          this.txType = TxType.receive;
-          this.rawAmount = (this.currentBlock.balance.minus(this.previousBlock.balance));
-          this.fromAccountID = nanocurrency.deriveAddress(this.currentBlock.link,{useNanoPrefix: true});
+        // it's a change block
+        else if (new BigNumber(this.previousBlock.balance).eq(new BigNumber(this.currentBlock.balance)) && this.previousBlock.representative != this.currentBlock.representative && this.currentBlock.link === this.nullBlock) {
+          this.txType = TxType.change;
+          this.txTypeMessage = 'change representative to';
+          this.rawAmount = new BigNumber(0);
+          this.fromAccountID = this.currentBlock.account;
           this.toAccountID = this.currentBlock.account;
-          this.toAccountBalance = this.previousBlock.balance;
+          this.fromAccountBalance = new BigNumber(this.currentBlock.balance);
+          this.toAccountBalance = new BigNumber(this.currentBlock.balance);
+        }
+        // it's an open block
+        else if (new BigNumber(this.previousBlock.balance).lt(new BigNumber(this.currentBlock.balance)) && this.currentBlock.previous === this.nullBlock) {
+          this.txType = TxType.open;
+          this.txTypeMessage = 'receive';
+          this.rawAmount = new BigNumber(this.currentBlock.balance).minus(new BigNumber(this.previousBlock.balance));
+          this.fromAccountID = this.util.account.getPublicAccountID(this.util.hex.toUint8(this.currentBlock.link));
+          this.toAccountID = this.currentBlock.account;
+          this.toAccountBalance = new BigNumber(this.previousBlock.balance);
             // sending to itself
           if (this.fromAccountID === this.toAccountID) {
             this.fromAccountBalance = this.toAccountBalance;
           }
+        }
+        // it's a receive block
+        else if (new BigNumber(this.previousBlock.balance).lt(new BigNumber(this.currentBlock.balance)) && this.currentBlock.previous !== this.nullBlock) {
+          this.txType = TxType.receive;
+          this.txTypeMessage = 'receive';
+          this.rawAmount = new BigNumber(this.currentBlock.balance).minus(new BigNumber(this.previousBlock.balance));
+          this.fromAccountID = this.util.account.getPublicAccountID(this.util.hex.toUint8(this.currentBlock.link));
+          this.toAccountID = this.currentBlock.account;
+          this.toAccountBalance = new BigNumber(this.previousBlock.balance);
+            // sending to itself
+          if (this.fromAccountID === this.toAccountID) {
+            this.fromAccountBalance = this.toAccountBalance;
+          }
+        }
+        else {
+          return this.notificationService.sendError(`Meaningless block. The balance and representative are unchanged!`, {length: 0})
         }
         this.amount = this.util.nano.rawToMnano(this.rawAmount).toString(10);
         this.prepareTransaction()
@@ -116,22 +148,24 @@ export class SignComponent implements OnInit {
     }
 
     this.addressBookService.loadAddressBook();
+    this.signTypeSelected = this.signTypes[0];
   }
 
-  verifyBlocks(currentBlock:Block, previousBlock:Block) {
+  verifyBlocks(currentBlock:StateBlock, previousBlock:StateBlock) {
     var previousHash = null;
-    if (nanocurrency.checkAddress(currentBlock.account) &&
-      nanocurrency.checkAddress(previousBlock.account) &&
-      nanocurrency.checkAddress(currentBlock.representative) &&
-      nanocurrency.checkAddress(previousBlock.representative) &&
-      nanocurrency.checkAmount(currentBlock.balance.toString(10)) &&
-      nanocurrency.checkAmount(previousBlock.balance.toString(10)) &&
-      nanocurrency.checkHash(currentBlock.previous) &&
-      nanocurrency.checkHash(previousBlock.previous) &&
-      nanocurrency.checkHash(currentBlock.link) &&
-      nanocurrency.checkHash(previousBlock.link))
+    if (this.util.account.isValidAccount(currentBlock.account) &&
+      this.util.account.isValidAccount(previousBlock.account) &&
+      this.util.account.isValidAccount(currentBlock.representative) &&
+      this.util.account.isValidAccount(previousBlock.representative) &&
+      this.util.account.isValidAmount(currentBlock.balance) &&
+      this.util.account.isValidAmount(previousBlock.balance) &&
+      this.util.nano.isValidHash(currentBlock.previous) &&
+      this.util.nano.isValidHash(previousBlock.previous) &&
+      this.util.nano.isValidHash(currentBlock.link) &&
+      this.util.nano.isValidHash(previousBlock.link))
     {
-      previousHash = nanocurrency.hashBlock({account:previousBlock.account, link:previousBlock.link, previous:previousBlock.previous, representative: previousBlock.representative, balance: previousBlock.balance.toString(10)});
+      let block:StateBlock = {account:previousBlock.account, link:previousBlock.link, previous:previousBlock.previous, representative: previousBlock.representative, balance: previousBlock.balance, signature: null, work: null};
+      previousHash = this.util.hex.fromUint8(this.util.nano.hashStateBlock(block));
       if (!currentBlock.previous || previousHash !== currentBlock.previous) {
         this.notificationService.sendError(`The hash of the previous block does not match the frontier in the new block!`, {length: 0})
       }
@@ -154,6 +188,41 @@ export class SignComponent implements OnInit {
     this.addressBookResults$.next(matches);
   }
 
+  signTypeChange() {
+    this.signatureMessage = '';
+    this.signatureMessageSuccess = '';
+
+    switch (this.signTypeSelected) {
+      // wallet
+      case this.signTypes[0]:
+        this.walletAccount = this.accounts.find(a => a.id == this.signatureAccount);
+        if (!this.walletAccount) return this.signatureMessage = 'Could not find a matching wallet account to sign with. Make sure it\'s added under your accounts';
+        else this.signatureMessageSuccess = 'A matching account found!';
+        break;
+
+      case this.signTypes[1]:
+        this.seedChange(this.sourceSecret);
+        break;
+
+      case this.signTypes[2]:
+        this.privkeyChange(this.sourcePriv);
+        break;
+    }
+  }
+
+  powChange() {
+    if (this.shouldGenWork) this.prepareWork();
+  }
+
+  prepareWork() {
+    // The block has been verified
+    if (this.toAccountID) {
+      console.log('Precomputing work...')
+      let workBlock = this.txType === TxType.open ? this.util.account.getAccountPublicKey(this.toAccountID) : this.currentBlock.previous;
+      this.workPool.addWorkToCache(workBlock);
+    }
+  }
+
   async prepareTransaction() {
     this.fromAddressBook = this.addressBookService.getAccountName(this.fromAccountID);
     this.toAddressBook = this.addressBookService.getAccountName(this.toAccountID);
@@ -161,23 +230,205 @@ export class SignComponent implements OnInit {
     this.activePanel = 'confirm';
     // Start precopmuting the work...
     if (this.shouldGenWork) {
-      this.workPool.addWorkToCache(this.previousBlock.previous);
+      this.prepareWork()
     }
+
+    if (this.txType === TxType.send) {
+      this.signatureAccount = this.fromAccountID;
+    }
+    else if (this.txType === TxType.receive) {
+      this.signatureAccount = this.toAccountID;
+    }
+
+    this.signTypeChange();
   }
 
   async confirmTransaction() {
-    var work = null;
-    //const walletAccount = this.walletService.wallet.accounts.find(a => a.id == this.fromAccountID);
-    //if (!walletAccount) throw new Error(`Unable to find sending account in wallet`);
-    //if (this.walletService.walletIsLocked()) return this.notificationService.sendWarning(`Wallet must be unlocked`);
+    var walletAccount = this.walletAccount;
+    var isLedger = this.walletService.isLedgerWallet();
+
+    // using internal wallet
+    if (this.signTypeSelected === this.signTypes[0] && walletAccount) {
+      if (this.walletService.walletIsLocked()) return this.notificationService.sendWarning('Wallet must be unlocked for signing with it');
+    }
+    else if (this.signTypeSelected === this.signTypes[0]) {
+      return this.notificationService.sendWarning('Could not find a matching wallet account to sign with. Make sure it\'s added under your accounts');
+    }
+
+    // using seed or private key
+    if (((this.signTypeSelected === this.signTypes[1] && !this.validSeed) || (this.signTypeSelected === this.signTypes[2]) && !this.validPrivkey)) return this.notificationService.sendWarning('Could not find a matching private key to sign with.');
+    if (this.signTypeSelected === this.signTypes[1] || this.signTypeSelected === this.signTypes[2]) {
+      isLedger = false;
+      // create dummy wallet that only contains needed elements for signature
+      walletAccount = {keyPair:{secretKey:this.util.hex.toUint8(this.privateKey), expanded:this.privateKeyExpanded}}
+    }
 
     this.confirmingTransaction = true;
-    if (this.shouldGenWork) {
-      if (!this.workPool.workExists(this.previousBlock.previous)) {
-        this.notificationService.sendInfo(`Generating Proof of Work...`);
-      }
-      work = await this.workPool.getWork(this.previousBlock.previous);
-    }
+
+    // sign the block
+    const block = await this.nanoBlock.signOfflineBlock(walletAccount, this.currentBlock, this.txType, this.shouldGenWork, isLedger);
+    console.log('Signature: ' + block.signature || 'Error')
+    console.log('Work: ' + block.work || 'Not applied')
+
+    if (!block.signature) return this.notificationService.sendError('The block could not be signed!',{lenth: 0});
+    let qrString = 'nanoblock:{"block":' + JSON.stringify(block) + '}'
+    const qrCode = await QRCode.toDataURL(qrString, { errorCorrectionLevel: 'M', scale: 8 });
+    this.qrCodeImageBlock = qrCode;
     this.confirmingTransaction = false;
+    this.notificationService.sendSuccess('The block has been signed and can be sent to the network!');
+  }
+
+  copied() {
+    this.notificationService.sendSuccess(`Successfully copied to clipboard!`);
+  }
+
+  seedChange(input) {
+    let keyType = this.checkMasterKey(input);
+    this.validSeed = keyType !== null;
+    if (this.validSeed && this.validIndex) {
+      this.verifyKey(keyType, input, Number(this.index));
+    }
+    else {
+      this.signatureMessage = ''
+      this.signatureMessageSuccess = ''
+    }
+  }
+
+  privkeyChange(input) {
+    let privKey = this.convertPrivateKey(input);
+    if (privKey !== null) {
+      // Match given block account with with private key
+      const pubKey = this.util.account.generateAccountKeyPair(this.util.hex.toUint8(privKey), this.privateKeyExpanded).publicKey;
+      const address = this.util.account.getPublicAccountID(pubKey);
+      if (address === this.signatureAccount ) {
+        this.validPrivkey = true;
+        this.privateKey = privKey;
+        this.signatureMessage = ''
+        this.signatureMessageSuccess = 'The private key match the account!'
+        return
+      }
+      else {
+        this.signatureMessage = 'The account for this private key does not match!'
+      }
+    }
+    else {
+      this.signatureMessage = ''
+    }
+    this.signatureMessageSuccess = ''
+    this.validPrivkey = false;
+    this.privateKey = '';
+  }
+
+  indexChange(index) {
+    this.validIndex = true
+    if (this.util.string.isNumeric(index) && index % 1 === 0) {
+      index = parseInt(index)
+      if (!this.util.nano.isValidIndex(index)) {
+        this.validIndex = false
+      }
+      if (index > INDEX_MAX) {
+        this.validIndex = false
+      }
+    }
+    else {
+      this.validIndex = false
+    }
+
+    if (this.validSeed && this.validIndex) {
+      let keyType = this.checkMasterKey(this.sourceSecret);
+      this.verifyKey(keyType, this.sourceSecret, Number(this.index));
+    }
+    else {
+      this.signatureMessage = ''
+      this.signatureMessageSuccess = ''
+    }
+  }
+
+  verifyKey(keyType:string, input:string, index: number) {
+    var seed = ''
+    var privKey1 = ''
+    var privKey2 = ''
+
+    // input is mnemonic
+    if (keyType === 'mnemonic') {
+      seed = bip39.mnemonicToEntropy(input).toUpperCase()
+      // seed must be 64 or the nano wallet can't be created. This is the reason 12-words can't be used because the seed would be 32 in length
+      if (seed.length !== 64) {
+        this.notificationService.sendError(`Mnemonic not 24 words`);
+        return
+      }
+    }
+
+    // nano seed
+    if (keyType === 'nano_seed' || seed !== '' || keyType === 'bip39_seed') {
+      if (seed === '') { // seed from input, no mnemonic
+        seed = input
+      }
+      // start with blake2b derivation
+      if (keyType !== 'bip39_seed') {
+          privKey1 = this.util.hex.fromUint8(this.util.account.generateAccountSecretKeyBytes(this.util.hex.toUint8(seed),index))
+      }
+      // also check using bip39/44 derivation
+      var bip39Seed
+      // take 128 char bip39 seed directly from input or convert it from a 64 char nano seed (entropy)
+      if (keyType === 'bip39_seed') {
+        bip39Seed = input
+      }
+      else {
+        bip39Seed = bip39Wallet.wallet.generate(seed).seed
+      }
+      privKey2 = bip39Wallet.wallet.accounts(bip39Seed, index, index)[0].privateKey
+    }
+
+    // Match given block account with any of the private keys extracted
+    const pubKey1 = this.util.account.generateAccountKeyPair(this.util.hex.toUint8(privKey1), this.privateKeyExpanded).publicKey;
+    const pubKey2 = this.util.account.generateAccountKeyPair(this.util.hex.toUint8(privKey2), this.privateKeyExpanded).publicKey;
+    const address1 = this.util.account.getPublicAccountID(pubKey1);
+    const address2 = this.util.account.getPublicAccountID(pubKey2);
+
+    if (address1 === this.signatureAccount || address2 === this.signatureAccount ) {
+      if (address1 === this.signatureAccount) this.privateKey = privKey1
+      else this.privateKey = privKey2
+      this.signatureMessage = ''
+      this.signatureMessageSuccess = 'A matching private key found!'
+    }
+    else {
+      this.signatureMessage = 'Could not find a matching private key!'
+      this.signatureMessageSuccess = ''
+    }
+  }
+
+  // Validate type of master key
+  checkMasterKey(key) {
+    // validate nano seed
+    if (key.length === 64) {
+      if (this.util.nano.isValidSeed(key)) {
+        return 'nano_seed';
+      }
+    }
+    // validate bip39 seed
+    if (key.length === 128) {
+      if (this.util.hex.isHex(key)) {
+        return 'bip39_seed';
+      }
+    }
+    // validate mnemonic
+    if (bip39.validateMnemonic(key)) {
+      return 'mnemonic';
+    }
+    return null
+  }
+
+  convertPrivateKey(key) {
+    if (key.length === 128) {
+      this.privateKeyExpanded = true;
+      // expanded key includes deterministic R value material which we ignore
+      return key.substring(0, 64);
+    } else if (key.length === 64) {
+      return key;
+    }
+    else {
+      return null;
+    }
   }
 }

--- a/src/app/components/sign/sign.component.ts
+++ b/src/app/components/sign/sign.component.ts
@@ -4,11 +4,11 @@ import {AddressBookService} from "../../services/address-book.service";
 import {BehaviorSubject} from "rxjs";
 import {WalletService} from "../../services/wallet.service";
 import {NotificationService} from "../../services/notification.service";
-import {UtilService} from "../../services/util.service";
+import {UtilService, StateBlock, TxType} from "../../services/util.service";
 import {WorkPoolService} from "../../services/work-pool.service";
 import {AppSettingsService} from "../../services/app-settings.service";
 import {ActivatedRoute} from "@angular/router";
-import {NanoBlockService, StateBlock, TxType} from "../../services/nano-block.service";
+import {NanoBlockService} from "../../services/nano-block.service";
 import * as QRCode from 'qrcode';
 import * as bip39 from 'bip39'
 import * as bip39Wallet from 'nanocurrency-web'

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -96,9 +96,6 @@ export class ApiService {
   async accountInfo(account): Promise<any> {
     return await this.request('account_info', { account, pending: true, representative: true, weight: true });
   }
-  async validateAccountNumber(account): Promise<{ valid: '1'|'0' }> {
-    return await this.request('validate_account_number', { account });
-  }
   async pending(account, count): Promise<any> {
     return await this.request('pending', { account, count, source: true, include_only_confirmed: true });
   }

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -11,6 +11,10 @@ export class ApiService {
   private async request(action, data, skipError=false): Promise<any> {
     data.action = action;
     const apiUrl = this.appSettings.settings.serverAPI;
+    if (!apiUrl) {
+      this.node.setOffline(null); // offline mode
+      return;
+    }
     if (this.node.node.status === false) {
       this.node.setLoading();
     }

--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -92,6 +92,14 @@ export class AppSettingsService {
       ws: null,
       auth: null,
       shouldRandom: false,
+    },
+    {
+      name: 'Offline Mode',
+      value: 'offline',
+      api: null,
+      ws: null,
+      auth: null,
+      shouldRandom: false,
     }
   ];
 
@@ -122,6 +130,11 @@ export class AppSettingsService {
       this.settings.serverWS = randomServerOption.ws;
     } else if (this.settings.serverName === 'custom') {
       console.log('SETTINGS: Custom');
+    } else if (this.settings.serverName === 'offline') {
+      console.log('SETTINGS: Offline Mode');
+      this.settings.serverName = matchingServerOption.value;
+      this.settings.serverAPI = matchingServerOption.api;
+      this.settings.serverWS = matchingServerOption.ws;
     } else {
       console.log('SETTINGS: Found', matchingServerOption);
       this.settings.serverName = matchingServerOption.value;

--- a/src/app/services/ledger.service.ts
+++ b/src/app/services/ledger.service.ts
@@ -367,6 +367,25 @@ export class LedgerService {
     }
   }
 
+  async updateCacheOffline(accountIndex, blockData) {
+    if (this.ledger.status !== LedgerStatus.READY) {
+      await this.loadLedger(); // Make sure ledger is ready
+    }
+
+    const cacheData = {
+      representative: blockData.representative,
+      balance: blockData.balance,
+      previousBlock: blockData.previous === '0000000000000000000000000000000000000000000000000000000000000000' ? null : blockData.previous,
+      sourceBlock: blockData.link,
+    };
+
+    if (this.isDesktop) {
+      return await this.updateCacheDesktop(accountIndex, cacheData, blockData.signature);
+    } else {
+      return await this.ledger.nano.cacheBlock(this.ledgerPath(accountIndex), cacheData, blockData.signature);
+    }
+  }
+
   async signBlock(accountIndex: number, blockData: any) {
     if (this.ledger.status !== LedgerStatus.READY) {
       await this.loadLedger(); // Make sure ledger is ready

--- a/src/app/services/nano-block.service.ts
+++ b/src/app/services/nano-block.service.ts
@@ -7,9 +7,20 @@ import BigNumber from "bignumber.js";
 import {NotificationService} from "./notification.service";
 import {AppSettingsService} from "./app-settings.service";
 import {LedgerService} from "./ledger.service";
+import { WalletAccount, Block } from './wallet.service';
 const nacl = window['nacl'];
 
-const STATE_BLOCK_PREAMBLE = '0000000000000000000000000000000000000000000000000000000000000006';
+export interface StateBlock {
+  account: string;
+  previous: string;
+  representative: string;
+  balance: string;
+  link: string;
+  signature: string;
+  work: string;
+}
+
+export enum TxType {"send", "receive", "open", "change"};
 
 @Injectable()
 export class NanoBlockService {
@@ -308,6 +319,71 @@ export class NanoBlockService {
     }
   }
 
+  // for signing block when offline
+  async signOfflineBlock(walletAccount:WalletAccount, block:StateBlock, type:TxType, genWork:boolean, ledger = false) {
+    // special treatment if open block
+    const openEquiv = type === TxType.open;
+    console.log("Signing block of subtype: " + TxType[type]);
+
+    if (ledger) {
+      var ledgerBlock = null;
+      if (type === TxType.send) {
+        ledgerBlock = {
+          previousBlock: block.previous,
+          representative: block.representative,
+          balance: block.balance,
+          recipient: this.util.account.getPublicAccountID(this.util.hex.toUint8(block.link)),
+        };
+      }
+      else if (type === TxType.receive) {
+        ledgerBlock = {
+          representative: block.representative,
+          balance: block.balance,
+          sourceBlock: block.link,
+        };
+        if (!openEquiv) {
+          ledgerBlock.previousBlock = block.previous;
+        }
+      }
+
+      else if (type === TxType.change) {
+        ledgerBlock = {
+          previousBlock: block.previous,
+          representative: block.representative,
+          balance: block.balance,
+        };
+      }
+      try {
+        this.sendLedgerNotification();
+        // On new accounts, we do not need to cache anything
+        if (!openEquiv) {
+          await this.ledgerService.updateCache(walletAccount.index, block.previous);
+        }
+        const sig = await this.ledgerService.signBlock(walletAccount.index, ledgerBlock);
+        this.clearLedgerNotification();
+        block.signature = sig.signature;
+      } catch (err) {
+        this.clearLedgerNotification();
+        this.sendLedgerDeniedNotification(err);
+        return null;
+      }
+    } else {
+      this.signStateBlock(walletAccount, block);
+    }
+
+    if (genWork) {
+      // For open blocks which don't have a frontier, use the public key of the account
+      let workBlock = openEquiv ? this.util.account.getAccountPublicKey(walletAccount.id) : block.previous;
+      if (!this.workPool.workExists(workBlock)) {
+        this.notifications.sendInfo(`Generating Proof of Work...`);
+      }
+  
+      block.work = await this.workPool.getWork(workBlock);
+      this.workPool.removeFromCache(workBlock);
+    }
+    return block; //return signed block (with or without work)
+  }
+
   async validateAccount(accountInfo) {
     if (!accountInfo) return;
     if (!accountInfo.frontier || accountInfo.frontier === this.zeroHash) {
@@ -329,31 +405,14 @@ export class NanoBlockService {
     if (blockData.contents.type !== 'state') {
       throw new Error(`Frontier block wasn't a state block, which shouldn't be possible`);
     }
-    if (this.util.hex.fromUint8(this.hashStateBlock(blockData.contents)) !== accountInfo.frontier) {
+    if (this.util.hex.fromUint8(this.util.nano.hashStateBlock(blockData.contents)) !== accountInfo.frontier) {
       throw new Error(`Frontier hash didn't match block data`);
     }
   }
 
-  hashStateBlock(block) {
-    const balance = new BigNumber(block.balance);
-    if (balance.isNegative() || balance.isNaN()) {
-      throw new Error(`Negative or NaN balance`);
-    }
-    let balancePadded = balance.toString(16);
-    while (balancePadded.length < 32) balancePadded = '0' + balancePadded; // Left pad with 0's
-    const context = blake.blake2bInit(32, null);
-    blake.blake2bUpdate(context, this.util.hex.toUint8(STATE_BLOCK_PREAMBLE));
-    blake.blake2bUpdate(context, this.util.hex.toUint8(this.util.account.getAccountPublicKey(block.account)));
-    blake.blake2bUpdate(context, this.util.hex.toUint8(block.previous));
-    blake.blake2bUpdate(context, this.util.hex.toUint8(this.util.account.getAccountPublicKey(block.representative)));
-    blake.blake2bUpdate(context, this.util.hex.toUint8(balancePadded));
-    blake.blake2bUpdate(context, this.util.hex.toUint8(block.link));
-    return blake.blake2bFinal(context);
-  }
-
   // Sign a state block, and insert the signature into the block.
   signStateBlock(walletAccount, blockData) {
-    const hashBytes = this.hashStateBlock(blockData);
+    const hashBytes = this.util.nano.hashStateBlock(blockData);
     const privKey = walletAccount.keyPair.secretKey;
     const signed = nacl.sign.detached(hashBytes, privKey, walletAccount.keyPair.expanded);
     blockData.signature = this.util.hex.fromUint8(signed);

--- a/src/app/services/nano-block.service.ts
+++ b/src/app/services/nano-block.service.ts
@@ -1,26 +1,13 @@
 import { Injectable } from '@angular/core';
 import {ApiService} from "./api.service";
-import {UtilService} from "./util.service";
-import * as blake from 'blakejs';
+import {UtilService, StateBlock, TxType} from "./util.service";
 import {WorkPoolService} from "./work-pool.service";
 import BigNumber from "bignumber.js";
 import {NotificationService} from "./notification.service";
 import {AppSettingsService} from "./app-settings.service";
 import {LedgerService} from "./ledger.service";
-import { WalletAccount, Block } from './wallet.service';
+import { WalletAccount } from './wallet.service';
 const nacl = window['nacl'];
-
-export interface StateBlock {
-  account: string;
-  previous: string;
-  representative: string;
-  balance: string;
-  link: string;
-  signature: string;
-  work: string;
-}
-
-export enum TxType {"send", "receive", "open", "change"};
 
 @Injectable()
 export class NanoBlockService {

--- a/src/app/services/node.service.ts
+++ b/src/app/services/node.service.ts
@@ -14,7 +14,7 @@ export class NodeService {
     if (this.node.status === false) return; // Already offline
     this.node.status = false;
 
-    this.notifications.sendError(msg, { identifier: 'node-offline', length: 0 });
+    if (msg) this.notifications.sendError(msg, { identifier: 'node-offline', length: 0 });
   }
 
   setOnline() {

--- a/src/app/services/remote-sign.service.spec.ts
+++ b/src/app/services/remote-sign.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { RemoteSignService } from './remote-sign.service';
+
+describe('RemoteSignService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [RemoteSignService]
+    });
+  });
+
+  it('should be created', inject([RemoteSignService], (service: RemoteSignService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/services/remote-sign.service.ts
+++ b/src/app/services/remote-sign.service.ts
@@ -1,0 +1,111 @@
+import { Injectable } from '@angular/core';
+import { NotificationService } from "./notification.service";
+import { Router } from "@angular/router";
+import { UtilService } from './util.service';
+
+@Injectable()
+export class RemoteSignService {
+  
+
+  constructor(
+    private router: Router,
+    private notifcationService: NotificationService,
+    private util: UtilService,
+  ) { }
+
+  navigateSignBlock(url) {
+    if (!this.checkSignBlock(url.pathname)) return this.notifcationService.sendWarning('Not a recognized format of an unsigned block.', { length: 5000 })
+    try {
+      let data = JSON.parse(url.pathname);
+      // Block to sign
+      var paramsSign = {
+        sign: 1,
+        n_account: data.block.account,
+        n_previous: data.block.previous,
+        n_representative: data.block.representative,
+        n_balance: data.block.balance,
+        n_link: data.block.link,
+      }
+      // only include if it exist
+      if (data.previous) {
+        paramsSign = {...paramsSign,...{
+          p_account: data.previous.account,
+          p_previous: data.previous.previous,
+          p_representative: data.previous.representative,
+          p_balance: data.previous.balance,
+          p_link: data.previous.link,
+          p_signature: data.previous.signature,
+        }}
+      }
+      this.router.navigate(['sign'], { queryParams: paramsSign});
+    }
+    catch (error) {
+      this.notifcationService.sendWarning('Block sign data detected but not correct format.', { length: 5000 })
+    }
+  }
+
+  navigateProcessBlock(url) {
+    if (!this.checkSignBlock(url.pathname) || !this.checkProcessBlock(url.pathname)) return this.notifcationService.sendWarning('Not a recognized format of a signed block.', { length: 5000 })
+    try {
+      let data = JSON.parse(url.pathname);
+      // Block to process
+      var paramsProcess = {
+        sign: 0,
+        n_account: data.block.account,
+        n_previous: data.block.previous,
+        n_representative: data.block.representative,
+        n_balance: data.block.balance,
+        n_link: data.block.link,
+        n_signature: data.block.signature,
+        n_work: data.block.work,
+      }
+      // only include if it exist
+      if (data.previous) {
+        paramsProcess = {...paramsProcess,...{
+          p_account: data.previous.account,
+          p_previous: data.previous.previous,
+          p_representative: data.previous.representative,
+          p_balance: data.previous.balance,
+          p_link: data.previous.link,
+        }}
+      }
+      this.router.navigate(['sign'], { queryParams: paramsProcess});
+    }
+    catch (error) {
+      this.notifcationService.sendWarning('Block process data detected but not correct format.', { length: 5000 })
+    }
+  }
+
+  checkSignBlock(stringdata:string) {
+    try {
+      let data = JSON.parse(stringdata);
+      console.log(data)
+
+      return (this.util.account.isValidAccount(data.block.account) &&
+        (data.previous ? this.util.account.isValidAccount(data.previous.account):true) &&
+        this.util.account.isValidAccount(data.block.representative) &&
+        (data.previous ? this.util.account.isValidAccount(data.previous.representative):true) &&
+        this.util.account.isValidAmount(data.block.balance) &&
+        (data.previous ? this.util.account.isValidAmount(data.previous.balance):true) &&
+        this.util.nano.isValidHash(data.block.previous) &&
+        (data.previous ? this.util.nano.isValidHash(data.previous.previous):true) &&
+        this.util.nano.isValidHash(data.block.link) &&
+        (data.previous ? this.util.nano.isValidHash(data.previous.link):true) &&
+        (data.previous ? this.util.nano.isValidSignature(data.previous.signature):true))
+    }
+    catch (error) {
+      return false
+    }
+  }
+
+  checkProcessBlock(stringdata:string) {
+    try {
+      let data = JSON.parse(stringdata);
+      return (this.util.nano.isValidSignature(data.block.signature) &&
+        (data.block.work ? this.util.nano.isValidWork(data.block.work):true))
+    }
+    catch (error) {
+      return false
+    }
+  }
+}

--- a/src/app/services/representative.service.ts
+++ b/src/app/services/representative.service.ts
@@ -207,6 +207,7 @@ export class RepresentativeService {
   async getOnlineRepresentatives(): Promise<string[]> {
     const representatives = [];
     const reps = await this.api.representativesOnline();
+    if (!reps) return representatives;
     for (let representative in reps.representatives) {
       if (!reps.representatives.hasOwnProperty(representative)) continue;
       representatives.push(reps.representatives[representative]);

--- a/src/app/services/util.service.ts
+++ b/src/app/services/util.service.ts
@@ -2,10 +2,21 @@ import { Injectable } from '@angular/core';
 import * as blake from 'blakejs';
 import {BigNumber} from 'bignumber.js';
 import * as nanocurrency from 'nanocurrency';
-import {StateBlock} from "./nano-block.service";
 
 const nacl = window['nacl'];
 const STATE_BLOCK_PREAMBLE = '0000000000000000000000000000000000000000000000000000000000000006';
+
+export interface StateBlock {
+  account: string;
+  previous: string;
+  representative: string;
+  balance: string;
+  link: string;
+  signature: string;
+  work: string;
+}
+
+export enum TxType {"send", "receive", "open", "change"};
 
 @Injectable()
 export class UtilService {

--- a/src/app/services/util.service.ts
+++ b/src/app/services/util.service.ts
@@ -73,6 +73,8 @@ export class UtilService {
     isValidSeed: isValidSeed,
     isValidHash: isValidHash,
     isValidIndex: isValidIndex,
+    isValidSignature: isValidSignature,
+    isValidWork: isValidWork,
   };
 
 }
@@ -352,6 +354,14 @@ function isValidIndex(val:number) {
   return nanocurrency.checkIndex(val);
 }
 
+function isValidSignature(val:string) {
+  return nanocurrency.checkSignature(val);
+}
+
+function isValidWork(val:string) {
+  return nanocurrency.checkWork(val);
+}
+
 function hashStateBlock(block:StateBlock) {
   const balance = new BigNumber(block.balance);
   if (balance.isNegative() || balance.isNaN()) {
@@ -440,5 +450,7 @@ const util = {
     isValidSeed: isValidSeed,
     isValidHash: isValidHash,
     isValidIndex: isValidIndex,
+    isValidSignature: isValidSignature,
+    isValidWork: isValidWork,
   }
 };

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -629,6 +629,7 @@ export class WalletService {
     let walletBalance = new BigNumber(0);
     let walletPending = new BigNumber(0);
 
+    if (!accounts) return;
     for (const accountID in accounts.balances) {
       if (!accounts.balances.hasOwnProperty(accountID)) continue;
       // Find the account, update it
@@ -937,8 +938,11 @@ export class WalletService {
       this.wallet.accounts.map(account =>
         this.api.accountInfo(account.id)
           .then(res => {
-            res.id = account.id;
-            res.addressBookName = account.addressBookName;
+            try {
+              res.id = account.id;
+              res.addressBookName = account.addressBookName;
+            }
+            catch {return null;}
 
             return res;
           })

--- a/src/app/services/work-pool.service.ts
+++ b/src/app/services/work-pool.service.ts
@@ -44,7 +44,10 @@ export class WorkPoolService {
   // Get work for a hash.  Uses the cache, or the current setting for generating it.
   public async getWork(hash) {
     const cached = this.workCache.find(p => p.hash == hash);
-    if (cached && cached.work) return cached.work;
+    if (cached && cached.work) {
+      console.log('Using cached work: ' + cached.work)
+      return cached.work;
+    }
 
     const work = await this.pow.getPow(hash);
     if (!work) {
@@ -52,6 +55,7 @@ export class WorkPoolService {
       return null;
     }
 
+    console.log('Work found: ' + work)
     this.workCache.push({ hash, work });
     if (this.workCache.length >= this.cacheLength) this.workCache.shift(); // Prune if we are at max length
     this.saveWorkCache();


### PR DESCRIPTION
**This is a work in progress linked to #40.**

**SEND BLOCKS**
Currently testing how the procedure could look like beginning with creating a send block from the account detail view aka "watch-only account". That can be reached by anyone without having an active wallet.

![image](https://user-images.githubusercontent.com/2406720/87597000-5133f900-c6f1-11ea-8fe4-c72113d1a827.png)

**Edit 2020-07-20:**
Implemented screen for signing the block. Working with internal wallet, ledger, seed, mnemonic, bip39 seed, bip39 mnemonic, private key or expanded private key. The QR now includes both new and previous block which means it's tamper-safe. The correct balance can be determined and block hash verified against the frontier.
![image](https://user-images.githubusercontent.com/2406720/87974967-35529d80-cacb-11ea-88a3-62925687896d.png)

**Edit 2020-07-22**

- Implemented button for creating receive-blocks on pending transactions
- Implemented screen for processing signed block
- Implemented landing screen (Available under "Advanced Tools")

![image](https://user-images.githubusercontent.com/2406720/88199161-c7ca7c80-cc44-11ea-8ea5-cef4096d9ad4.png)
![image](https://user-images.githubusercontent.com/2406720/88199197-d4e76b80-cc44-11ea-97ca-8a007afcf7a8.png)
![image](https://user-images.githubusercontent.com/2406720/88199040-a7022700-cc44-11ea-8952-90d041b0c27a.png)

**Edit 2020-07-24**
Landing page now allow the whole block to be copied as text, in case any of the devices don't have a camera for QR.
![image](https://user-images.githubusercontent.com/2406720/88389168-3a0e9e80-cdb6-11ea-8b4f-d55ab11457cf.png)


**TODO:**

- [x] Read the signed block in online Nault and process it after user confirmation.
- [x] Create receive blocks in online Nault to be signed offline (receive pending)
- [x] Create blocks for rep change (sign new rep offline)
- [x] Make a landing page for remote signing (that includes both online and offline part)