### PR TITLE
refactor(address-book): Move import/export away from manage wallet

### DIFF
--- a/src/app/components/address-book/address-book.component.html
+++ b/src/app/components/address-book/address-book.component.html
@@ -3,7 +3,10 @@
     
     <div class="uk-margin-bottom" uk-grid>
       <div class="uk-width-expand@s uk-width-1-1">
-        <h2 class="uk-heading-divider">Address Book</h2>
+        <h2 class="uk-heading-divider">
+          Address Book
+          <a (click)="activePanel =  activePanel === 0 ? 2 : 0;" style="font-size: 12px; margin-left: 25px;">{{ activePanel === 2 ? 'ADDRESS BOOK' : 'IMPORT / EXPORT' }}</a>
+        </h2>
       </div>
       <div class="uk-width-auto@s uk-width-1-1 uk-text-right">
         <button class="uk-button uk-button-secondary uk-align-right uk-width-auto@s" (click)="activePanel = 1;">Add New Contact</button>
@@ -16,7 +19,7 @@
       </p>
     </div>
 
-    <div class="uk-animation-slide-left-small" *ngIf="activePanel == 0" uk-grid>
+    <div class="uk-animation-slide-left-small" *ngIf="activePanel === 0" uk-grid>
       <div class="uk-width-1-1">
         <div class="uk-card uk-margin">
 
@@ -71,11 +74,11 @@
       </div>
     </div>
 
-    <div class="uk-animation-slide-left-small" *ngIf="activePanel == 1" uk-grid>
+    <div class="uk-animation-slide-left-small" *ngIf="activePanel === 1" uk-grid>
       <div class="uk-width-1-1">
         <div class="uk-card uk-card-default">
           <div class="uk-card-header">
-            <h2 class="uk-card-title">Create New Contact</h2>
+            <h2 class="uk-card-title">Add New Contact</h2>
           </div>
           <div class="uk-card-body">
             <div class="uk-form-horizontal">
@@ -106,6 +109,44 @@
                 <button class="uk-button uk-button-primary uk-width-1-1" (click)="saveNewAddress()">Save New Contact</button>
               </div>
             </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="uk-animation-slide-left-small" *ngIf="activePanel === 2" uk-grid>
+      <div class="uk-width-1-1">
+        <div class="uk-card uk-card-default">
+          <div class="uk-card-header">
+            <h3 class="uk-card-title">Import / Export</h3>
+          </div>
+          <div class="uk-card-body">
+            Use this tool to simplify transferring your address book between devices.  Use the options below to import or export your
+            address book from a file or QR Code/URL.  Your address book is NOT encrypted by your wallet password.
+            <div *ngIf="addressBookShowQRExport" uk-grid>
+              <div class="uk-width-1-1">
+                <hr class="uk-divider-icon">
+              </div>
+
+              <div class="uk-width-1-2@s uk-width-1-4@m">
+                <img [src]="addressBookQRExportImg" alt="QR code">
+              </div>
+              <div class="uk-width-1-2@s uk-width-3-4@m">
+                Scan the QR code on any device to import your Nault Address Book!<br>
+                <br>
+                If you do not have a QR code scanner, you can also import your address book by using the URL below.<br>
+                <input type="text" class="uk-input" value="{{ addressBookQRExportUrl }}"><br>
+                <a title="Copy Export URL To Clipboard" ngxClipboard [cbContent]="addressBookQRExportUrl" (cbOnSuccess)="notifications.sendSuccess('Address book export copied to clipboard!')" uk-tooltip>Copy to clipboard</a>
+              </div>
+            </div>
+          </div>
+          <div class="uk-card-footer uk-text-right@s uk-text-center nlt-button-group">
+            <div class="js-upload uk-text-left uk-width-auto@s uk-width-1-1" style="display: inline-block;" uk-form-custom>
+              <input type="file" id="import-from-file" (change)="importFromFile($event.target.files)" multiple>
+              <button class="uk-button uk-button-primary uk-width-auto@s uk-width-1-1" type="button" tabindex="-1">Import Address Book</button>
+            </div>
+            <button (click)="exportAddressBookToFile()" class="uk-button uk-button-secondary uk-width-auto@s uk-width-1-1">Export As File</button>
+            <button (click)="exportAddressBook()" class="uk-button uk-button-secondary uk-width-auto@s uk-width-1-1">Export As QR Code / URL</button>
           </div>
         </div>
       </div>

--- a/src/app/components/import-address-book/import-address-book.component.html
+++ b/src/app/components/import-address-book/import-address-book.component.html
@@ -74,18 +74,5 @@
       </div>
     </div>
 
-    <div class="uk-card uk-card-default uk-margin" *ngIf="activePanel == 'imported'">
-      <div class="uk-card-header">
-        <h3 class="uk-card-title">Address Book Imported</h3>
-      </div>
-      <div class="uk-card-body">
-        <p>Your address book has been successfully imported!</p>
-      </div>
-      <div class="uk-card-footer uk-text-right">
-        <button routerLink="/address-book" class="uk-button uk-button-secondary">View Address Book</button>
-      </div>
-    </div>
-
-
   </div>
 </div>

--- a/src/app/components/import-address-book/import-address-book.component.ts
+++ b/src/app/components/import-address-book/import-address-book.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import {NotificationService} from '../../services/notification.service';
 import {ActivatedRoute} from '@angular/router';
 import {AddressBookService} from '../../services/address-book.service';
+import {Router} from '@angular/router';
 
 @Component({
   selector: 'app-import-address-book',
@@ -19,7 +20,11 @@ export class ImportAddressBookComponent implements OnInit {
   existingEntries = 0;
   hostname = '';
 
-  constructor(private route: ActivatedRoute, private notifications: NotificationService, private addressBook: AddressBookService) { }
+  constructor(
+    private route: ActivatedRoute,
+    private notifications: NotificationService,
+    private addressBook: AddressBookService,
+    private router: Router) { }
 
   ngOnInit() {
     const importData = this.route.snapshot.fragment;
@@ -73,8 +78,8 @@ export class ImportAddressBookComponent implements OnInit {
       }
     }
 
+    this.router.navigate(['address-book']);
     this.notifications.sendSuccess(`Successfully imported ${importedCount} address book entries`);
-    this.activePanel = 'imported';
   }
 
   importDataError(message) {

--- a/src/app/components/manage-wallet/manage-wallet.component.html
+++ b/src/app/components/manage-wallet/manage-wallet.component.html
@@ -97,39 +97,5 @@
       </ng-template>
     </div>
 
-    <div class="uk-card uk-card-default uk-margin">
-      <div class="uk-card-header">
-        <h3 class="uk-card-title">Nault Address Book</h3>
-      </div>
-      <div class="uk-card-body">
-        Use this tool to simplify transferring your address book between devices.  Use the options below to import or export your
-        address book from a file or QR Code/URL.  Your address book is not encrypted by your wallet password.
-        <div *ngIf="addressBookShowQRExport" uk-grid>
-          <div class="uk-width-1-1">
-            <hr class="uk-divider-icon">
-          </div>
-
-          <div class="uk-width-1-2@s uk-width-1-4@m">
-            <img [src]="addressBookQRExportImg" alt="QR code">
-          </div>
-          <div class="uk-width-1-2@s uk-width-3-4@m">
-            Scan the QR code on any device to import your Nault Address Book!<br>
-            <br>
-            If you do not have a QR code scanner, you can also import your address book by using the URL below.<br>
-            <input type="text" class="uk-input" value="{{ addressBookQRExportUrl }}"><br>
-            <a title="Copy Export URL To Clipboard" ngxClipboard [cbContent]="addressBookQRExportUrl" (cbOnSuccess)="notifications.sendSuccess('Address book export copied to clipboard!')" uk-tooltip>Copy to clipboard</a>
-          </div>
-        </div>
-      </div>
-      <div class="uk-card-footer uk-text-right@s uk-text-center nlt-button-group">
-        <div class="js-upload uk-text-left uk-width-auto@s uk-width-1-1" style="display: inline-block;" uk-form-custom>
-          <input type="file" id="import-from-file" (change)="importFromFile($event.target.files)" multiple>
-          <button class="uk-button uk-button-primary uk-width-auto@s uk-width-1-1" type="button" tabindex="-1">Import Address Book</button>
-        </div>
-        <button (click)="exportAddressBookToFile()" class="uk-button uk-button-secondary uk-width-auto@s uk-width-1-1">Export As File</button>
-        <button (click)="exportAddressBook()" class="uk-button uk-button-secondary uk-width-auto@s uk-width-1-1">Export As QR Code / URL</button>
-      </div>
-    </div>
-
   </div>
 </div>

--- a/src/app/components/manage-wallet/manage-wallet.component.ts
+++ b/src/app/components/manage-wallet/manage-wallet.component.ts
@@ -2,8 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import {WalletService} from '../../services/wallet.service';
 import {NotificationService} from '../../services/notification.service';
 import * as QRCode from 'qrcode';
-import {AddressBookService} from '../../services/address-book.service';
-import {Router} from '@angular/router';
 import * as bip from 'bip39';
 
 @Component({
@@ -21,15 +19,10 @@ export class ManageWalletComponent implements OnInit {
   showQRExport = false;
   QRExportUrl = '';
   QRExportImg = '';
-  addressBookShowQRExport = false;
-  addressBookQRExportUrl = '';
-  addressBookQRExportImg = '';
 
   constructor(
     public walletService: WalletService,
-    private addressBookService: AddressBookService,
-    public notifications: NotificationService,
-    private router: Router) { }
+    public notifications: NotificationService) { }
 
   async ngOnInit() {
     this.wallet = this.walletService.wallet;
@@ -77,31 +70,6 @@ export class ManageWalletComponent implements OnInit {
     }
   }
 
-  async exportAddressBook() {
-    const exportData = this.addressBookService.addressBook;
-    if (exportData.length >= 25) {
-      return this.notifications.sendError(`Address books with 25 or more entries need to use the file export method.`);
-    }
-    const base64Data = btoa(JSON.stringify(exportData));
-    const exportUrl = `https://nault.cc/import-address-book#${base64Data}`;
-
-    this.addressBookQRExportUrl = exportUrl;
-    this.addressBookQRExportImg = await QRCode.toDataURL(exportUrl);
-    this.addressBookShowQRExport = true;
-  }
-
-  exportAddressBookToFile() {
-    if (this.walletService.walletIsLocked()) {
-      return this.notifications.sendWarning(`Wallet must be unlocked`);
-    }
-    const fileName = `Nault-AddressBook.json`;
-
-    const exportData = this.addressBookService.addressBook;
-    this.triggerFileDownload(fileName, exportData);
-
-    this.notifications.sendSuccess(`Address book export downloaded!`);
-  }
-
   triggerFileDownload(fileName, exportData) {
     const blob = new Blob([JSON.stringify(exportData)], { type: 'application/json' });
 
@@ -138,31 +106,6 @@ export class ManageWalletComponent implements OnInit {
     this.triggerFileDownload(fileName, exportData);
 
     this.notifications.sendSuccess(`Wallet export downloaded!`);
-  }
-
-  importFromFile(files) {
-    if (!files.length) {
-      return;
-    }
-
-    const file = files[0];
-    const reader = new FileReader();
-    reader.onload = (event) => {
-      const fileData = event.target['result'] as string;
-      try {
-        const importData = JSON.parse(fileData);
-        if (!importData.length || !importData[0].account) {
-          return this.notifications.sendError(`Bad import data, make sure you selected a Nault Address Book export`);
-        }
-
-        const walletEncrypted = btoa(JSON.stringify(importData));
-        this.router.navigate(['import-address-book'], { fragment: walletEncrypted });
-      } catch (err) {
-        this.notifications.sendError(`Unable to parse import data, make sure you selected the right file!`);
-      }
-    };
-
-    reader.readAsText(file);
   }
 
 }


### PR DESCRIPTION
Now as a subview of the address book view

- Importing entries directly navigates back to address book
- Not needed to unlock wallet to export address book
- Fixes #175

![image](https://user-images.githubusercontent.com/2406720/92325441-2314ca80-f04b-11ea-978e-619a2d3d802b.png)
![image](https://user-images.githubusercontent.com/2406720/92325443-2a3bd880-f04b-11ea-80f3-8d9ddfb72aa5.png)
