### PR TITLE
Wallet logic for selected sidebar account

### DIFF
--- a/src/app/components/accounts/accounts.component.css
+++ b/src/app/components/accounts/accounts.component.css
@@ -1,4 +1,4 @@
 .account-index {
-  color: #d2d2d2;
+  color: #383844;
   margin-right: 5px;
 }

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -39,9 +39,9 @@
             <div uk-grid>
               <div class="uk-width-expand uk-text-truncate">
                 <div class="uk-width-1-1">
-                  <span class="account-index">
+                  <a class="account-index" [routerLink]="'/account/' + account.id" title="View Account Details" uk-tooltip>
                     {{ account.addressBookName ? account.addressBookName : 'Account #' + account.index }}
-                  </span>
+                  </a>
                 </div>
                 <a [routerLink]="'/account/' + account.id" class="uk-link-text" title="View Account Details" uk-tooltip>
                   <app-nano-account-id [accountID]="account.id" middle="on"></app-nano-account-id>

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -27,8 +27,6 @@
         <thead>
         <tr>
           <th class="uk-width-3-5@m uk-width-1-2">
-            <a class="account-index" *ngIf="viewAdvanced" uk-icon="icon: hashtag;" title="Sort Accounts" (click)="sortAccounts()" uk-tooltip>
-            </a>
             Account
           </th>
           <th class="uk-width-1-5@m uk-width-1-4 uk-text-right">Balance</th>
@@ -40,16 +38,17 @@
           <td class="uk-visible-toggle uk-text-truncate">
             <div uk-grid>
               <div class="uk-width-expand uk-text-truncate">
-                <span class="account-index" *ngIf="viewAdvanced">
-                  {{ account.index }}
-                </span>
+                <div class="uk-width-1-1">
+                  <span class="account-index">
+                    {{ account.addressBookName ? account.addressBookName : 'Account #' + account.index }}
+                  </span>
+                </div>
                 <a [routerLink]="'/account/' + account.id" class="uk-link-text" title="View Account Details" uk-tooltip>
-                  <span *ngIf="account.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ account.addressBookName }}</span> 
                   <app-nano-account-id [accountID]="account.id" middle="on"></app-nano-account-id>
                 </a>
               </div>
               <div class="uk-width-auto" style="padding-left: 10px;">
-                <ul class="uk-hidden-hover uk-iconnav">
+                <ul class="uk-iconnav">
                   <!--<li class="account-index">#{{ account.index }}</li>-->
                   <li><a ngxClipboard [cbContent]="account.id" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                   <li *ngIf="isLedgerWallet"><a uk-icon="icon: commenting" title="Confirm Address On Ledger" (click)="showLedgerAddress(account)" uk-tooltip></a></li>
@@ -58,26 +57,29 @@
             </div>
           </td>
           <td class="uk-text-right">
-            {{ account.balance | rai: settings.settings.displayDenomination }}
-            <div *ngIf="account.balanceRaw.gt(0)" style="font-size: 10px;" class="uk-text-muted">
-              +{{ account.balanceRaw.toString(10) | squeeze:'5,5' }} raw
+            <div class="uk-width-1-1">
+              {{ account.balance | rai: settings.settings.displayDenomination }}
+              <div *ngIf="account.balanceRaw.gt(0)" style="font-size: 10px;" class="uk-text-muted">
+                +{{ account.balanceRaw.toString(10) | squeeze:'5,5' }} raw
+              </div>
+              <div *ngIf="account.pending.gt(0)" class="uk-text-muted uk-text-small">
+                {{ account.pending | rai: settings.settings.displayDenomination }}
+              </div>
+              <div *ngIf="account.pendingRaw.gt(0)" style="font-size: 10px;" class="uk-text-muted">
+                +{{ account.pendingRaw.toString(10) | squeeze:'5,5' }} raw
+              </div>
             </div>
-            <div *ngIf="account.pending.gt(0)" class="uk-text-muted uk-text-small">
-              {{ account.pending | rai: settings.settings.displayDenomination }}
-            </div>
-            <div *ngIf="account.pendingRaw.gt(0)" style="font-size: 10px;" class="uk-text-muted">
-              +{{ account.pendingRaw.toString(10) | squeeze:'5,5' }} raw
+            <div class="uk-width-1-1">
+              {{ account.balanceFiat | fiat: settings.settings.displayCurrency }}
+              <div *ngIf="account.pending.gt(0)" class="uk-text-muted uk-text-small">
+                {{ account.pendingFiat | fiat: settings.settings.displayCurrency }}
+              </div>
             </div>
           </td>
-          <td class="uk-text-left@m uk-text-right">
-            {{ account.balanceFiat | fiat: settings.settings.displayCurrency }}
-            <div *ngIf="account.pending.gt(0)" class="uk-text-muted uk-text-small">
-              {{ account.pendingFiat | fiat: settings.settings.displayCurrency }}
-            </div>
-            <div class="uk-float-right uk-hidden-hover">
+          <td class="uk-text-right">
+            <div class="uk-float-right">
               <a (click)="deleteAccount(account)" class="uk-text-danger" title="Hide Account" uk-tooltip><span uk-icon="icon: close;"></span></a>
             </div>
-
           </td>
         </tr>
         <tr *ngIf="!(accounts).length">

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -16,10 +16,10 @@
       </div>
 
     <div uk-grid>
-      <div class="uk-width-expand@s">
+      <div class="uk-width-3-4@s">
         <select class="uk-select" [(ngModel)]="pendingAccountModel" (change)="changeQRAccount(pendingAccountModel)">
           <option [value]="0">All Accounts</option>
-          <option *ngFor="let account of accounts" [value]="account.id">{{ account.id }}</option>
+          <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: settings.settings.displayDenomination }})</option>
         </select>
       </div>
       <div class="uk-width-auto@s">

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -21,7 +21,7 @@ import BigNumber from 'bignumber.js';
 export class ReceiveComponent implements OnInit {
   accounts = this.walletService.wallet.accounts;
 
-  pendingAccountModel = 0;
+  pendingAccountModel = '0';
   pendingBlocks = [];
   qrCodeImage = null;
   qrAccount = "";
@@ -41,6 +41,11 @@ export class ReceiveComponent implements OnInit {
     setTimeout(() => {
       this.getPending();
     }, 100);
+
+    // Set the account selected in the sidebar as default
+    if (this.walletService.wallet.selectedAccount !== null) {
+      this.pendingAccountModel = this.walletService.wallet.selectedAccount.id;
+    }
   }
 
   async loadPendingForAll() {

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -76,7 +76,7 @@
                 <div class="uk-form-controls">
                   <select class="uk-select" [(ngModel)]="changeAccountID" (change)="newAccountID()" id="form-horizontal-select">
                     <option [value]="null">Select Accounts to Change</option>
-                    <option [value]="'all'">All Accounts</option>
+                    <option [value]="'all'">All Current Accounts</option>
                     <option *ngFor="let account of wallet.wallet.accounts" [value]="account.id">{{ account.addressBookName ? account.addressBookName + ' - ' : '' }} {{ account.id | squeeze }} ({{ account.balance | rai: settings.settings.displayDenomination }})</option>
                   </select>
                   <ul class="uk-list uk-list-striped">
@@ -84,7 +84,8 @@
                       <div uk-grid>
                         <div class="uk-width-5-6 uk-text-truncate">
                           <span *ngIf="account.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ account.addressBookName }}</span> 
-                          <app-nano-account-id [accountID]="account.id" middle="on"></app-nano-account-id>
+                          <span *ngIf="account.id !== 'All Current Accounts'"><app-nano-account-id [accountID]="account.id" middle="on"></app-nano-account-id></span>
+                          <span *ngIf="account.id === 'All Current Accounts'">{{ account.id }}</span>
                         </div>
                         <div class="uk-width-1-6 uk-text-center" style="padding-left: 0;">
                           <a (click)="removeSelectedAccount(account)" class="uk-text-danger" title="Remove From List" uk-tooltip><span uk-icon="icon: close;"></span></a>
@@ -101,7 +102,7 @@
                 <div class="uk-form-controls">
                   <div class="uk-inline uk-width-1-1">
                     <a class="uk-form-icon uk-form-icon-flip" uk-icon="icon: camera" (click)="openQR('rep1','account')" uk-tooltip title="Scan from QR code"></a>
-                    <input (blur)="validateRepresentative()" (keyup)="searchRepresentatives()" (focus)="searchRepresentatives()" [(ngModel)]="toRepresentativeID" class="uk-input" id="form-horizontal-text2" type="text" placeholder="Representative Account ID" #repInput>
+                    <input (blur)="validateRepresentative()" (keyup)="searchRepresentatives()" (focus)="searchRepresentatives()" [(ngModel)]="toRepresentativeID" class="uk-input" id="form-horizontal-text2" type="text" placeholder="Representative Account" #repInput>
 
                     <div *ngIf="(representativeResults$ | async).length" [hidden]="!showRepresentatives" class="uk-animation-slide-down-small uk-width-1-1 uk-card uk-card-default uk-card-body uk-position-absolute" style="z-index: 15000">
                       <ul class="uk-nav uk-nav-default">

--- a/src/app/components/representatives/representatives.component.ts
+++ b/src/app/components/representatives/representatives.component.ts
@@ -123,7 +123,7 @@ export class RepresentativesComponent implements OnInit {
     const existingAccount = this.selectedAccounts.find(a => a.id === newAccount);
     if (existingAccount) return; // Already selected
 
-    const allExists = this.selectedAccounts.find(a => a.id === 'All Accounts');
+    const allExists = this.selectedAccounts.find(a => a.id === 'All Current Accounts');
     if (newAccount === 'all' && !allExists) {
       this.selectedAccounts = []; // Reset the list before adding all
     }
@@ -132,7 +132,9 @@ export class RepresentativesComponent implements OnInit {
     }
 
     if (newAccount === 'all') {
-      this.selectedAccounts.push({ id: 'All Accounts' });
+      if (this.selectedAccounts.length === 0) {
+        this.selectedAccounts.push({ id: 'All Current Accounts' });
+      }
     } else {
       const walletAccount = this.wallet.getWalletAccount(newAccount);
       this.selectedAccounts.push(walletAccount);
@@ -253,7 +255,7 @@ export class RepresentativesComponent implements OnInit {
       return this.notifications.sendWarning(`Representative is not a valid account`);
     }
 
-    const allAccounts = accounts.find(a => a.id === 'All Accounts');
+    const allAccounts = accounts.find(a => a.id === 'All Current Accounts');
     const accountsToChange = allAccounts ? this.wallet.wallet.accounts : accounts;
 
     // Remove any that don't need their represetatives to be changed

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -15,7 +15,7 @@
                 <label class="uk-form-label" for="form-horizontal-select">From Account</label>
                 <div class="uk-form-controls">
                   <select class="uk-select" [(ngModel)]="fromAccountID" (change)="resetRaw()" id="form-horizontal-select">
-                    <option *ngFor="let account of accounts" [value]="account.id">{{ account.addressBookName ? account.addressBookName + ' - ' : '' }} {{ account.id | squeeze }} ({{ account.balance | rai: settings.settings.displayDenomination }})</option>
+                    <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: settings.settings.displayDenomination }})</option>
                   </select>
                 </div>
               </div>

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -79,23 +79,28 @@ export class SendComponent implements OnInit {
     // Set default From account
     this.fromAccountID = this.accounts.length ? this.accounts[0].id : '';
 
-    // We want to look for the first account in the wallet that has a balance
+    // Set the account selected in the sidebar as default
+    if (this.walletService.wallet.selectedAccount !== null) {
+      this.fromAccountID = this.walletService.wallet.selectedAccount.id;
+    } else {
+      // If "total balance" is selected in the sidebar, use the first account in the wallet that has a balance
 
-    // If the wallet balance is zero, this might be an initial load to the send page
-    // If it is, we want to load balances before we try to find the right account
-    if (this.walletService.wallet.balance.isZero()) {
-      await this.walletService.reloadBalances();
-    }
+      // If the wallet balance is zero, this might be an initial load to the send page
+      // If it is, we want to load balances before we try to find the right account
+      if (this.walletService.wallet.balance.isZero()) {
+        await this.walletService.reloadBalances();
+      }
 
-    // Look for the first account that has a balance
-    const accountIDWithBalance = this.accounts.reduce((previous, current) => {
-      if (previous) return previous;
-      if (current.balance.gt(0)) return current.id;
-      return null;
-    }, null);
+      // Look for the first account that has a balance
+      const accountIDWithBalance = this.accounts.reduce((previous, current) => {
+        if (previous) return previous;
+        if (current.balance.gt(0)) return current.id;
+        return null;
+      }, null);
 
-    if (accountIDWithBalance) {
-      this.fromAccountID = accountIDWithBalance;
+      if (accountIDWithBalance) {
+        this.fromAccountID = accountIDWithBalance;
+      }
     }
   }
 

--- a/src/app/components/sweeper/sweeper.component.html
+++ b/src/app/components/sweeper/sweeper.component.html
@@ -44,7 +44,7 @@
                 <label class="uk-form-label" for="destination-account">Local Destination<span uk-icon="icon: info;" uk-tooltip title="Local accounts that can be used as destination for the swept funds. Make sure you are able to unlock your Nault wallet."></span></label>
                 <div class="uk-form-controls">
                   <select class="uk-select" id="destination-account" [(ngModel)]="myAccountModel" (change)="setDestination(myAccountModel)">
-                    <option *ngFor="let account of accounts" [value]="account.id">{{ account.addressBookName ? account.addressBookName + ' - ' : '' }} {{ account.id }}</option>
+                    <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: settings.settings.displayDenomination }})</option>
                     <option [value]="0">Custom Destination</option>
                   </select>
                 </div>

--- a/src/app/components/sweeper/sweeper.component.ts
+++ b/src/app/components/sweeper/sweeper.component.ts
@@ -75,6 +75,10 @@ export class SweeperComponent implements OnInit {
     }
 
   async ngOnInit() {
+    // Set the account selected in the sidebar as default
+    if (this.walletService.wallet.selectedAccount !== null) {
+      this.myAccountModel = this.walletService.wallet.selectedAccount.id;
+    }
   }
 
   sleep(ms) {


### PR DESCRIPTION
Fixes #110 
- When "total balance" is selected in the sidebar, the same logic applies as before.
- When an account is selected in the sidebar: Set default account in SEND, RECEIVE and SWEEPER tool
- Improved accounts screen: Indexed account labels for unknown labels (multi-line) to reflect the sidebar
![image](https://user-images.githubusercontent.com/2406720/89563095-3568d200-d81b-11ea-8865-f53439a36e6a.png)

- Improved dropdown for SEND, RECEIVE and SWEEPER (destination): Now with index/label, account and balance. The balance is also properly updated in realtime when doing transactions
![image](https://user-images.githubusercontent.com/2406720/89563140-47e30b80-d81b-11ea-8540-02088c2848d6.png)
