### PR TITLE
Better Account ID readability

### DIFF
--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -25,11 +25,15 @@
               <div class="uk-width-1-1">
                 <div *ngIf="addressBookEntry">
                     <h3 class="uk-card-title">{{ addressBookEntry }}</h3>
-                    <div class="uk-text-small uk-text-truncate">{{ accountID }}</div>
+                    <div class="uk-text-small uk-text-truncate">
+                      <app-nano-account-id [accountID]="accountID"></app-nano-account-id>
+                    </div>
                 </div>
 
                 <div *ngIf="!addressBookEntry">
-                  <h3 class="uk-card-title uk-text-truncate" style="margin-bottom: 0;">{{ accountID }}</h3>
+                  <h3 class="uk-card-title uk-text-truncate" style="margin-bottom: 0;">
+                    <app-nano-account-id [accountID]="accountID"></app-nano-account-id>
+                  </h3>
                 </div>
               </div>
             </div>
@@ -117,7 +121,8 @@
                     <div *ngIf="!showEditRepresentative">
                       <div uk-grid>
                         <div class="uk-width-expand uk-text-truncate ">
-                          <span *ngIf="repLabel" class="uk-label uk-label-danger">{{ repLabel }}</span> {{ account.representative }}
+                          <span *ngIf="repLabel" class="uk-label uk-label-danger">{{ repLabel }}</span> 
+                          <app-nano-account-id [accountID]="account.representative"></app-nano-account-id>
                         </div>
                         <div class="uk-width-auto" style="padding-left: 10px;" *ngIf="walletAccount && account.representative">
                           <ul class="uk-hidden-hover uk-iconnav">
@@ -164,7 +169,8 @@
                   <div uk-grid>
                     <div class="uk-width-expand uk-text-truncate">
                       <a [routerLink]="'/account/' + pending.account" class="uk-link-text" title="View Account Details" uk-tooltip>
-                        <span *ngIf="pending.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ pending.addressBookName }}</span> {{ pending.account }}
+                        <span *ngIf="pending.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ pending.addressBookName }}</span> 
+                        <app-nano-account-id [accountID]="pending.account" middle="off"></app-nano-account-id>
                       </a>
                     </div>
                     <div class="uk-width-auto" style="padding-left: 10px;">
@@ -187,7 +193,8 @@
                   <div uk-grid>
                     <div class="uk-width-expand uk-text-truncate">
                       <a [routerLink]="'/account/' + (history.link_as_account || history.account)" class="uk-link-text" title="View Account Details" uk-tooltip>
-                        <span *ngIf="history.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ history.addressBookName }}</span> {{ history.link_as_account || history.account }}
+                        <span *ngIf="history.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ history.addressBookName }}</span> 
+                        <app-nano-account-id [accountID]="history.link_as_account || history.account" middle="off"></app-nano-account-id>
                       </a>
                     </div>
                     <div class="uk-width-auto" style="padding-left: 10px;">

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -41,7 +41,8 @@
                   {{ account.index }}
                 </span>
                 <a [routerLink]="'/account/' + account.id" class="uk-link-text" title="View Account Details" uk-tooltip>
-                  <span *ngIf="account.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ account.addressBookName }}</span> {{ account.id }}
+                  <span *ngIf="account.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ account.addressBookName }}</span> 
+                  <app-nano-account-id [accountID]="account.id" middle="on"></app-nano-account-id>
                 </a>
               </div>
               <div class="uk-width-auto" style="padding-left: 10px;">

--- a/src/app/components/address-book/address-book.component.html
+++ b/src/app/components/address-book/address-book.component.html
@@ -44,7 +44,7 @@
                   <div uk-grid>
                     <div class="uk-width-expand uk-text-truncate">
                       <a [routerLink]="'/account/' + addressBook.account" class="uk-link-text" title="View Account Details" uk-tooltip>
-                        {{ addressBook.account }}
+                        <app-nano-account-id [accountID]="addressBook.account"></app-nano-account-id>
                       </a>
                     </div>
                     <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">

--- a/src/app/components/address-book/address-book.component.html
+++ b/src/app/components/address-book/address-book.component.html
@@ -43,7 +43,7 @@
                 <div class="uk-width-expand uk-text-truncate uk-visible-toggle">
                   <div uk-grid>
                     <div class="uk-width-expand uk-text-truncate">
-                      <a [routerLink]="'/account/' + addressBook.account" class="uk-link-text" title="View Account Details" uk-tooltip>
+                      <a [routerLink]="'/account/' + addressBook.account" class="uk-link-text uk-display-block" title="View Account Details" uk-tooltip>
                         <app-nano-account-id [accountID]="addressBook.account"></app-nano-account-id>
                       </a>
                     </div>

--- a/src/app/components/helpers/nano-account-id/nano-account-id.component.html
+++ b/src/app/components/helpers/nano-account-id/nano-account-id.component.html
@@ -1,5 +1,3 @@
-<span [class]="middle === 'auto' ? 'uk-flex' : ''">
-    <span style="color: #4A90E2;">{{ firstCharacters }}</span>
-    <span [class]="middle === 'auto' ? 'uk-text-truncate' : ''">{{ middleCharacters || '...'}}</span>
-    <span style="color: #cba644;">{{ lastCharacters }}</span>
-</span>
+<span style="color: #4A90E2;">{{ firstCharacters }}</span>
+<span [class.uk-text-truncate]="middle === 'auto'">{{ middleCharacters || '...'}}</span>
+<span style="color: #cba644;">{{ lastCharacters }}</span>

--- a/src/app/components/helpers/nano-account-id/nano-account-id.component.html
+++ b/src/app/components/helpers/nano-account-id/nano-account-id.component.html
@@ -1,2 +1,5 @@
-<span style="color: #506577;">{{ firstCharacters }}</span>...<span style="color: #cba644;">{{ lastCharacters }}</span>
-<!--<span style="color: #506577; font-weight: bold;">{{ firstCharacters }}</span>...<span style="color: #506577; font-weight: bold;">{{ lastCharacters }}</span>-->
+<span [class]="middle === 'auto' ? 'uk-flex' : ''">
+    <span style="color: #4A90E2;">{{ firstCharacters }}</span>
+    <span [class]="middle === 'auto' ? 'uk-text-truncate' : ''">{{ middleCharacters || '...'}}</span>
+    <span style="color: #cba644;">{{ lastCharacters }}</span>
+</span>

--- a/src/app/components/helpers/nano-account-id/nano-account-id.component.ts
+++ b/src/app/components/helpers/nano-account-id/nano-account-id.component.ts
@@ -3,7 +3,10 @@ import {Component, Input, OnChanges} from '@angular/core';
 @Component({
   selector: 'app-nano-account-id',
   templateUrl: './nano-account-id.component.html',
-  styleUrls: ['./nano-account-id.component.css']
+  styleUrls: ['./nano-account-id.component.css'],
+  host: {
+    '[class.uk-flex]': 'middle === "auto"'
+  }
 })
 export class NanoAccountIdComponent implements OnChanges {
 

--- a/src/app/components/helpers/nano-account-id/nano-account-id.component.ts
+++ b/src/app/components/helpers/nano-account-id/nano-account-id.component.ts
@@ -1,26 +1,30 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnChanges} from '@angular/core';
 
 @Component({
   selector: 'app-nano-account-id',
   templateUrl: './nano-account-id.component.html',
   styleUrls: ['./nano-account-id.component.css']
 })
-export class NanoAccountIdComponent implements OnInit {
+export class NanoAccountIdComponent implements OnChanges {
 
   @Input('accountID') accountID: string;
+  @Input('middle') middle: 'on'|'off'|'auto' = 'auto';
 
   firstCharacters = '';
+  middleCharacters = '';
   lastCharacters = '';
 
   constructor() { }
 
-  ngOnInit() {
+  ngOnChanges() {
     const accountID = this.accountID;
     const openingChars = 9;
     const closingChars = 5;
     this.firstCharacters = accountID.split('').slice(0, openingChars).join('');
     this.lastCharacters = accountID.split('').slice(-closingChars).join('');
-    // return `<span style="color: #f00;">${firstChars}</span>.....${lastChars}`;
+    if (this.middle !== 'off') {
+      this.middleCharacters = accountID.split('').slice(openingChars, -closingChars).join('')
+    }
   }
 
 }

--- a/src/app/components/helpers/nano-account-id/nano-account-id.component.ts
+++ b/src/app/components/helpers/nano-account-id/nano-account-id.component.ts
@@ -21,7 +21,7 @@ export class NanoAccountIdComponent implements OnChanges {
 
   ngOnChanges() {
     const accountID = this.accountID;
-    const openingChars = 9;
+    const openingChars = 10;
     const closingChars = 5;
     this.firstCharacters = accountID.split('').slice(0, openingChars).join('');
     this.lastCharacters = accountID.split('').slice(-closingChars).join('');

--- a/src/app/components/manage-representatives/manage-representatives.component.html
+++ b/src/app/components/manage-representatives/manage-representatives.component.html
@@ -47,7 +47,7 @@
                 <div class="uk-width-expand uk-text-truncate uk-visible-toggle">
                   <div uk-grid>
                     <div class="uk-width-expand uk-text-truncate">
-                      <a [routerLink]="'/account/' + representative.id" class="uk-link-text" title="View Account Details" uk-tooltip>
+                      <a [routerLink]="'/account/' + representative.id" class="uk-link-text uk-display-block" title="View Account Details" uk-tooltip>
                         <app-nano-account-id [accountID]="representative.id"></app-nano-account-id>
                       </a>
                     </div>

--- a/src/app/components/manage-representatives/manage-representatives.component.html
+++ b/src/app/components/manage-representatives/manage-representatives.component.html
@@ -48,7 +48,7 @@
                   <div uk-grid>
                     <div class="uk-width-expand uk-text-truncate">
                       <a [routerLink]="'/account/' + representative.id" class="uk-link-text" title="View Account Details" uk-tooltip>
-                        {{ representative.id }}
+                        <app-nano-account-id [accountID]="representative.id"></app-nano-account-id>
                       </a>
                     </div>
                     <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -32,7 +32,10 @@
       </div>
       <div *ngIf="qrCodeImage" class="uk-width-1-1@s narrow-div">
         <img [src]="qrCodeImage"><br>
-        <span>{{pendingAccountModel}}</span><a class="span-icon" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
+        <div class="uk-flex">
+          <app-nano-account-id [accountID]="pendingAccountModel" class="uk-width-auto" style="max-width: 90%;"></app-nano-account-id>
+          <a class="span-icon" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
+        </div>
       </div>
       <div class="uk-width-1-1">
         <div class="uk-card uk-card-default">

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -41,7 +41,7 @@
                   <div class="uk-width-expand uk-text-truncate" (click)="addSelectedAccounts(rep.accounts)" style="cursor: pointer;" uk-tooltip title="Select the accounts which are using this representative">
                     <span class="circle circle-online" *ngIf="rep.status.online" uk-tooltip title="Representative is online"></span>
                     <span class="circle circle-offline" *ngIf="!rep.status.online" uk-tooltip title="Representative is offline"></span>
-                    <span *ngIf="rep.label">{{ rep.label }}</span> <span *ngIf="!rep.label">{{ rep.id }}</span>
+                    <span *ngIf="rep.label">{{ rep.label }}</span> <span *ngIf="!rep.label"><app-nano-account-id [accountID]="rep.id" middle="on"></app-nano-account-id></span>
                   </div>
                   <div class="uk-width-1-4">
                     {{ rep.delegatedWeight | rai: 'mnano' }}
@@ -82,7 +82,8 @@
                     <li *ngFor="let account of selectedAccounts">
                       <div uk-grid>
                         <div class="uk-width-5-6 uk-text-truncate">
-                          <span *ngIf="account.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ account.addressBookName }}</span> {{ account.id }}
+                          <span *ngIf="account.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ account.addressBookName }}</span> 
+                          <app-nano-account-id [accountID]="account.id" middle="on"></app-nano-account-id>
                         </div>
                         <div class="uk-width-1-6 uk-text-center" style="padding-left: 0;">
                           <a (click)="removeSelectedAccount(account)" class="uk-text-danger" title="Remove From List" uk-tooltip><span uk-icon="icon: close;"></span></a>

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -116,10 +116,10 @@
                   <div *ngIf="fromAddressBook">
                     <span class="confirm-title">{{ fromAddressBook }}</span>
                     <span class="confirm-subtitle">From Account</span>
-                    <span class="uk-text-small uk-text-truncate">{{ fromAccountID | squeeze }}</span>
+                    <span class="uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
                   </div>
                   <div *ngIf="!fromAddressBook">
-                    <span class="confirm-title uk-text-truncate">{{ fromAccountID | squeeze }}</span>
+                    <span class="confirm-title uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
                     <span class="confirm-subtitle">From Account</span>
                     <br class="br-spacer" />
                   </div>
@@ -147,10 +147,10 @@
                   <div *ngIf="toAddressBook">
                     <span class="confirm-title">{{ toAddressBook }}</span>
                     <span class="confirm-subtitle">To Account</span>
-                    <span class="uk-text-small uk-text-truncate">{{ toAccountID | squeeze }}</span>
+                    <span class="uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
                   </div>
                   <div *ngIf="!toAddressBook">
-                    <span class="confirm-title uk-text-truncate">{{ toAccountID | squeeze }}</span>
+                    <span class="confirm-title uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
                     <span class="confirm-subtitle">To Account</span>
                     <br class="br-spacer" />
                   </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,4 +23,9 @@
 
 .uk-panel-scrollable {
     resize: none;
-  }
+}
+
+a.uk-link-text:hover {
+    color: #777;
+    filter: brightness(1.25);
+}


### PR DESCRIPTION
This PR utilize the existing `app-nano-account-id` component to prettify nano account id's in the app with colorization of the first and last part of the ID for better readability. It also adds an input option `middle` to the component.

The input option `middle` is used to determine if the middle part of a nano account should be shown. There are 3 options:
- `off`: This is exactly the same as the old behavior of the component, where the middle part is replaced with '...'
- `on`: This will show the middle part between the colorized first and last parts. Essentially exactly the same as simply showing the account directly with `{{ account.id }}` except the beginning and end is colorized for readability.
- `auto`: Applies truncation on the **middle** part of the account id. Basically a slightly more human readable version of `on` when the account doesn't fit on the screen that ensures both the beginning and end is always shown. If the whole account fits then all of it is shown just like `on`. This options wraps the string in a `uk-flex` to determine when truncation should take place so some slight tweaks to the template or style might be needed when this is used inline together with other elements.

I have made `auto` be the default just because it should probably be the most common.

![image](https://user-images.githubusercontent.com/1097444/87875157-80878600-c9cf-11ea-8598-b73ef2cfcf11.png)

![image](https://user-images.githubusercontent.com/1097444/87875165-89785780-c9cf-11ea-9508-2bb5ef84d00f.png)

![image](https://user-images.githubusercontent.com/1097444/87875167-8da47500-c9cf-11ea-9668-07f8ff2bb038.png)

![image](https://user-images.githubusercontent.com/1097444/87875275-8336ab00-c9d0-11ea-962a-13b081a855ed.png)

