### PR TITLE
Add a "Missing accounts" hint on the Accounts page

### DIFF
--- a/src/app/components/accounts/accounts.component.css
+++ b/src/app/components/accounts/accounts.component.css
@@ -54,3 +54,24 @@
 		display: none;
 	}
 }
+
+.missing-accounts-hint {
+	background: #F2F7EB !important;
+	color: rgb(85, 121, 33);
+}
+
+.missing-accounts-hint .uk-icon {
+	vertical-align: 1px;
+}
+
+.missing-accounts-hint a {
+	text-decoration: none;
+	padding-bottom: 2px;
+	border-bottom: 2px dotted rgba(85, 121, 33, 0.6);
+	transition: border-color 100ms ease-in-out;
+}
+
+.missing-accounts-hint a:hover {
+	border-color: rgba(85, 121, 33, 1);
+	border-bottom-style: solid;
+}

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -75,8 +75,11 @@
             </div>
           </td>
         </tr>
-        <tr *ngIf="!(accounts).length">
-          <td colspan="4" style="text-align: center;">You don't have any accounts yet, <a (click)="createAccount()">click here to create one</a></td>
+        <tr *ngIf="!accounts.length">
+          <td colspan="4" style="text-align: center;">You don't have any accounts yet, <a (click)="createAccount()">click here to create one</a>.</td>
+        </tr>
+        <tr class="uk-alert uk-alert-primary missing-accounts-hint">
+          <td colspan="4" style="text-align: center;"><span uk-icon="icon: info"></span> Missing accounts? <a (click)="createAccount()">Add new account</a> to import a previously used address.</td>
         </tr>
         </tbody>
       </table>


### PR DESCRIPTION
after importing a wallet, users are often unable to find the accounts they used in another app, hopefully this hint helps

![image](https://user-images.githubusercontent.com/29272208/91098154-7dc42480-e650-11ea-81b7-e2eb68b7e8a7.png)
