### PR TITLE
Representative status display fixes

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -113,7 +113,7 @@
                 </div>
               </div>
 
-              <ng-container *ngIf="(wallet.selectedAccount === null && walletService.hasPendingTransactions()) || wallet.selectedAccount !== null && wallet.selectedAccount.pending.gt(0)">
+              <ng-container *ngIf="(wallet.selectedAccount !== null) ? wallet.selectedAccount.pending.gt(0) : walletService.hasPendingTransactions()">
                 <ng-container *ngIf="walletService.processingPending else notProcessingPending">
                   <div class="nav-action-receive" *ngIf="walletService.processingPending">
                     <div class="icon" uk-icon="icon: chevron-up; ratio: 1.2;"></div>

--- a/src/app/components/change-rep-widget/change-rep-widget.component.ts
+++ b/src/app/components/change-rep-widget/change-rep-widget.component.ts
@@ -28,12 +28,6 @@ export class ChangeRepWidgetComponent implements OnInit {
     ) { }
 
   async ngOnInit() {
-    this.updateSelectedAccountHasRep();
-    this.representatives = await this.repService.getRepresentativesOverview();
-    await this.updateChangeableRepresentatives();
-    this.updateDisplayedRepresentatives();
-    this.initialLoadComplete = true;
-
     this.repService.walletReps$.subscribe(async reps => {
       this.representatives = reps;
       await this.updateChangeableRepresentatives();
@@ -55,7 +49,7 @@ export class ChangeRepWidgetComponent implements OnInit {
     // Detect if a new open block is received
     this.blockService.newOpenBlock$.subscribe(async shouldReload => {
       if (shouldReload) {
-        this.representatives = await this.repService.getRepresentativesOverview(); // calls walletReps$.next
+        await this.repService.getRepresentativesOverview(); // calls walletReps$.next
       }
     });
 
@@ -69,6 +63,11 @@ export class ChangeRepWidgetComponent implements OnInit {
 
       this.updateDisplayedRepresentatives();
     });
+
+    this.selectedAccount = this.walletService.wallet.selectedAccount;
+    this.updateSelectedAccountHasRep();
+    await this.repService.getRepresentativesOverview(); // calls walletReps$.next
+    this.initialLoadComplete = true;
   }
 
   async resetRepresentatives() {
@@ -78,7 +77,7 @@ export class ChangeRepWidgetComponent implements OnInit {
     this.changeableRepresentatives = [];
     this.showRepChangeRequired = false;
     this.updateDisplayedRepresentatives();
-    this.representatives = await this.repService.getRepresentativesOverview(); // calls walletReps$.next
+    await this.repService.getRepresentativesOverview(); // calls walletReps$.next
     console.log('Representatives reloaded');
   }
 

--- a/src/app/components/change-rep-widget/change-rep-widget.component.ts
+++ b/src/app/components/change-rep-widget/change-rep-widget.component.ts
@@ -29,9 +29,15 @@ export class ChangeRepWidgetComponent implements OnInit {
 
   async ngOnInit() {
     this.repService.walletReps$.subscribe(async reps => {
+      if ( reps[0] === null ) {
+        // initial state from new BehaviorSubject([null])
+        return;
+      }
+
       this.representatives = reps;
       await this.updateChangeableRepresentatives();
       this.updateDisplayedRepresentatives();
+      this.initialLoadComplete = true;
     });
 
     this.walletService.wallet.selectedAccount$.subscribe(async acc => {
@@ -67,11 +73,11 @@ export class ChangeRepWidgetComponent implements OnInit {
     this.selectedAccount = this.walletService.wallet.selectedAccount;
     this.updateSelectedAccountHasRep();
     await this.repService.getRepresentativesOverview(); // calls walletReps$.next
-    this.initialLoadComplete = true;
   }
 
   async resetRepresentatives() {
     console.log('Reloading representatives..');
+    this.initialLoadComplete = false;
     this.selectedAccount = null;
     this.representatives = [];
     this.changeableRepresentatives = [];

--- a/src/app/services/representative.service.ts
+++ b/src/app/services/representative.service.ts
@@ -58,7 +58,7 @@ export class RepresentativeService {
   representatives$ = new BehaviorSubject([]);
   representatives = [];
 
-  walletReps$ = new BehaviorSubject([]);
+  walletReps$ = new BehaviorSubject([null]);
   walletReps = [];
 
   changeableReps$ = new BehaviorSubject([]);
@@ -228,6 +228,7 @@ export class RepresentativeService {
     }
 
     this.walletReps = allReps;
+    console.log('done .next')
     this.walletReps$.next(allReps);
 
     return allReps;

--- a/src/app/services/representative.service.ts
+++ b/src/app/services/representative.service.ts
@@ -228,7 +228,6 @@ export class RepresentativeService {
     }
 
     this.walletReps = allReps;
-    console.log('done .next')
     this.walletReps$.next(allReps);
 
     return allReps;

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -622,7 +622,7 @@ export class WalletService {
     this.wallet.hasPending = false;
     this.wallet.selectedAccountId = null;
     this.wallet.selectedAccount = null;
-    this.wallet.selectedAccount$ = new BehaviorSubject(null);
+    this.wallet.selectedAccount$.next(null);
     this.wallet.pendingBelowThreshold = [new BigNumber(0)];
     this.wallet.pendingBlocks = [];
   }


### PR DESCRIPTION
fixes displayed rep not being the rep of active account on init (broken since active accounts are restored from the local storage)
fixes displayed rep not being the rep of active account after switching wallets
fixes "rep: None" state instead of "rep: Loading..." after switching wallets
simplifies logic a bit to avoid unnecessary calls