### PR TITLE
Mention support of Ledger Nano X

### DIFF
--- a/src/app/components/configure-wallet/configure-wallet.component.ts
+++ b/src/app/components/configure-wallet/configure-wallet.component.ts
@@ -30,7 +30,7 @@ export class ConfigureWalletComponent implements OnInit {
     { name: 'Nano Seed', value: 'seed' },
     { name: 'Nano Mnemonic Phrase', value: 'mnemonic' },
     { name: 'Nault Wallet File', value: 'file' },
-    { name: 'Ledger Nano S', value: 'ledger' },
+    { name: 'Ledger Nano S / Nano X', value: 'ledger' },
     { name: 'Private Key', value: 'privateKey' },
     { name: 'Expanded Private Key', value: 'expandedKey' },
   ];


### PR DESCRIPTION
seems Nano X works just as well as Nano S, so this change proposes renaming the dropdown entry from
`Ledger Nano S`
to
`Ledger Nano S / Nano X`