### PR TITLE
Warn for 2%

### DIFF
--- a/src/app/components/change-rep-widget/change-rep-widget.component.html
+++ b/src/app/components/change-rep-widget/change-rep-widget.component.html
@@ -49,7 +49,7 @@
         <span uk-icon="icon: warning;"></span>This representative has a <b>very high voting weight</b> (over 3%).
       </p>
       <p class="uk-text-warning" *ngIf="rep.status.highWeight">
-        <span uk-icon="icon: warning;"></span>This representative has a <b>high voting weight</b> (over 1%).
+        <span uk-icon="icon: warning;"></span>This representative has a <b>high voting weight</b> (over 2%).
       </p>
       <p class="uk-text-danger" *ngIf="rep.status.veryLowUptime && rep.status.uptime > 0">
         <span uk-icon="icon: warning;"></span>This representative is <b>often offline</b> ({{ rep.status.uptime.toFixed(1) }}% uptime).

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -34,7 +34,7 @@
 
                   <div class="uk-width-1-5" [ngClass]="{ 'uk-text-danger': rep.statusText === 'alert', 'uk-text-warning': rep.statusText === 'warn', 'uk-text-success': rep.statusText === 'trusted', 'uk-text-primary': rep.statusText === 'ok' }">
                     <span *ngIf="rep.statusText === 'alert'" uk-tooltip title="This is an unknown or official representative, or it's marked because of bad uptime or high (3%+ of online) voting weight.  It is recommended to change to a new representative!"><span uk-icon="icon: warning"></span> Change</span>
-                    <span *ngIf="rep.statusText === 'warn'" uk-tooltip title="This representative has a bad uptime or a high (1%+ of online) voting weight.  Consider changing to a new representative."><span uk-icon="icon: warning"></span> Change</span>
+                    <span *ngIf="rep.statusText === 'warn'" uk-tooltip title="This representative has a bad uptime or a high (2%+ of online) voting weight.  Consider changing to a new representative."><span uk-icon="icon: warning"></span> Change</span>
                     <span *ngIf="rep.statusText === 'trusted'" uk-tooltip title="This representative is marked as trusted.  No change is needed."><span uk-icon="icon: star"></span> Trusted</span>
                     <span *ngIf="rep.statusText === 'ok'" uk-tooltip title="This representative is saved in your list, as long as it is online, no change is needed."><span uk-icon="icon: check"></span> Okay</span>
                     <span *ngIf="rep.statusText === 'none'" uk-tooltip title="This representative is not known, consider switching to a known one or add this one to your list"><span uk-icon="icon: question"></span> Unknown</span>

--- a/src/app/services/representative.service.ts
+++ b/src/app/services/representative.service.ts
@@ -157,7 +157,7 @@ export class RepresentativeService {
         status = 'alert'; // Has extremely high voting weight
         repStatus.veryHighWeight = true;
         repStatus.changeRequired = true;
-      } else if (percent.gte(1)) {
+      } else if (percent.gte(2)) {
         status = 'warn'; // Has high voting weight
         repStatus.highWeight = true;
       }


### PR DESCRIPTION
IMO a "warning" for a rep should occur at >2%.
If a rep has ~1.X % this should not trigger a warning.

At the current state this would be better than the current check, as the decentralization get's better these limits can get modified again.