### PR TITLE
fix(pow): New default base threshold of fffffff800000000

### DIFF
--- a/src/app/components/sign/sign.component.ts
+++ b/src/app/components/sign/sign.component.ts
@@ -66,15 +66,12 @@ export class SignComponent implements OnInit {
   privateKeyExpanded = false; // if a private key is provided manually and it's expanded 128 char
   processedHash: string = null;
   finalSignature: string = null;
-  // TODO: These are based on the node v20 levels. With v21 the 8x will be the new 1x and max will be 8x due to the webgl threshold
+  // With v21 the 1x is the old 8x and max will be 8x due to the webgl threshold is max ffffffff00000000
   thresholds = [
     { name: '1x', value: 1 },
     { name: '2x', value: 2 },
     { name: '4x', value: 4 },
-    { name: '8x', value: 8 },
-    { name: '16x', value: 16 },
-    { name: '32x', value: 32 },
-    { name: '64x', value: 64 },
+    { name: '8x', value: 8 }
   ];
   selectedThreshold = this.thresholds[0].value;
   selectedThresholdOld = this.selectedThreshold;

--- a/src/app/services/pow.service.ts
+++ b/src/app/services/pow.service.ts
@@ -7,9 +7,7 @@ import Worker from 'worker-loader!./../../assets/lib/cpupow.js';
 import {UtilService} from './util.service';
 
 const mod = window['Module'];
-// NEW v21 THRESHOLD BELOW TO BE ACTIVATED
-// const baseThreshold = 'fffffff800000000'
-const baseThreshold = 'ffffffc000000000';
+const baseThreshold = 'fffffff800000000'; // threshold since v21 epoch update
 const hardwareConcurrency = window.navigator.hardwareConcurrency || 2;
 const workerCount = Math.max(hardwareConcurrency - 1, 1);
 let workerList = [];


### PR DESCRIPTION
Affective for cpuPoW and WebGl PoW
8x multiplier for all transactions

New desktop release will be needed as well to not invalidate transactions after the epoch upgrade has started.