### PR TITLE
Fix "Unable to connect to the server" alert sometimes not displaying

### DIFF
--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -17,7 +17,9 @@ export class ApiService {
       return;
     }
     if (this.node.node.status === false) {
-      this.node.setLoading();
+      if (!skipError) {
+        this.node.setLoading();
+      }
     }
     let header;
     if (this.appSettings.settings.serverAuth != null && this.appSettings.settings.serverAuth !== '') {


### PR DESCRIPTION
`version` and `confirmation_quorum` requests change the node's state to `loading`, but they provide an argument `skipError` that's set to true, causing all failed requests to keep the state in `loading` rather than change it to `offline`