### PR TITLE
fix(pow): Invalidate work cache with low threshold

### DIFF
--- a/src/app/services/pow.service.ts
+++ b/src/app/services/pow.service.ts
@@ -7,7 +7,7 @@ import Worker from 'worker-loader!./../../assets/lib/cpupow.js';
 import {UtilService} from './util.service';
 
 const mod = window['Module'];
-const baseThreshold = 'fffffff800000000'; // threshold since v21 epoch update
+export const baseThreshold = 'fffffff800000000'; // threshold since v21 epoch update
 const hardwareConcurrency = window.navigator.hardwareConcurrency || 2;
 const workerCount = Math.max(hardwareConcurrency - 1, 1);
 let workerList = [];

--- a/src/app/services/pow.service.ts
+++ b/src/app/services/pow.service.ts
@@ -164,6 +164,8 @@ export class PowService {
    * Actual PoW functions
    */
   async getHashServer(hash, multiplier) {
+    const newThreshold = this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold);
+    console.log('Generating work at threshold ' + newThreshold + ' using remote server', hash);
     return await this.api.workGenerate(hash)
     .then(work => work.work)
     .catch(async err => await this.getHashCPUWorker(hash, multiplier));

--- a/src/app/services/util.service.ts
+++ b/src/app/services/util.service.ts
@@ -75,6 +75,7 @@ export class UtilService {
     isValidIndex: isValidIndex,
     isValidSignature: isValidSignature,
     isValidWork: isValidWork,
+    validateWork: validateWork,
     difficultyFromMultiplier: difficultyFromMultiplier,
   };
   array = {
@@ -374,6 +375,10 @@ function isValidWork(val: string) {
   return nanocurrency.checkWork(val);
 }
 
+function validateWork(blockHash: string, threshold: string, work: string) {
+  return nanocurrency.validateWork({blockHash: blockHash, threshold: threshold, work: work});
+}
+
 function hashStateBlock(block: StateBlock) {
   const balance = new BigNumber(block.balance);
   if (balance.isNegative() || balance.isNaN()) {
@@ -492,6 +497,7 @@ const util = {
     isValidIndex: isValidIndex,
     isValidSignature: isValidSignature,
     isValidWork: isValidWork,
+    validateWork: validateWork,
     difficultyFromMultiplier: difficultyFromMultiplier,
   }
 };

--- a/src/app/services/work-pool.service.ts
+++ b/src/app/services/work-pool.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import {PowService} from './pow.service';
+import {PowService, baseThreshold} from './pow.service';
 import {NotificationService} from './notification.service';
 import {UtilService} from './util.service';
 
@@ -9,7 +9,6 @@ export class WorkPoolService {
 
   cacheLength = 25;
   workCache = [];
-  minThreshold = 'fffffff800000000';
 
   constructor(private pow: PowService, private notifications: NotificationService, private util: UtilService) { }
 
@@ -46,7 +45,7 @@ export class WorkPoolService {
   // Get work for a hash.  Uses the cache, or the current setting for generating it.
   public async getWork(hash, multiplier= 1) {
     const cached = this.workCache.find(p => p.hash === hash);
-    if (cached && cached.work && this.util.nano.validateWork(hash, this.minThreshold, cached.work)) {
+    if (cached && cached.work && this.util.nano.validateWork(hash, baseThreshold, cached.work)) {
       console.log('Using cached work: ' + cached.work);
       return cached.work;
     }


### PR DESCRIPTION
If old work cache is found but threshold is below new default,
Redo the work at new threshold
For example if someone load the desktop app a month from now, this will prevent their transactions to fail due to work being too low.