### PR TITLE
Representative UX improvements

### DIFF
--- a/src/app/components/change-rep-widget/change-rep-widget.component.html
+++ b/src/app/components/change-rep-widget/change-rep-widget.component.html
@@ -1,8 +1,19 @@
 <div *ngIf="displayedRepresentatives.length > 0" class="nav-representative-info">
-  <h2>Representative{{ displayedRepresentatives.length > 1 ? 's' : '' }}</h2>
-  <div class="representative" *ngFor="let rep of displayedRepresentatives" (mouseover)="showRepHelp=rep.id" (mouseout)="showRepHelp=null">
+  <div class="representative" *ngFor="let rep of displayedRepresentatives; let repIdx = index" (mouseover)="showRepHelp=rep.id" (mouseout)="showRepHelp=null">
+      <h2>Representative{{
+          (repIdx !== 0)
+        ? (
+            ' for '
+          + (
+              rep.accounts[0].addressBookName
+            ? ( '"' + rep.accounts[0].addressBookName + '"' )
+            : ( rep.accounts[0].id.slice(0, 10) + '...' )
+          )
+        )
+        : ''
+      }}</h2>
     <div class="representative-name-row">
-      <a (click)="showRepSelectionForSpecificRepId(rep.id)" class="name">{{ rep.label || 'Unknown' }}</a>
+      <a (click)="showRepSelectionForSpecificRep(rep)" class="name">{{ rep.label || 'Unknown' }}</a>
       <div class="weight-total">{{ rep.percent.toFixed(2) }}%</div>
     </div>
     <ng-container [ngSwitch]="true">
@@ -55,7 +66,7 @@
   </div>
 </div>
 
-<div class="nav-status-row interactable uk-animation-slide-left" (click)="showRepSelectionForAllChangeableReps()" *ngIf="changeableRepresentatives.length">
+<div class="nav-status-row interactable uk-animation-slide-left" (click)="showRepSelectionForAllChangeableReps()" *ngIf="showRepChangeRequired">
   <div class="status-icon">
     <span class="uk-text-warning" uk-icon="icon: warning; ratio: 1.2;"></span>
   </div>

--- a/src/app/services/representative.service.ts
+++ b/src/app/services/representative.service.ts
@@ -14,6 +14,7 @@ export interface RepresentativeStatus {
   lowUptime: boolean;
   markedToAvoid: boolean;
   trusted: boolean;
+  changeRequired: boolean;
   warn: boolean;
   known: boolean;
   uptime: Number;
@@ -141,6 +142,7 @@ export class RepresentativeService {
         lowUptime: false,
         markedToAvoid: false,
         trusted: false,
+        changeRequired: false,
         warn: false,
         known: false,
         uptime: null,
@@ -154,6 +156,7 @@ export class RepresentativeService {
       if (percent.gte(3)) {
         status = 'alert'; // Has extremely high voting weight
         repStatus.veryHighWeight = true;
+        repStatus.changeRequired = true;
       } else if (percent.gte(1)) {
         status = 'warn'; // Has high voting weight
         repStatus.highWeight = true;
@@ -171,6 +174,7 @@ export class RepresentativeService {
           status = 'alert'; // In our list and marked for avoidance
           repStatus.markedToAvoid = true;
           repStatus.warn = true;
+          repStatus.changeRequired = true;
         }
       } else if (knownRepNinja) {
         status = status === 'none' ? 'ok' : status; // In our list
@@ -181,6 +185,7 @@ export class RepresentativeService {
           status = 'alert';
           repStatus.veryLowUptime = true;
           repStatus.warn = true;
+          repStatus.changeRequired = true;
         } else if (knownRepNinja.uptime_over.week < 90) {
           if (status !== 'alert') {
             status = 'warn';

--- a/src/less/components/nav.less
+++ b/src/less/components/nav.less
@@ -470,23 +470,24 @@
 	border-bottom: 1px solid @nav-border-color;
 	padding: 0px 20px 0px 20px;
 	margin-bottom: 15px;
-	position: relative;
-
-	> h2 {
-		text-transform: uppercase;
-		font-size: 12px;
-		font-weight: 500;
-		color: @nav-half-muted-color;
-		margin-bottom: 5px;
-	}
 
 	> .representative {
 		display: flex;
 		flex-direction: column;
+		position: relative;
 
 		&:hover > .representative-name-row > .name {
 			border-bottom-style: dotted;
 			border-color: #868AB0;
+		}
+
+		> h2 {
+			text-transform: uppercase;
+			font-size: 12px;
+			font-weight: 500;
+			color: @nav-half-muted-color;
+			margin-bottom: 5px;
+			.truncated-text();
 		}
 	}
 
@@ -523,7 +524,7 @@
 		}
 	}
 
-	> div > .representative-health-row {
+	> .representative > .representative-health-row {
 		display: flex;
 		align-items: center;
 		margin-top: 5px;
@@ -558,7 +559,7 @@
 		}
 	}
 
-	> div > .representative-help-tooltip {
+	> .representative > .representative-help-tooltip {
 		display: flex;
 		flex-direction: column;
 		width: calc(100% - 75px);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29272208/89101466-96de0a80-d3ef-11ea-9e31-a8354443b38b.png)

this commit fixes "Representative Change Required" appearing for "acceptable" reps as opposed to only "bad" reps. clicking on "Representative Change Required" still includes "acceptable" reps but it will no longer force the alert to appear

--

![image](https://user-images.githubusercontent.com/29272208/89101498-e6bcd180-d3ef-11ea-99e8-8f4af0be9be6.png)

it also includes one representative (with the most confirmed funds) that triggered the "Representative Change Required" underneath the rep that's normally displayed, so you don't get mixed signals from simultaneously seeing "Good Representative" and "Change Required".