### PR TITLE
Readme split

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <hello@nault.cc>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [https://contributor-covenant.org/version/1/4][version]
+
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to Nault
+We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
+
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing new features
+- Becoming a maintainer
+
+## Project Goals
+1. Building a secure wallet by the community for the community
+2. Keep with best practices in the Angular development community
+3. Stay current with major developments in Angular and Angular-CLI
+4. Sharing responsibility: The project should be seen as *our* wallet and be self maintained by the community
+
+## We Develop with Github
+We use github to host code, to track issues and feature requests, as well as accept pull requests.
+
+## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html), So All Code Changes Happen Through Pull Requests
+Pull requests are the best way to propose changes to the codebase (we use [Github Flow](https://guides.github.com/introduction/flow/index.html)). We actively welcome your pull requests:
+
+1. Fork the repo and create your branch from `master`.
+2. If you've added code that should be tested, add tests.
+3. Ensure the test suite passes.
+4. Make sure your code lints.
+5. Issue that pull request!
+
+## Any contributions you make will be under the MIT Software License
+In short, when you submit code changes, your submissions are understood to be under the same [MIT License](LICENSE) that covers the project. Feel free to contact the maintainers if that's a concern.
+
+## Report bugs using Github's [issues](https://github.com/Nault/Nault/issues)
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/Nault/Nault/issues); it's that easy!
+
+**Great Bug Reports** tend to have:
+
+- A quick summary and/or background
+- Steps to reproduce
+  - Be specific!
+  - Give sample code if you can
+- What you expected would happen
+- What actually happens
+- Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+
+People *love* thorough bug reports. I'm not even kidding.
+
+## Use a Consistent Coding Style
+* 2 spaces for indentation rather than tabs
+* You can try running `npm run lint` for style unification
+
+## License
+By contributing, you agree that your contributions will be licensed under its MIT License.
+
+## References
+This document was adapted from the open-source contribution guidelines for [Facebook's Draft](https://github.com/facebook/draft-js/blob/a9316a723f9e918afde44dea68b5f9f39b7d9b00/CONTRIBUTING.md)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,74 @@
+# Nault Development
+
+## Application Structure
+
+- [Nault](https://github.com/Nault/Nault) - The main wallet application (UI + Seed Generation/Block Signing/Etc).
+- Communication with the network is done via Nano RPC and Websocket protocols, private or public on any nano network.
+
+## Development Prerequisites
+- [NodeJS](https://nodejs.org) v12.x + NPM v6.x
+- Angular CLI: `npm install -g @angular/cli`
+
+## Development Guide
+#### Clone repository and install dependencies
+```bash
+git clone https://github.com/Nault/Nault
+cd Nault
+npm install
+```
+
+#### Run the wallet in dev mode
+```bash
+npm run wallet:dev
+```
+
+If you want to debug in VS code, first install [debugger for chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome)
+Then you can just go to the debug screen and choose "Launch Chrome http"
+
+#### Run the wallet in dev mode as https (for example if using the Ledger device)
+```bash
+npm run wallet:dev-ssl
+```
+
+To debug in VS code: Go to debug screen and choose "Launch Chrome https"
+
+## Build Wallet (For Production)
+Build a production version of the wallet for web:
+```bash
+npm run wallet:build
+```
+
+Build a production version of the wallet for desktop: *(Required for all desktop builds)*
+```bash
+npm run wallet:build-desktop
+```
+
+## Desktop Builds
+
+*All desktop builds require that you have built a desktop version of the wallet before running!*
+
+Run the desktop wallet in dev mode:
+```bash
+npm run desktop:dev
+```
+
+If you want to debug in VS code, first install [debugger for chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome)
+Then you can just go to the debug screen and choose "Electron: Main", "Electron: Renderer", or "Electron: All" for both Main and Renderer threads.
+
+Build the desktop wallet for your local OS (Will be in `desktop-app\build`):
+```bash
+npm run desktop:local
+```
+
+Build the desktop wallet for Windows+Mac+Linux (May require dependencies for your OS [View them here](https://www.electron.build/multi-platform-build)):
+```bash
+npm run desktop:full
+```
+
+## Running unit tests
+
+Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+
+## Running end-to-end tests
+
+Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).

--- a/README.md
+++ b/README.md
@@ -9,108 +9,17 @@ Seamless integration with any Nano compatible RPC backend/websocket and the aim 
 ![Nault Screenshot](/src/assets/img/preview.png)
 ___
 
-# Table of Contents
-* [How To Use](#how-to-use)
-* [Bugs/Feedback](#bugsfeedback)
-* [Application Structure](#application-structure)
-* [Development Prerequisites](#development-prerequisites)
-* [Development Guide](#development-guide)
-* [Acknowledgements](#acknowledgements)
-* [Donations](#donations)
-
-
-# How To Use
+## How To Use
 Nault is available on your desktop (Windows/Mac/Linux) - just head over to the [latest release](https://github.com/Nault/Nault/releases/latest) and download the version for your OS.
 
-You can also use Nault from any device on the web at [nault.cc](https://nault.cc)
+You can also use Nault from any device on the web at [nault.cc](https://nault.cc).
 
-# Bugs/Feedback
-If you run into any issues, please use the [GitHub Issue Tracker](https://github.com/Nault/Nault/issues) or head over to the [TNC Discord Server](http://discord.nanocenter.org/)!  
-We are continually improving and adding new features based on the feedback you provide, so please let your opinions be known!
+## How To Help
+Thanks for your interest in contributing! There are many ways to contribute to this project. [Get started here at CONTRIBUTING.md](CONTRIBUTING.md).
 
-___
+If you want to know how to setup the development environment head over to [DEVELOPMENT.md](DEVELOPMENT.md).
 
-#### Everything below is only for contributing to the development of Nault
-#### To download Nault as a desktop app go to the [releases section](https://github.com/Nault/Nault/releases), or use the web wallet at [nault.cc](https://nault.cc)
-
-___
-
-# Application Structure
-
-- [Nault](https://github.com/Nault/Nault) - The main wallet application (UI + Seed Generation/Block Signing/Etc).
-- Communication with the network is done via Nano RPC and Websocket protocols, private or public on any nano network.
-
-
-# Development Prerequisites
-- [NodeJS](https://nodejs.org) v12.x + NPM v6.x
-- Angular CLI: `npm install -g @angular/cli`
-
-
-# Development Guide
-#### Clone repository and install dependencies
-```bash
-git clone https://github.com/Nault/Nault
-cd Nault
-npm install
-```
-
-#### Run the wallet in dev mode
-```bash
-npm run wallet:dev
-```
-
-If you want to debug in VS code, first install [debugger for chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome)
-Then you can just go to the debug screen and choose "Launch Chrome http"
-
-#### Run the wallet in dev mode as https (for example if using the Ledger device)
-```bash
-npm run wallet:dev-ssl
-```
-
-To debug in VS code: Go to debug screen and choose "Launch Chrome https"
-
-## Build Wallet (For Production)
-Build a production version of the wallet for web:
-```bash
-npm run wallet:build
-```
-
-Build a production version of the wallet for desktop: *(Required for all desktop builds)*
-```bash
-npm run wallet:build-desktop
-```
-
-## Desktop Builds
-
-*All desktop builds require that you have built a desktop version of the wallet before running!*
-
-Run the desktop wallet in dev mode:
-```bash
-npm run desktop:dev
-```
-
-If you want to debug in VS code, first install [debugger for chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome)
-Then you can just go to the debug screen and choose "Electron: Main", "Electron: Renderer", or "Electron: All" for both Main and Renderer threads.
-
-Build the desktop wallet for your local OS (Will be in `desktop-app\build`):
-```bash
-npm run desktop:local
-```
-
-Build the desktop wallet for Windows+Mac+Linux (May require dependencies for your OS [View them here](https://www.electron.build/multi-platform-build)):
-```bash
-npm run desktop:full
-```
-
-## Running unit tests
-
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
-
-## Running end-to-end tests
-
-Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
-
-# Acknowledgements
+## Acknowledgements
 Special thanks to the following!
 - [NanoVault](https://github.com/cronoh/nanovault) - The original one
 - [numtel/nano-webgl-pow](https://github.com/numtel/nano-webgl-pow) - WebGL PoW Implementation
@@ -118,7 +27,7 @@ Special thanks to the following!
 - [dcposch/blakejs](https://github.com/dcposch/blakejs) - Blake2b Implementation
 - [dchest/tweetnacl-js](https://github.com/dchest/tweetnacl-js) - Cryptography Implementation
 
-# Donations
+## Donations
 If you have found Nault useful and are feeling generous, you can donate at 
 `nano_3niceeeyiaa86k58zhaeygxfkuzgffjtwju9ep33z9c8qekmr3iuc95jbqc8`
 


### PR DESCRIPTION
Splitted up the README, making the main page of the repo clearer.
Added a Code of Conduct and seperate docs for the development process.