### PR TITLE
Hide "Missing accounts" hint in private key mode

### DIFF
--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -78,7 +78,7 @@
         <tr *ngIf="!accounts.length">
           <td colspan="4" style="text-align: center;">You don't have any accounts yet, <a (click)="createAccount()">click here to create one</a>.</td>
         </tr>
-        <tr class="uk-alert uk-alert-primary missing-accounts-hint">
+        <tr class="uk-alert uk-alert-primary missing-accounts-hint" *ngIf="!isSingleKeyWallet">
           <td colspan="4" style="text-align: center;"><span uk-icon="icon: info"></span> Missing accounts? <a (click)="createAccount()">Add new account</a> to import a previously used address.</td>
         </tr>
         </tbody>

--- a/src/app/components/accounts/accounts.component.ts
+++ b/src/app/components/accounts/accounts.component.ts
@@ -19,6 +19,7 @@ import {
 export class AccountsComponent implements OnInit {
   accounts = this.walletService.wallet.accounts;
   isLedgerWallet = this.walletService.isLedgerWallet();
+  isSingleKeyWallet = this.walletService.isSingleKeyWallet();
   viewAdvanced = false;
   newAccountIndex = null;
 

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -645,6 +645,10 @@ export class WalletService {
     return this.wallet.type === 'ledger';
   }
 
+  isSingleKeyWallet() {
+    return (this.wallet.type === 'privateKey' || this.wallet.type === 'expandedKey');
+  }
+
   hasPendingTransactions() {
     return this.wallet.hasPending;
     // if (this.appSettings.settings.minimumReceive) {
@@ -853,11 +857,11 @@ export class WalletService {
 
     let newAccount: WalletAccount|null;
 
-    if (this.wallet.type === 'privateKey' || this.wallet.type === 'expandedKey') {
-      throw new Error(`Cannot add another account in private key mode`);
+    if (this.isSingleKeyWallet()) {
+      throw new Error(`Wallet consists of a single private key.`);
     } else if (this.wallet.type === 'seed') {
       newAccount = await this.createSeedAccount(index);
-    } else if (this.wallet.type === 'ledger') {
+    } else if (this.isLedgerWallet()) {
       try {
         newAccount = await this.createLedgerAccount(index);
       } catch (err) {


### PR DESCRIPTION
clearer message when attempting to add an account in private key mode
`Unable to add new account: Cannot add another account in private key mode`
->
`Unable to add new account: Wallet consists of a single private key.`

adds walletService.isSingleKeyWallet() which might be useful later for any UI tweaks exclusive to single key wallets