### PR TITLE
feat(min threshold): Track accounts below min threshold

### DIFF
--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -49,7 +49,7 @@
             </thead>
             <tbody>
             <tr *ngFor="let block of pendingBlocks">
-              <td *ngIf="block.account == pendingAccountModel || pendingAccountModel == 0" class="uk-visible-toggle">
+              <td *ngIf="block.account == pendingAccountModel || pendingAccountModel === '0'" class="uk-visible-toggle">
                 <div uk-grid>
                   <div class="uk-width-auto uk-text-truncate">
                     <a [routerLink]="'/account/' + block.account" class="uk-link-text" title="View Account Details" uk-tooltip>
@@ -63,7 +63,7 @@
                   </div>
                 </div>
               </td>
-              <td *ngIf="block.account == pendingAccountModel || pendingAccountModel == 0" class="uk-visible-toggle">
+              <td *ngIf="block.account == pendingAccountModel || pendingAccountModel === '0'" class="uk-visible-toggle">
                 <div uk-grid>
                   <div class="uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
                     <a [routerLink]="'/account/' + block.source" class="uk-link-text" title="View Account Details" uk-tooltip>
@@ -77,14 +77,20 @@
                   </div>
                 </div>
               </td>
-              <td *ngIf="block.account == pendingAccountModel || pendingAccountModel == 0">{{ block.amount | rai: settings.settings.displayDenomination }}</td>
-              <td *ngIf="block.account == pendingAccountModel || pendingAccountModel == 0" class="uk-text-nowrap">
+              <td *ngIf="block.account == pendingAccountModel || pendingAccountModel === '0'">{{ block.amount | rai: settings.settings.displayDenomination }}</td>
+              <td *ngIf="block.account == pendingAccountModel || pendingAccountModel === '0'" class="uk-text-nowrap">
                 <button *ngIf="!block.loading" (click)="receivePending(block)" class="uk-button uk-button-secondary uk-button-small">Receive</button>
                 <button *ngIf="block.loading" class="uk-button uk-button-secondary uk-disabled uk-button-small"><span class="uk-margin-right" uk-spinner></span> Loading</button>
               </td>
             </tr>
-            <tr *ngIf="!pendingBlocks.length">
+            <tr *ngIf="!pendingBlocks.length && ((pendingAccountModel === '0' && pendingBelowThreshold.length > 0 && !pendingBelowThreshold[0].gt(0)) || (pendingAccountModel !== '0' && walletAccount && walletAccount.pendingBelowThreshold.length > 0 && !walletAccount.pendingBelowThreshold[0].gt(0)))">
               <td colspan="4" style="text-align: center;">No incoming transactions</td>
+            </tr>
+            <tr *ngIf="pendingAccountModel === '0' && pendingBelowThreshold.length > 0 && pendingBelowThreshold[0].gt(0)">
+              <td colspan="4" style="text-align: center;">Some transactions ({{pendingBelowThreshold[0] | rai: settings.settings.displayDenomination}} total) were hidden due to a Minimum Receive Amount of {{minAmount | rai: settings.settings.displayDenomination}} <a routerLink="/configure-app" routerLinkActive="active">(configure)</a></td>
+            </tr>
+            <tr *ngIf="pendingAccountModel !== '0' && walletAccount && walletAccount.pendingBelowThreshold.length > 0 && walletAccount.pendingBelowThreshold[0].gt(0)">
+              <td colspan="4" style="text-align: center;">Some transactions ({{walletAccount.pendingBelowThreshold[0] | rai: settings.settings.displayDenomination}} total) were hidden due to a Minimum Receive Amount of {{minAmount | rai: settings.settings.displayDenomination}} <a routerLink="/configure-app" routerLinkActive="active">(configure)</a></td>
             </tr>
             </tbody>
           </table>

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -49,6 +49,7 @@ export class SendComponent implements OnInit {
   toAddressBook = '';
   toAccountStatus = null;
   confirmingTransaction = false;
+  selAccountInit = false;
 
   constructor(
     private router: ActivatedRoute,
@@ -79,36 +80,43 @@ export class SendComponent implements OnInit {
     // Set default From account
     this.fromAccountID = this.accounts.length ? this.accounts[0].id : '';
 
+    // Update selected account if changed in the sidebar
+    this.walletService.wallet.selectedAccount$.subscribe(async acc => {
+      if (this.selAccountInit) {
+        if (acc) {
+          this.fromAccountID = acc.id;
+        } else {
+          this.findFirstAccount();
+        }
+      }
+      this.selAccountInit = true;
+    });
+
     // Set the account selected in the sidebar as default
     if (this.walletService.wallet.selectedAccount !== null) {
       this.fromAccountID = this.walletService.wallet.selectedAccount.id;
     } else {
       // If "total balance" is selected in the sidebar, use the first account in the wallet that has a balance
+      this.findFirstAccount();
+    }
+  }
 
-      // If the wallet balance is zero, this might be an initial load to the send page
-      // If it is, we want to load balances before we try to find the right account
-      if (this.walletService.wallet.balance.isZero()) {
-        await this.walletService.reloadBalances();
-      }
-
-      // Look for the first account that has a balance
-      const accountIDWithBalance = this.accounts.reduce((previous, current) => {
-        if (previous) return previous;
-        if (current.balance.gt(0)) return current.id;
-        return null;
-      }, null);
-
-      if (accountIDWithBalance) {
-        this.fromAccountID = accountIDWithBalance;
-      }
+  async findFirstAccount() {
+    // Load balances before we try to find the right account
+    if (this.walletService.wallet.balance.isZero()) {
+      await this.walletService.reloadBalances();
     }
 
-    // Update selected account if changed in the sidebar
-    this.walletService.wallet.selectedAccount$.subscribe(async acc => {
-      if (acc) {
-        this.fromAccountID = acc.id;
-      }
-    });
+    // Look for the first account that has a balance
+    const accountIDWithBalance = this.accounts.reduce((previous, current) => {
+      if (previous) return previous;
+      if (current.balance.gt(0)) return current.id;
+      return null;
+    }, null);
+
+    if (accountIDWithBalance) {
+      this.fromAccountID = accountIDWithBalance;
+    }
   }
 
   // An update to the Nano amount, sync the fiat value

--- a/src/app/components/sweeper/sweeper.component.ts
+++ b/src/app/components/sweeper/sweeper.component.ts
@@ -54,6 +54,7 @@ export class SweeperComponent implements OnInit {
   validStartIndex = true;
   validEndIndex = true;
   validMaxIncoming = true;
+  selAccountInit = false;
 
   @ViewChild('outputarea') logArea: ElementRef;
 
@@ -75,16 +76,18 @@ export class SweeperComponent implements OnInit {
     }
 
   async ngOnInit() {
+    // Update selected account if changed in the sidebar
+    this.walletService.wallet.selectedAccount$.subscribe(async acc => {
+      if (this.selAccountInit) {
+        this.myAccountModel = acc ? acc.id : (this.accounts.length > 0 ? this.accounts[0].id : '0');
+      }
+      this.selAccountInit = true;
+    });
+
     // Set the account selected in the sidebar as default
     if (this.walletService.wallet.selectedAccount !== null) {
       this.myAccountModel = this.walletService.wallet.selectedAccount.id;
     }
-    // Update selected account if changed in the sidebar
-    this.walletService.wallet.selectedAccount$.subscribe(async acc => {
-      if (acc) {
-        this.myAccountModel = acc.id;
-      }
-    });
   }
 
   sleep(ms) {

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -166,11 +166,11 @@ export class WalletService {
             this.appSettings.settings.minimumReceive
           );
         }
-
+        await this.processStateBlock(transaction);
       } else if (transaction.block.type === 'state') {
         shouldNotify = true;
+        await this.processStateBlock(transaction);
       }
-      await this.processStateBlock(transaction);
 
       // TODO: We don't really need to call to update balances, we should be able to balance on our own from here
       // I'm not sure about that because what happens if the websocket is disconnected and misses a transaction?

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -23,6 +23,7 @@ export interface WalletAccount {
   index: number;
   balance: BigNumber;
   pending: BigNumber;
+  pendingBelowThreshold: BigNumber[];
   balanceRaw: BigNumber;
   pendingRaw: BigNumber;
   balanceFiat: number;
@@ -56,6 +57,7 @@ export interface FullWallet {
   locked: boolean;
   password: string;
   pendingBlocks: Block[];
+  pendingBelowThreshold: BigNumber[];
 }
 
 export interface BaseApiAccount {
@@ -100,6 +102,7 @@ export class WalletService {
     locked: false,
     password: '',
     pendingBlocks: [],
+    pendingBelowThreshold: [new BigNumber(0)],
   };
 
   processingPending = false;
@@ -119,6 +122,7 @@ export class WalletService {
     this.websocket.newTransactions$.subscribe(async (transaction) => {
       if (!transaction) return; // Not really a new transaction
       console.log('New Transaction', transaction);
+      let shouldNotify = false;
 
       // Find out if this is a send, with our account as a destination or not
       const walletAccountIDs = this.wallet.accounts.map(a => a.id);
@@ -141,30 +145,39 @@ export class WalletService {
       } else if (transaction.block.type === 'state'
       && transaction.block.subtype === 'send'
       && walletAccountIDs.indexOf(transaction.block.link_as_account) !== -1) {
-        // Notify user if incoming is below threshold
         if (this.appSettings.settings.minimumReceive) {
           const minAmount = this.util.nano.mnanoToRaw(this.appSettings.settings.minimumReceive);
-          if ((new BigNumber(transaction.amount)).lt(minAmount)) {
-            this.notifications.sendWarning(`New incoming transaction below threshold detected`, { length: 10000, identifier: 'pending-locked' });
+          if ((new BigNumber(transaction.amount)).gte(minAmount)) {
+            shouldNotify = true;
           }
         } else {
+          shouldNotify = true;
+        }
+        if (shouldNotify) {
           if (this.wallet.locked && this.appSettings.settings.pendingOption !== 'manual') {
             this.notifications.sendWarning(`New incoming transaction - Unlock the wallet to receive`, { length: 10000, identifier: 'pending-locked' });
           } else if (this.appSettings.settings.pendingOption === 'manual') {
             this.notifications.sendWarning(`New incoming transaction - Set to be received manually`, { length: 10000, identifier: 'pending-locked' });
           }
+        } else {
+          console.log(
+            `Found new pending block that was below minimum receive amount: `,
+            transaction.amount,
+            this.appSettings.settings.minimumReceive
+          );
         }
 
-
-
-        await this.processStateBlock(transaction);
-
       } else if (transaction.block.type === 'state') {
-        await this.processStateBlock(transaction);
+        shouldNotify = true;
       }
+      await this.processStateBlock(transaction);
 
       // TODO: We don't really need to call to update balances, we should be able to balance on our own from here
-      await this.reloadBalances(false);
+      // I'm not sure about that because what happens if the websocket is disconnected and misses a transaction?
+      // won't the balance be incorrect if relying only on the websocket? / Json
+      if (shouldNotify) {
+        await this.reloadBalances(false);
+      }
     });
 
     this.addressBook.addressBook$.subscribe(newAddressBook => {
@@ -173,8 +186,6 @@ export class WalletService {
   }
 
   async processStateBlock(transaction) {
-    console.log('Processing state block', transaction);
-
     // If we have a minimum receive,  once we know the account... add the amount to wallet pending? set pending to true
     if (transaction.block.subtype === 'send' && transaction.block.link_as_account) {
       // This is an incoming send block, we want to perform a receive
@@ -184,26 +195,27 @@ export class WalletService {
       // Check for a min receive
       const txAmount = new BigNumber(transaction.amount);
 
-      if (this.wallet.pending.lte(0)) {
-        this.wallet.pending = this.wallet.pending.plus(txAmount);
-        this.wallet.pendingRaw = this.wallet.pendingRaw.plus(txAmount.mod(this.nano));
-        this.wallet.pendingFiat += this.util.nano.rawToMnano(txAmount).times(this.price.price.lastPrice).toNumber();
-        this.wallet.hasPending = true;
-      }
-
       if (this.appSettings.settings.minimumReceive) {
         const minAmount = this.util.nano.mnanoToRaw(this.appSettings.settings.minimumReceive);
 
         if (txAmount.gte(minAmount)) {
+          this.wallet.pending = this.wallet.pending.plus(txAmount);
+          this.wallet.pendingRaw = this.wallet.pendingRaw.plus(txAmount.mod(this.nano));
+          this.wallet.pendingFiat += this.util.nano.rawToMnano(txAmount).times(this.price.price.lastPrice).toNumber();
+          this.wallet.hasPending = true;
           this.addPendingBlock(walletAccount.id, transaction.hash, txAmount, transaction.account);
         } else {
-          console.log(
-            `Found new pending block that was below minimum receive amount: `,
-            transaction.amount,
-            this.appSettings.settings.minimumReceive
-          );
+          // The resons for using push and shift is to keep the reference when used in another component
+          this.wallet.pendingBelowThreshold.push(this.wallet.pendingBelowThreshold[0].plus(txAmount));
+          this.wallet.pendingBelowThreshold.shift();
+          walletAccount.pendingBelowThreshold.push(walletAccount.pendingBelowThreshold[0].plus(txAmount));
+          walletAccount.pendingBelowThreshold.shift();
         }
       } else {
+        this.wallet.pending = this.wallet.pending.plus(txAmount);
+        this.wallet.pendingRaw = this.wallet.pendingRaw.plus(txAmount.mod(this.nano));
+        this.wallet.pendingFiat += this.util.nano.rawToMnano(txAmount).times(this.price.price.lastPrice).toNumber();
+        this.wallet.hasPending = true;
         this.addPendingBlock(walletAccount.id, transaction.hash, txAmount, transaction.account);
       }
 
@@ -549,6 +561,7 @@ export class WalletService {
       keyPair: null,
       balance: new BigNumber(0),
       pending: new BigNumber(0),
+      pendingBelowThreshold: [new BigNumber(0)],
       balanceRaw: new BigNumber(0),
       pendingRaw: new BigNumber(0),
       balanceFiat: 0,
@@ -571,6 +584,7 @@ export class WalletService {
       keyPair: accountKeyPair,
       balance: new BigNumber(0),
       pending: new BigNumber(0),
+      pendingBelowThreshold: [new BigNumber(0)],
       balanceRaw: new BigNumber(0),
       pendingRaw: new BigNumber(0),
       balanceFiat: 0,
@@ -616,6 +630,8 @@ export class WalletService {
     this.wallet.selectedAccountId = null;
     this.wallet.selectedAccount = null;
     this.wallet.selectedAccount$ = new BehaviorSubject(null);
+    this.wallet.pendingBelowThreshold = [new BigNumber(0)];
+    this.wallet.pendingBlocks = [];
   }
 
   isConfigured() {
@@ -703,17 +719,13 @@ export class WalletService {
       walletAccount.pendingFiat = this.util.nano.rawToMnano(walletAccount.pending).times(fiatPrice).toNumber();
 
       walletAccount.frontier = frontiers.frontiers[accountID] || null;
+      walletAccount.pendingBelowThreshold = [new BigNumber(0)];
 
       walletBalance = walletBalance.plus(walletAccount.balance);
       walletPending = walletPending.plus(walletAccount.pending);
     }
 
     let hasPending = false;
-
-    // If this is just a normal reload.... do not use the minimum receive setting?
-    if (!reloadPending && walletPending.gt(0)) {
-      hasPending = true; // Temporary override? New incoming transaction on half reload? skip?
-    }
 
     // Check if there is a pending balance at all
     if (walletPending.gt(0)) {
@@ -739,10 +751,14 @@ export class WalletService {
                 accountPending = accountPending.plus(pending.blocks[block][hash].amount);
               }
               // Update the actual account pending amount with this above-threshold-value
+              walletAccount.pendingBelowThreshold.push(walletAccount.pending.minus(accountPending));
+              walletAccount.pendingBelowThreshold.shift();
               walletAccount.pending = accountPending;
               walletAccount.pendingRaw = accountPending.mod(this.nano);
               walletAccount.pendingFiat = this.util.nano.rawToMnano(accountPending).times(fiatPrice).toNumber();
             } else {
+              walletAccount.pendingBelowThreshold.push(walletAccount.pending);
+              walletAccount.pendingBelowThreshold.shift();
               walletAccount.pending = new BigNumber(0);
               walletAccount.pendingRaw = new BigNumber(0);
               walletAccount.pendingFiat = 0;
@@ -769,11 +785,20 @@ export class WalletService {
     this.wallet.balanceFiat = this.util.nano.rawToMnano(walletBalance).times(fiatPrice).toNumber();
     this.wallet.pendingFiat = this.util.nano.rawToMnano(walletPendingReal).times(fiatPrice).toNumber();
 
+    // Save pending that will be ignored, to be displayed to the user
+    // The resons for using push and shift is to keep the reference when used in another component
+    this.wallet.pendingBelowThreshold.push(walletPending.minus(walletPendingReal));
+    this.wallet.pendingBelowThreshold.shift();
+
     // tslint:disable-next-line
     this.wallet.hasPending = hasPending;
 
+    if (reloadPending) {
+      this.clearPendingBlocks();
+    }
+
     // If there is a pending balance, search for the actual pending transactions
-    if (reloadPending && walletPendingReal.gt(0)) {
+    if (reloadPending && walletPending.gt(0)) {
       await this.loadPendingBlocksForWallet();
     }
   }
@@ -791,6 +816,7 @@ export class WalletService {
       keyPair: null,
       balance: new BigNumber(0),
       pending: new BigNumber(0),
+      pendingBelowThreshold: [new BigNumber(0)],
       balanceRaw: new BigNumber(0),
       pendingRaw: new BigNumber(0),
       balanceFiat: 0,


### PR DESCRIPTION
- Track all small tx in the receive screen, updated live with total balance
- Send, Receive, Sweeper dropdown fallback to 1st if "total balance" is selected in the sidebar
- Removed custom notifcation on incoming "below threshold"
- No more RPC calls and reload balances when incoming "below threshold". Spam-safe

![image](https://user-images.githubusercontent.com/2406720/89869906-56cc1400-dbb5-11ea-8c78-fdcc6a3e9b05.png)
