### PR TITLE
fix(rep-widget): Reload reps when a new wallet is imported

### DIFF
--- a/src/app/components/change-rep-widget/change-rep-widget.component.ts
+++ b/src/app/components/change-rep-widget/change-rep-widget.component.ts
@@ -37,6 +37,18 @@ export class ChangeRepWidgetComponent implements OnInit {
       this.updateDisplayedRepresentatives();
     });
 
+    // Detect if a wallet is reset
+    this.walletService.wallet.newWallet$.subscribe(async bool => {
+      if (bool) {
+        console.log('Reloading representatives..');
+        this.representatives = await this.repService.getRepresentativesOverview();
+        this.selectedAccount = null;
+        this.updateDisplayedRepresentatives();
+        await this.repService.detectChangeableReps();
+        console.log('Representatives reloaded');
+      }
+    });
+
     await this.repService.detectChangeableReps();
 
     this.repService.changeableReps$.subscribe(async reps => {

--- a/src/app/components/change-rep-widget/change-rep-widget.component.ts
+++ b/src/app/components/change-rep-widget/change-rep-widget.component.ts
@@ -40,16 +40,9 @@ export class ChangeRepWidgetComponent implements OnInit {
     });
 
     // Detect if a wallet is reset
-    this.walletService.wallet.newWallet$.subscribe(async bool => {
-      if (bool) {
-        console.log('Reloading representatives..');
-        this.selectedAccount = null;
-        this.representatives = [];
-        this.changeableRepresentatives = [];
-        this.showRepChangeRequired = false;
-        this.updateDisplayedRepresentatives();
-        this.representatives = await this.repService.getRepresentativesOverview(); // calls walletReps$.next
-        console.log('Representatives reloaded');
+    this.walletService.wallet.newWallet$.subscribe(shouldReload => {
+      if (shouldReload) {
+        this.resetRepresentatives();
       }
     });
 
@@ -63,6 +56,17 @@ export class ChangeRepWidgetComponent implements OnInit {
 
       this.updateDisplayedRepresentatives();
     });
+  }
+
+  async resetRepresentatives() {
+    console.log('Reloading representatives..');
+    this.selectedAccount = null;
+    this.representatives = [];
+    this.changeableRepresentatives = [];
+    this.showRepChangeRequired = false;
+    this.updateDisplayedRepresentatives();
+    this.representatives = await this.repService.getRepresentativesOverview(); // calls walletReps$.next
+    console.log('Representatives reloaded');
   }
 
   async updateChangeableRepresentatives() {

--- a/src/app/components/change-rep-widget/change-rep-widget.component.ts
+++ b/src/app/components/change-rep-widget/change-rep-widget.component.ts
@@ -25,10 +25,12 @@ export class ChangeRepWidgetComponent implements OnInit {
 
   async ngOnInit() {
     this.representatives = await this.repService.getRepresentativesOverview();
+    await this.updateChangeableRepresentatives();
     this.updateDisplayedRepresentatives();
 
     this.repService.walletReps$.subscribe(async reps => {
       this.representatives = reps;
+      await this.updateChangeableRepresentatives();
       this.updateDisplayedRepresentatives();
     });
 
@@ -41,15 +43,15 @@ export class ChangeRepWidgetComponent implements OnInit {
     this.walletService.wallet.newWallet$.subscribe(async bool => {
       if (bool) {
         console.log('Reloading representatives..');
-        this.representatives = await this.repService.getRepresentativesOverview();
         this.selectedAccount = null;
+        this.representatives = [];
+        this.changeableRepresentatives = [];
+        this.showRepChangeRequired = false;
         this.updateDisplayedRepresentatives();
-        await this.repService.detectChangeableReps();
+        this.representatives = await this.repService.getRepresentativesOverview(); // calls walletReps$.next
         console.log('Representatives reloaded');
       }
     });
-
-    await this.repService.detectChangeableReps();
 
     this.repService.changeableReps$.subscribe(async reps => {
       // Includes both acceptable and bad reps
@@ -61,6 +63,10 @@ export class ChangeRepWidgetComponent implements OnInit {
 
       this.updateDisplayedRepresentatives();
     });
+  }
+
+  async updateChangeableRepresentatives() {
+    await this.repService.detectChangeableReps(this.representatives);
   }
 
   updateDisplayedRepresentatives() {

--- a/src/app/components/configure-wallet/configure-wallet.component.ts
+++ b/src/app/components/configure-wallet/configure-wallet.component.ts
@@ -106,7 +106,8 @@ export class ConfigureWalletComponent implements OnInit {
     this.activePanel = 4;
     this.notifications.sendSuccess(`Successfully imported wallet!`);
 
-    this.repService.detectChangeableReps();
+    // this.repService.detectChangeableReps(); // this is now called from change-rep-widget.component when new wallet
+    this.walletService.informNewWallet();
   }
 
   async importSingleKeyWallet() {
@@ -135,6 +136,7 @@ export class ConfigureWalletComponent implements OnInit {
 
     this.activePanel = 4;
     this.notifications.sendSuccess(`Successfully imported wallet!`);
+    this.walletService.informNewWallet();
   }
 
   async importLedgerWallet(refreshOnly = false) {
@@ -172,6 +174,8 @@ export class ConfigureWalletComponent implements OnInit {
     if (this.ledgerService.isBrokenBrowser()) {
       this.notifications.sendLedgerChromeWarning();
     }
+
+    this.walletService.informNewWallet();
   }
 
   // Send a confirmation dialog to the user if they already have a wallet configured

--- a/src/app/components/configure-wallet/configure-wallet.component.ts
+++ b/src/app/components/configure-wallet/configure-wallet.component.ts
@@ -215,6 +215,8 @@ export class ConfigureWalletComponent implements OnInit {
 
     this.activePanel = 3;
     this.notifications.sendSuccess(`Successfully created new wallet! Make sure to write down your seed!`);
+
+    this.walletService.informNewWallet();
   }
 
   confirmNewSeed() {

--- a/src/app/components/representatives/representatives.component.ts
+++ b/src/app/components/representatives/representatives.component.ts
@@ -323,13 +323,16 @@ export class RepresentativesComponent implements OnInit {
 
     this.notifications.sendSuccess(`Successfully updated representatives!`);
 
+    let useCachedReps = false;
+
     // If the overview panel is displayed, reload its data now
     if (!this.hideOverview) {
       this.representativeOverview = await this.representativeService.getRepresentativesOverview();
+      useCachedReps = true;
     }
 
     // Detect if any new reps should be changed
-    await this.representativeService.detectChangeableReps();
+    await this.representativeService.detectChangeableReps(useCachedReps ? this.representativeOverview : null);
   }
 
   // open qr reader modal

--- a/src/app/services/representative.service.ts
+++ b/src/app/services/representative.service.ts
@@ -80,8 +80,8 @@ export class RepresentativeService {
    * Determine if any accounts in the wallet need a rep change
    * @returns {Promise<FullRepresentativeOverview[]>}
    */
-  async detectChangeableReps(): Promise<FullRepresentativeOverview[]> {
-    const representatives = await this.getRepresentativesOverview();
+  async detectChangeableReps(cachedReps?: FullRepresentativeOverview[]): Promise<FullRepresentativeOverview[]> {
+    const representatives = cachedReps ? cachedReps : await this.getRepresentativesOverview();
 
     // Now based on some of their properties, we filter them out
     const needsChange = [];

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -58,6 +58,7 @@ export interface FullWallet {
   password: string;
   pendingBlocks: Block[];
   pendingBelowThreshold: BigNumber[];
+  newWallet$: BehaviorSubject<boolean|false>;
 }
 
 export interface BaseApiAccount {
@@ -103,6 +104,7 @@ export class WalletService {
     password: '',
     pendingBlocks: [],
     pendingBelowThreshold: [new BigNumber(0)],
+    newWallet$: new BehaviorSubject(false),
   };
 
   processingPending = false;
@@ -624,6 +626,8 @@ export class WalletService {
     this.wallet.accountsIndex = 0;
     this.wallet.balance = new BigNumber(0);
     this.wallet.pending = new BigNumber(0);
+    this.wallet.balanceRaw = new BigNumber(0);
+    this.wallet.pendingRaw = new BigNumber(0);
     this.wallet.balanceFiat = 0;
     this.wallet.pendingFiat = 0;
     this.wallet.hasPending = false;
@@ -1046,5 +1050,11 @@ export class WalletService {
           })
       )
     );
+  }
+
+  // Subscribable event when a new wallet is created
+  informNewWallet() {
+    this.wallet.newWallet$.next(true);
+    this.wallet.newWallet$.next(false);
   }
 }


### PR DESCRIPTION
-Subscribe to when a new wallet is created
-Reload reps accordingly

Fixes #150 

Is this a valid approach, or can it be made more simple? Tested and working for new seed, ledger or private key import. See the linked issue.