### PR TITLE
feat(wallet-export): All active account indexes instead of last index

### DIFF
--- a/src/app/components/configure-wallet/configure-wallet.component.ts
+++ b/src/app/components/configure-wallet/configure-wallet.component.ts
@@ -322,7 +322,7 @@ export class ConfigureWalletComponent implements OnInit {
       const fileData = event.target['result'] as string;
       try {
         const importData = JSON.parse(fileData);
-        if (!importData.seed || !importData.hasOwnProperty('accountsIndex')) {
+        if (!importData.seed || (!importData.hasOwnProperty('accountsIndex') && !importData.hasOwnProperty('indexes'))) {
           return this.notifications.sendError(`Bad import data `);
         }
 

--- a/src/app/components/import-wallet/import-wallet.component.ts
+++ b/src/app/components/import-wallet/import-wallet.component.ts
@@ -61,8 +61,12 @@ export class ImportWalletComponent implements OnInit {
 
       this.router.navigate(['accounts']); // load accounts and watch them update in real-time
       this.notifications.sendInfo(`Loading all accounts for the wallet...`);
-      await this.walletService.loadImportedWallet(decryptedSeed, this.walletPassword, this.importData.accountsIndex || 0);
-      this.notifications.sendSuccess(`Successfully imported the wallet!`, {length: 10000});
+      if (await this.walletService.loadImportedWallet(decryptedSeed, this.walletPassword,
+        this.importData.accountsIndex || 0, this.importData.indexes || null)) {
+          this.notifications.sendSuccess(`Successfully imported the wallet!`, {length: 10000});
+      } else {
+        return this.notifications.sendError(`Failed importing the wallet. Invalid data!`);
+      }
 
     } catch (err) {
       this.walletPassword = '';

--- a/src/app/components/manage-wallet/manage-wallet.component.html
+++ b/src/app/components/manage-wallet/manage-wallet.component.html
@@ -68,10 +68,10 @@
                 </div>
               </div>
 
-              <div class="uk-width-1-2@s uk-width-1-4@m">
+              <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
                 <img [src]="QRExportImg" alt="QR code">
               </div>
-              <div class="uk-width-1-2@s uk-width-3-4@m">
+              <div class="uk-width-1-1@s uk-width-1-2@m uk-width-2-3@l">
                 <br>
                 Scan the QR code on any device to import your Nault wallet!<br>
                 <br>

--- a/src/app/components/manage-wallet/manage-wallet.component.ts
+++ b/src/app/components/manage-wallet/manage-wallet.component.ts
@@ -63,7 +63,7 @@ export class ManageWalletComponent implements OnInit {
 
     const exportUrl = this.walletService.generateExportUrl();
     this.QRExportUrl = exportUrl;
-    this.QRExportImg = await QRCode.toDataURL(exportUrl);
+    this.QRExportImg = await QRCode.toDataURL(exportUrl, { errorCorrectionLevel: 'M', scale: 8 });
     this.showQRExport = true;
   }
 

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -267,7 +267,7 @@ export class WalletService {
     }
 
     if (walletJson.accounts && walletJson.accounts.length) {
-        walletJson.accounts.forEach(account => this.loadWalletAccount(account.index, account.id));
+      walletJson.accounts.forEach(account => this.loadWalletAccount(account.index, account.id));
     }
 
     this.wallet.selectedAccountId = walletJson.selectedAccountId || null;


### PR DESCRIPTION
- Allow import of accounts 1,2,7,555
- Before, it would import 0 to 7
- Increased the QR size a little bit because if user have 100 accounts, more info needs to be encoded
- Backward compatible
- Fixes 184

**Old json:**
{"accountsIndex":4,"seed":"xyz"}

**New json:**
{"indexes":[0,1,2,3,500],"seed":"xyz"}