### PR TITLE
(account selection): Enhanced UX

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -43,7 +43,13 @@
             <div class="address">{{ account.id }}</div>
           </div>
           <div class="balance-column">
-            <div class="balance primary">{{ account.balance | rai: settings.settings.displayDenomination }}</div>
+            <div class="balance primary">
+              <span class="incoming-label" *ngIf="account.pending.gt(0)">
+                <span class="text-snippet">New</span>
+                <span class="text-full">+{{ account.pending | rai: 'mnano,true' }}</span>
+              </span>
+              {{ account.balance | rai: settings.settings.displayDenomination }}
+            </div>
             <div class="balance converted">{{ account.balanceFiat | fiat: settings.settings.displayCurrency }}</div>
           </div>
         </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -107,7 +107,7 @@
                 </div>
               </div>
 
-              <ng-container *ngIf="walletService.hasPendingTransactions()">
+              <ng-container *ngIf="(wallet.selectedAccount === null && walletService.hasPendingTransactions()) || wallet.selectedAccount !== null && wallet.selectedAccount.pending.gt(0)">
                 <ng-container *ngIf="walletService.processingPending else notProcessingPending">
                   <div class="nav-action-receive" *ngIf="walletService.processingPending">
                     <div class="icon" uk-icon="icon: chevron-up; ratio: 1.2;"></div>
@@ -137,15 +137,15 @@
                       <div class="balance-container primary">
                         <div class="currency-name">NANO</div>
                         <div class="amount-container">
-                          <div class="amount-integer">{{ wallet.pending | rai: 'mnano,true' | amountsplit: 0 }}</div>
-                          <div class="amount-fractional">{{ wallet.pending | rai: 'mnano,true' | amountsplit: 1 }}</div>
+                          <div class="amount-integer">{{ (wallet.selectedAccount ? wallet.selectedAccount.pending : wallet.pending) | rai: 'mnano,true' | amountsplit: 0 }}</div>
+                          <div class="amount-fractional">{{ (wallet.selectedAccount ? wallet.selectedAccount.pending : wallet.pending) | rai: 'mnano,true' | amountsplit: 1 }}</div>
                         </div>
                       </div>
                       <div class="balance-container converted" *ngIf="settings.settings.displayCurrency">
                         <div class="currency-name"><span class="estimate-symbol">~</span>{{ settings.settings.displayCurrency }}</div>
                         <div class="amount-container">
-                          <div class="amount-integer">{{ wallet.pendingFiat | fiat: settings.settings.displayCurrency | amountsplit: 0 }}</div>
-                          <div class="amount-fractional">{{ wallet.pendingFiat | fiat: settings.settings.displayCurrency | amountsplit: 1 }}</div>
+                          <div class="amount-integer">{{ (wallet.selectedAccount ? wallet.selectedAccount.pendingFiat : wallet.pendingFiat) | fiat: settings.settings.displayCurrency | amountsplit: 0 }}</div>
+                          <div class="amount-fractional">{{ (wallet.selectedAccount ? wallet.selectedAccount.pendingFiat : wallet.pendingFiat) | fiat: settings.settings.displayCurrency | amountsplit: 1 }}</div>
                         </div>
                       </div>
                     </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -72,6 +72,14 @@ export class AppComponent implements OnInit {
 
     await this.walletService.loadStoredWallet();
 
+    // update selected account object with the latest balance, pending, etc
+    if (this.wallet.selectedAccountId) {
+      const currentUpdatedAccount = this.wallet.accounts.find(a => a.id === this.wallet.selectedAccountId);
+      this.wallet.selectedAccount = currentUpdatedAccount;
+    }
+
+    await this.walletService.reloadBalances(true);
+
     // Workaround fix for github pages when Nault is refreshed (or externally linked) and there is a subpath for example to the send screen.
     // This data is saved from the 404.html page
     const path = localStorage.getItem('path');
@@ -173,6 +181,7 @@ export class AppComponent implements OnInit {
 
   selectAccount(account) {
     // note: account is null when user is switching to 'Total Balance'
+    this.wallet.selectedAccountId = account ? account.id : null;
     this.wallet.selectedAccount = account;
     this.wallet.selectedAccount$.next(account);
     this.toggleAccountsDropdown();

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -189,6 +189,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
       if (this.settings.settings.minimumReceive) {
         const minAmount = this.util.nano.mnanoToRaw(this.settings.settings.minimumReceive);
         pending = await this.api.pendingLimit(this.accountID, 50, minAmount.toString(10));
+        this.account.pending = '0';
       } else {
         pending = await this.api.pending(this.accountID, 50);
       }
@@ -203,6 +204,9 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
             addressBookName: this.addressBook.getAccountName(pending.blocks[block].source) || null,
             hash: block,
           });
+
+          // Update the actual account pending amount with this above-threshold-value
+          this.account.pending = new BigNumber(this.account.pending).plus(pending.blocks[block].amount).toString(10);
         }
       }
     }

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -47,6 +47,14 @@ export class ReceiveComponent implements OnInit {
       this.pendingAccountModel = this.walletService.wallet.selectedAccount.id;
       this.changeQRAccount(this.pendingAccountModel);
     }
+
+    // Update selected account if changed in the sidebar
+    this.walletService.wallet.selectedAccount$.subscribe(async acc => {
+      if (acc) {
+        this.pendingAccountModel = acc.id;
+        this.changeQRAccount(this.pendingAccountModel);
+      }
+    });
   }
 
   async loadPendingForAll() {

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -102,6 +102,13 @@ export class SendComponent implements OnInit {
         this.fromAccountID = accountIDWithBalance;
       }
     }
+
+    // Update selected account if changed in the sidebar
+    this.walletService.wallet.selectedAccount$.subscribe(async acc => {
+      if (acc) {
+        this.fromAccountID = acc.id;
+      }
+    });
   }
 
   // An update to the Nano amount, sync the fiat value

--- a/src/app/components/sweeper/sweeper.component.ts
+++ b/src/app/components/sweeper/sweeper.component.ts
@@ -79,6 +79,12 @@ export class SweeperComponent implements OnInit {
     if (this.walletService.wallet.selectedAccount !== null) {
       this.myAccountModel = this.walletService.wallet.selectedAccount.id;
     }
+    // Update selected account if changed in the sidebar
+    this.walletService.wallet.selectedAccount$.subscribe(async acc => {
+      if (acc) {
+        this.myAccountModel = acc.id;
+      }
+    });
   }
 
   sleep(ms) {

--- a/src/app/services/desktop.service.ts
+++ b/src/app/services/desktop.service.ts
@@ -15,8 +15,6 @@ export class DesktopService {
       } catch (e) {
         throw e;
       }
-    } else {
-      console.warn('Electron\'s IPC was not loaded. Normal on web but not desktop.');
     }
   }
 

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -50,6 +50,7 @@ export interface FullWallet {
   hasPending: boolean;
   accounts: WalletAccount[];
   accountsIndex: number;
+  selectedAccountId: string|null;
   selectedAccount: WalletAccount|null;
   selectedAccount$: BehaviorSubject<WalletAccount|null>;
   locked: boolean;
@@ -93,6 +94,7 @@ export class WalletService {
     hasPending: false,
     accounts: [],
     accountsIndex: 0,
+    selectedAccountId: null,
     selectedAccount: null,
     selectedAccount$: new BehaviorSubject(null),
     locked: false,
@@ -272,9 +274,7 @@ export class WalletService {
       }
     }
 
-    this.wallet.selectedAccount = walletJson.selectedAccount || null;
-
-    await this.reloadBalances(true);
+    this.wallet.selectedAccountId = walletJson.selectedAccountId || null;
 
     if (walletType === 'ledger') {
       this.ledgerService.loadLedger(true);
@@ -602,6 +602,7 @@ export class WalletService {
     this.wallet.balanceFiat = 0;
     this.wallet.pendingFiat = 0;
     this.wallet.hasPending = false;
+    this.wallet.selectedAccountId = null;
     this.wallet.selectedAccount = null;
     this.wallet.selectedAccount$ = new BehaviorSubject(null);
   }
@@ -958,7 +959,7 @@ export class WalletService {
       type: this.wallet.type,
       accounts: this.wallet.accounts.map(a => ({ id: a.id, index: a.index })),
       accountsIndex: this.wallet.accountsIndex,
-      selectedAccount: this.wallet.selectedAccount,
+      selectedAccountId: this.wallet.selectedAccount ? this.wallet.selectedAccount.id : null,
     };
 
     if (this.wallet.type === 'ledger') {

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -155,7 +155,7 @@ export class WalletService {
           }
         }
 
-        
+
 
         await this.processStateBlock(transaction);
 
@@ -724,14 +724,17 @@ export class WalletService {
 
         if (pending && pending.blocks) {
           for (const block in pending.blocks) {
-            const walletAccount = this.wallet.accounts.find(a => a.id === block);
             if (!pending.blocks.hasOwnProperty(block)) {
               continue;
             }
+            const walletAccount = this.wallet.accounts.find(a => a.id === block);
             if (pending.blocks[block]) {
               hasPending = true;
               let accountPending = new BigNumber(0);
               for (const hash in pending.blocks[block]) {
+                if (!pending.blocks[block].hasOwnProperty(hash)) {
+                  continue;
+                }
                 walletPendingReal = walletPendingReal.plus(pending.blocks[block][hash].amount);
                 accountPending = accountPending.plus(pending.blocks[block][hash].amount);
               }
@@ -739,8 +742,7 @@ export class WalletService {
               walletAccount.pending = accountPending;
               walletAccount.pendingRaw = accountPending.mod(this.nano);
               walletAccount.pendingFiat = this.util.nano.rawToMnano(accountPending).times(fiatPrice).toNumber();
-            }
-            else {
+            } else {
               walletAccount.pending = new BigNumber(0);
               walletAccount.pendingRaw = new BigNumber(0);
               walletAccount.pendingFiat = 0;

--- a/src/less/components/nav.less
+++ b/src/less/components/nav.less
@@ -451,6 +451,35 @@
 					padding-bottom: 4px;
 					white-space: nowrap;
 					transition: color 100ms ease-in-out;
+
+					> .incoming-label {
+						background: @global-primary-background;
+						border-radius: 10px;
+						font-size: 10px;
+						padding: 2px 8px;
+						margin-right: 3px;
+						vertical-align: 1px;
+						text-transform: uppercase;
+						color: #FFF;
+
+						> .text-full {
+							display: none;
+						}
+
+						> .text-snippet {
+							display: inline-block;
+						}
+
+						@media (min-width: 1500px) {
+							> .text-full {
+								display: inline-block;
+							}
+
+							> .text-snippet {
+								display: none;
+							}
+						}
+					}
 				}
 
 				&.converted {
@@ -746,8 +775,8 @@
 			}
 
 			&.active {
-				border-left-color: #4E91E0;
-				color: #4E91E0;
+				border-left-color: @global-primary-background;
+				color: @global-primary-background;
 			}
 		}
 
@@ -804,7 +833,7 @@
 					}
 
 					&.active {
-						color: #4E91E0;
+						color: @global-primary-background;
 					}
 				}
 			}


### PR DESCRIPTION
- Only show incoming balance for the account selected (or for total balance)
- Subscribe to sidebar account changes in SEND/RECEIVE/SWEEPER screen
- Only store the selected account ID and reload the full selected account object on app init