### PR TITLE
Fix unknown reps not reporting 0% weekly uptime

### DIFF
--- a/src/app/components/change-rep-widget/change-rep-widget.component.html
+++ b/src/app/components/change-rep-widget/change-rep-widget.component.html
@@ -13,10 +13,14 @@
         : ''
       }}</h2>
     <div class="representative-name-row">
-      <a (click)="showRepSelectionForSpecificRep(rep)" class="name">{{ rep.label || 'Unknown' }}</a>
-      <div class="weight-total">{{ rep.percent.toFixed(2) }}%</div>
+      <a (click)="showRepSelectionForSpecificRep(rep)" class="name">{{ rep.label || 'Unknown Rep' }}</a>
+      <div class="weight-total" *ngIf="!rep.percent.isZero()">{{ rep.percent.toFixed(2) }}%</div>
     </div>
     <ng-container [ngSwitch]="true">
+      <div class="representative-health-row health-unknown" *ngSwitchCase="rep.statusText == 'unknown'">
+        <div class="health-icon"></div>
+        <div class="label">Unknown Status</div>
+      </div>
       <div class="representative-health-row health-yellow" *ngSwitchCase="rep.statusText == 'warn'">
         <div class="health-icon"></div>
         <div class="label">Acceptable Representative</div>
@@ -59,7 +63,10 @@
       <p class="uk-text-success" *ngIf="rep.statusText == 'ok'">
         <span uk-icon="icon: check;"></span>We've found no issues with uptime or weight distribution of your current representative.
       </p>
-      <p *ngIf="rep.statusText != 'ok'">
+      <p *ngIf="rep.statusText == 'unknown'">
+        <span uk-icon="icon: question;"></span>We could not determine status of this representative.
+      </p>
+      <p *ngIf="rep.statusText != 'ok' && rep.statusText != 'unknown'">
         It is <b>highly advised</b> to switch to a different representative, in order to improve security and decentralization of the Nano network.
       </p>
     </div>

--- a/src/app/services/ninja.service.ts
+++ b/src/app/services/ninja.service.ts
@@ -62,8 +62,19 @@ export class NinjaService {
     return replist[0];
   }
 
+  // false - does not exist, null - any other error
   async getAccount(account: string): Promise<any> {
-    return await this.request('accounts/' + account);
+    return await this.http.get(this.ninjaUrl + 'accounts/' + account).toPromise()
+      .then(res => {
+        return res;
+      })
+      .catch(err => {
+        if (err.status === 404) {
+          return false;
+        }
+
+        return null;
+      });
   }
 
 }

--- a/src/app/services/representative.service.ts
+++ b/src/app/services/representative.service.ts
@@ -193,12 +193,16 @@ export class RepresentativeService {
           repStatus.lowUptime = true;
           repStatus.warn = true;
         }
-      } else {
+      } else if (knownRepNinja === false) {
+        // does not exist (404)
         status = 'alert';
         repStatus.uptime = 0;
         repStatus.veryLowUptime = true;
         repStatus.warn = true;
         repStatus.changeRequired = true;
+      } else {
+        // any other api error
+        status = status === 'none' ? 'unknown' : status;
       }
 
       const additionalData = {

--- a/src/app/services/representative.service.ts
+++ b/src/app/services/representative.service.ts
@@ -193,6 +193,12 @@ export class RepresentativeService {
           repStatus.lowUptime = true;
           repStatus.warn = true;
         }
+      } else {
+        status = 'alert';
+        repStatus.uptime = 0;
+        repStatus.veryLowUptime = true;
+        repStatus.warn = true;
+        repStatus.changeRequired = true;
       }
 
       const additionalData = {

--- a/src/less/components/nav.less
+++ b/src/less/components/nav.less
@@ -545,6 +545,11 @@
 			.health-state-apply-colors();
 		}
 
+		&.health-unknown {
+			@health-state-color: #868AB0;
+			.health-state-apply-colors();
+		}
+
 		> .health-icon {
 			display: flex;
 			width: 15px;


### PR DESCRIPTION
This fixes #115, however i'd like to make sure 0% weekly uptime is only shown if the ninja service returns a 404 error and not simply fails the api call for any other reason. Otherwise we could risk reporting 0% weekly uptime on good reps.

We might still need an "Unknown Status", e.g. if the api call returns any other error code, as in that case we can't rule out "good" nor "bad".