### PR TITLE
fix(GUI): all copy/edit buttons visible without hover

### DIFF
--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -23,10 +23,10 @@
             </div>
             <div *ngIf="!showEditAddressBook" uk-grid>
               <div class="uk-width-1-1">
-                <div *ngIf="addressBookEntry">
+                <div *ngIf="addressBookEntry || walletAccount">
                   <div class="uk-width-1-1">
                     <div uk-grid>
-                    <h3 class="uk-width-auto uk-card-title uk-text-truncate" style="max-width: calc(100% - 35px);">{{ addressBookEntry }}</h3>
+                    <h3 class="uk-width-auto uk-card-title uk-text-truncate" style="max-width: calc(100% - 35px);">{{ addressBookEntry ? addressBookEntry : ('Account #' + walletAccount.index)}}</h3>
                       <div class="uk-width-auto" style="padding-left: 10px; margin-top: 3px;">
                         <li style="display: contents;"><span uk-icon="icon: pencil;" title="Edit Account Label" uk-tooltip (click)="showEditAddressBook = !showEditAddressBook" title="Edit Account Label"></span></li>
                       </div>
@@ -42,7 +42,7 @@
                   </div>
                 </div>
 
-                <div *ngIf="!addressBookEntry">
+                <div *ngIf="!addressBookEntry && !walletAccount">
                   <div uk-grid>
                     <h3 class="uk-width-auto uk-card-title uk-text-truncate" style="max-width: calc(100% - 80px);">
                       <app-nano-account-id [accountID]="accountID"></app-nano-account-id>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -40,8 +40,8 @@
 
           </div>
           <div class="uk-width-auto">
-            <ul class="uk-hidden-hover uk-iconnav">
-              <li><span uk-icon="icon: pencil;" title="Edit Account Label" uk-tooltip (click)="showEditAddressBook = !showEditAddressBook" title="Edit Account Label"></span></li>
+            <ul class="uk-iconnav">
+              <li style="display: contents;"><span uk-icon="icon: pencil;" title="Edit Account Label" uk-tooltip (click)="showEditAddressBook = !showEditAddressBook" title="Edit Account Label"></span></li>
               <li><a ngxClipboard [cbContent]="accountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
             </ul>
           </div>
@@ -125,7 +125,7 @@
                           <app-nano-account-id [accountID]="!account ? '':account.representative"></app-nano-account-id>
                         </div>
                         <div class="uk-width-auto" style="padding-left: 10px;" *ngIf="walletAccount && account && account.representative">
-                          <ul class="uk-hidden-hover uk-iconnav">
+                          <ul class="uk-iconnav">
                             <!--<li><a uk-icon="icon: pencil;" title="Change Representative" uk-tooltip (click)="showEditRepresentative = true"></a></li>-->
                             <li><a uk-icon="icon: pencil;" title="Change Representative" uk-tooltip routerLink="/representatives" [queryParams]="{ hideOverview: true, showRecommended: true, accounts: accountID }"></a></li>
                           </ul>
@@ -195,7 +195,7 @@
                       </a>
                     </div>
                     <div class="uk-width-auto" style="padding-left: 10px;">
-                      <ul class="uk-hidden-hover uk-iconnav">
+                      <ul class="uk-iconnav">
                         <li><a ngxClipboard [cbContent]="pending.account" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                       </ul>
                     </div>
@@ -220,7 +220,7 @@
                       </a>
                     </div>
                     <div class="uk-width-auto" style="padding-left: 10px;">
-                      <ul class="uk-hidden-hover uk-iconnav">
+                      <ul class="uk-iconnav">
                         <li><a ngxClipboard [cbContent]="history.link_as_account || history.account" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                       </ul>
                     </div>
@@ -272,11 +272,11 @@
 
       <div *ngIf="blockHashReceive" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
         <span class="uk-text-small" uk-tooltip title="Unsigned block string to be copied to remote device" style="overflow-wrap: anywhere;"><strong>Unsigned Block</strong></span>
-        <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+        <ul class="uk-iconnav" style="padding-left: 0;">
           <li><a ngxClipboard [cbContent]="qrString" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
         </ul>
         <span class="uk-text-small" uk-tooltip title="Final block hash to be signed or verified" style="overflow-wrap: anywhere; margin-left: 50px;"><strong>Block Hash</strong></span>
-        <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+        <ul class="uk-iconnav" style="padding-left: 0;">
           <li><a ngxClipboard [cbContent]="blockHashReceive" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
         </ul>
       </div>
@@ -406,11 +406,11 @@
 
       <div *ngIf="blockHash" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
         <span class="uk-text-small" uk-tooltip title="Unsigned block string to be copied to remote device" style="overflow-wrap: anywhere;"><strong>Unsigned Block</strong></span>
-        <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+        <ul class="uk-iconnav" style="padding-left: 0;">
           <li><a ngxClipboard [cbContent]="qrString" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
         </ul>
         <span class="uk-text-small" uk-tooltip title="Final block hash to be signed or verified" style="overflow-wrap: anywhere; margin-left: 50px;"><strong>Block Hash</strong></span>
-        <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+        <ul class="uk-iconnav" style="padding-left: 0;">
           <li><a ngxClipboard [cbContent]="blockHash" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
         </ul>
       </div>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -24,26 +24,40 @@
             <div *ngIf="!showEditAddressBook" uk-grid>
               <div class="uk-width-1-1">
                 <div *ngIf="addressBookEntry">
-                    <h3 class="uk-card-title">{{ addressBookEntry }}</h3>
-                    <div class="uk-text-small uk-text-truncate">
+                  <div class="uk-width-1-1">
+                    <div uk-grid>
+                    <h3 class="uk-width-auto uk-card-title uk-text-truncate" style="max-width: calc(100% - 35px);">{{ addressBookEntry }}</h3>
+                      <div class="uk-width-auto" style="padding-left: 10px; margin-top: 3px;">
+                        <li style="display: contents;"><span uk-icon="icon: pencil;" title="Edit Account Label" uk-tooltip (click)="showEditAddressBook = !showEditAddressBook" title="Edit Account Label"></span></li>
+                      </div>
+                    </div>
+                  </div>
+                  <div uk-grid>
+                    <div class="uk-width-auto uk-text-small uk-text-truncate" style="max-width: calc(100% - 35px);">
                       <app-nano-account-id [accountID]="accountID"></app-nano-account-id>
                     </div>
+                    <div class="uk-width-auto" style="padding-left: 10px; margin-top: -3px;">
+                      <li><a ngxClipboard [cbContent]="accountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
+                    </div>
+                  </div>
                 </div>
 
                 <div *ngIf="!addressBookEntry">
-                  <h3 class="uk-card-title uk-text-truncate" style="margin-bottom: 0;">
-                    <app-nano-account-id [accountID]="accountID"></app-nano-account-id>
-                  </h3>
+                  <div uk-grid>
+                    <h3 class="uk-width-auto uk-card-title uk-text-truncate" style="max-width: calc(100% - 80px);">
+                      <app-nano-account-id [accountID]="accountID"></app-nano-account-id>
+                    </h3>
+                    <div class="uk-width-auto">
+                      <ul class="uk-iconnav" style="margin-top: 5px;">
+                        <li style="display: contents;"><span uk-icon="icon: pencil;" title="Edit Account Label" uk-tooltip (click)="showEditAddressBook = !showEditAddressBook" title="Edit Account Label"></span></li>
+                        <li><a ngxClipboard [cbContent]="accountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
+                      </ul>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
 
-          </div>
-          <div class="uk-width-auto">
-            <ul class="uk-iconnav">
-              <li style="display: contents;"><span uk-icon="icon: pencil;" title="Edit Account Label" uk-tooltip (click)="showEditAddressBook = !showEditAddressBook" title="Edit Account Label"></span></li>
-              <li><a ngxClipboard [cbContent]="accountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
-            </ul>
           </div>
         </div>
       </div>
@@ -188,7 +202,7 @@
                 <td class="uk-text-truncate uk-text-muted" *ngIf="!pending.local_timestamp">N/A</td>
                 <td class="uk-visible-toggle">
                   <div uk-grid>
-                    <div class="uk-width-expand uk-text-truncate">
+                    <div class="uk-width-auto uk-text-truncate">
                       <a [routerLink]="'/account/' + pending.account" class="uk-link-text" title="View Account Details" uk-tooltip>
                         <span *ngIf="pending.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ pending.addressBookName }}</span> 
                         <app-nano-account-id [accountID]="pending.account" middle="off"></app-nano-account-id>
@@ -213,7 +227,7 @@
                 <td class="uk-text-truncate uk-text-muted" *ngIf="!history.local_timestamp">N/A</td>
                 <td class="uk-visible-toggle">
                   <div uk-grid>
-                    <div class="uk-width-expand uk-text-truncate">
+                    <div class="uk-width-auto uk-text-truncate">
                       <a [routerLink]="'/account/' + (history.link_as_account || history.account)" class="uk-link-text" title="View Account Details" uk-tooltip>
                         <span *ngIf="history.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ history.addressBookName }}</span> 
                         <app-nano-account-id [accountID]="history.link_as_account || history.account" middle="off"></app-nano-account-id>

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -54,7 +54,6 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
   statsRefreshEnabled = true;
 
   // Remote signing
-  accounts = this.wallet.wallet.accounts;
   addressBookResults$ = new BehaviorSubject([]);
   showAddressBook = false;
   addressBookMatch = '';

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -49,7 +49,7 @@
                 </a>
               </div>
               <div class="uk-width-auto" style="padding-left: 10px;">
-                <ul class="uk-hidden-hover uk-iconnav">
+                <ul class="uk-iconnav">
                   <!--<li class="account-index">#{{ account.index }}</li>-->
                   <li><a ngxClipboard [cbContent]="account.id" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                   <li *ngIf="isLedgerWallet"><a uk-icon="icon: commenting" title="Confirm Address On Ledger" (click)="showLedgerAddress(account)" uk-tooltip></a></li>
@@ -74,7 +74,7 @@
             <div *ngIf="account.pending.gt(0)" class="uk-text-muted uk-text-small">
               {{ account.pendingFiat | fiat: settings.settings.displayCurrency }}
             </div>
-            <div class="uk-float-right uk-hidden-hover">
+            <div class="uk-float-right">
               <a (click)="deleteAccount(account)" class="uk-text-danger" title="Hide Account" uk-tooltip><span uk-icon="icon: close;"></span></a>
             </div>
 

--- a/src/app/components/address-book/address-book.component.html
+++ b/src/app/components/address-book/address-book.component.html
@@ -38,7 +38,7 @@
                     <div class="uk-width-expand uk-text-truncate">
                       <a (click)="editEntry(addressBook)" class="uk-link-text" title="Edit Account Label" uk-tooltip>{{ addressBook.name }}</a>
                     </div>
-                    <ul class="uk-hidden-hover uk-iconnav uk-width-auto" style="padding-left: 0;">
+                    <ul class="uk-iconnav uk-width-auto" style="padding-left: 0;">
                       <li><span class="uk-sortable-handle uk-margin-small-right" uk-icon="icon: table"></span></li>
                     </ul>
                   </div>
@@ -50,7 +50,7 @@
                         <app-nano-account-id [accountID]="addressBook.account"></app-nano-account-id>
                       </a>
                     </div>
-                    <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+                    <ul class="uk-iconnav" style="padding-left: 0;">
                       <li><a ngxClipboard [cbContent]="addressBook.account" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                     </ul>
                   </div>

--- a/src/app/components/address-book/address-book.component.html
+++ b/src/app/components/address-book/address-book.component.html
@@ -50,7 +50,7 @@
                         <app-nano-account-id [accountID]="addressBook.account"></app-nano-account-id>
                       </a>
                     </div>
-                    <ul class="uk-iconnav" style="padding-left: 0;">
+                    <ul class="uk-iconnav" style="padding-left: 10px;">
                       <li><a ngxClipboard [cbContent]="addressBook.account" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                     </ul>
                   </div>

--- a/src/app/components/manage-representatives/manage-representatives.component.html
+++ b/src/app/components/manage-representatives/manage-representatives.component.html
@@ -41,7 +41,7 @@
                       <a (click)="editEntry(representative)" class="uk-link-text" title="Edit Representative" uk-tooltip>{{ representative.name }}</a>
                     </div>
                     <ul class="uk-iconnav uk-width-auto" style="padding-left: 0;">
-                      <!--<li><span class="uk-hidden-hover uk-sortable-handle uk-margin-small-right" uk-icon="icon: table"></span></li>-->
+                      <!--<li><span class="uk-sortable-handle uk-margin-small-right" uk-icon="icon: table"></span></li>-->
                       <li *ngIf="representative.trusted"><span class="uk-text-success" uk-icon="icon: star" uk-tooltip title="Representative marked as trusted"></span></li>
                       <li *ngIf="representative.warn"><span class="uk-text-warning" uk-icon="icon: warning" uk-tooltip title="Representative marked as avoid"></span></li>
                     </ul>
@@ -54,7 +54,7 @@
                         <app-nano-account-id [accountID]="representative.id"></app-nano-account-id>
                       </a>
                     </div>
-                    <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+                    <ul class="uk-iconnav" style="padding-left: 0;">
                       <li><a ngxClipboard [cbContent]="representative.id" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                     </ul>
                   </div>

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -57,7 +57,7 @@
                     </a>
                   </div>
                   <div class="uk-width-auto" style="padding-left: 10px;">
-                    <ul class="uk-hidden-hover uk-iconnav">
+                    <ul class="uk-iconnav">
                       <li><a ngxClipboard [cbContent]="block.account" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                     </ul>
                   </div>
@@ -71,7 +71,7 @@
                     </a>
                   </div>
                   <div class="uk-width-auto" style="padding-left: 10px;">
-                    <ul class="uk-hidden-hover uk-iconnav">
+                    <ul class="uk-iconnav">
                       <li><a ngxClipboard [cbContent]="block.source" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                     </ul>
                   </div>

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -51,9 +51,9 @@
             <tr *ngFor="let block of pendingBlocks">
               <td *ngIf="block.account == pendingAccountModel || pendingAccountModel == 0" class="uk-visible-toggle">
                 <div uk-grid>
-                  <div class="uk-width-expand uk-text-truncate">
+                  <div class="uk-width-auto uk-text-truncate">
                     <a [routerLink]="'/account/' + block.account" class="uk-link-text" title="View Account Details" uk-tooltip>
-                      {{ block.account | squeeze }}
+                      <app-nano-account-id [accountID]="block.account" middle="off"></app-nano-account-id>
                     </a>
                   </div>
                   <div class="uk-width-auto" style="padding-left: 10px;">
@@ -65,9 +65,9 @@
               </td>
               <td *ngIf="block.account == pendingAccountModel || pendingAccountModel == 0" class="uk-visible-toggle">
                 <div uk-grid>
-                  <div class="uk-width-expand uk-text-truncate">
+                  <div class="uk-width-auto uk-text-truncate">
                     <a [routerLink]="'/account/' + block.source" class="uk-link-text" title="View Account Details" uk-tooltip>
-                      {{ block.source | squeeze }}
+                      <app-nano-account-id [accountID]="block.source" middle="off"></app-nano-account-id>
                     </a>
                   </div>
                   <div class="uk-width-auto" style="padding-left: 10px;">

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -165,7 +165,7 @@
                 <span class="uk-text-success">Successfully processed block: </span><a [routerLink]="'/transaction/' + processedHash" class="uk-link-text" title="View Block Details" uk-tooltip>{{ processedHash }}</a>
               </div>
               <div class="uk-width-auto" style="padding-left: 10px;">
-                <ul class="uk-hidden-hover uk-iconnav">
+                <ul class="uk-iconnav">
                   <li><a ngxClipboard [cbContent]="processedHash" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Block Hash" uk-tooltip></a></li>
                 </ul>
               </div>
@@ -214,11 +214,11 @@
       
       <div *ngIf="finalSignature" class="uk-width-1-1 uk-text-center" style="display: flex; justify-content: center;">
         <span class="uk-text-small" uk-tooltip title="Signed block string to be copied to remote device" style="overflow-wrap: anywhere;"><strong>Signed Block</strong></span>
-        <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+        <ul class="uk-iconnav" style="padding-left: 0;">
           <li><a ngxClipboard [cbContent]="qrString" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
         </ul>
         <span class="uk-text-small" uk-tooltip title="Signature to be embedded into the final block" style="overflow-wrap: anywhere; margin-left: 50px;"><strong>Signature</strong></span>
-        <ul class="uk-hidden-hover uk-iconnav" style="padding-left: 0;">
+        <ul class="uk-iconnav" style="padding-left: 0;">
           <li><a ngxClipboard [cbContent]="finalSignature" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
         </ul>
       </div>


### PR DESCRIPTION
Copy address buttons was only visible on hover which was not only annoying but also impossible to use on mobile
- Removed all "uk-hidden-hover" styles

Fixes #124 and fixes #111 

Question: Is this ok UI-wise or too many visible buttons in tables, etc.? It's ok IMO.