### PR TITLE
Improve style of account labels and nano addresses

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -19,7 +19,7 @@
       <div class="account active" *ngIf="wallet.selectedAccount !== null"> <!-- active nano_ account -->
         <div class="name-column">
           <div class="name">{{ wallet.selectedAccount.addressBookName ? wallet.selectedAccount.addressBookName : ('Account #' + wallet.selectedAccount.index) }}</div>
-          <div class="address">{{ wallet.selectedAccount.id }}</div>
+          <div class="address nano-address-monospace">{{ wallet.selectedAccount.id }}</div>
         </div>
         <div class="balance-column">
           <div class="balance primary">{{ wallet.selectedAccount.balance | rai: settings.settings.displayDenomination }}</div>
@@ -40,7 +40,7 @@
         <div class="account inactive" (click)="selectAccount(account)" *ngIf="( (wallet.selectedAccount === null) || (wallet.selectedAccount.id !== account.id) )">
           <div class="name-column">
             <div class="name">{{ account.addressBookName ? account.addressBookName : ('Account #' + account.index) }}</div>
-            <div class="address">{{ account.id }}</div>
+            <div class="address nano-address-monospace">{{ account.id }}</div>
           </div>
           <div class="balance-column">
             <div class="balance primary">

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -1,3 +1,7 @@
+.nano-address-actions {
+    margin-top: 2px;
+}
+
 .block-qr {
     margin:auto;
     width: 100%;

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -33,7 +33,7 @@
                     </div>
                   </div>
                   <div uk-grid>
-                    <div class="uk-width-auto uk-text-small uk-text-truncate" style="max-width: calc(100% - 35px);">
+                    <div class="nano-address-monospace uk-width-auto uk-text-small uk-text-truncate" style="max-width: calc(100% - 35px);">
                       <app-nano-account-id [accountID]="accountID"></app-nano-account-id>
                     </div>
                     <div class="uk-width-auto" style="padding-left: 10px; margin-top: -3px;">
@@ -44,7 +44,7 @@
 
                 <div *ngIf="!addressBookEntry && !walletAccount">
                   <div uk-grid>
-                    <h3 class="uk-width-auto uk-card-title uk-text-truncate" style="max-width: calc(100% - 80px);">
+                    <h3 class="nano-address-monospace uk-width-auto uk-card-title uk-text-truncate" style="max-width: calc(100% - 80px);">
                       <app-nano-account-id [accountID]="accountID"></app-nano-account-id>
                     </h3>
                     <div class="uk-width-auto">
@@ -134,7 +134,7 @@
                     </div>
                     <div *ngIf="!showEditRepresentative">
                       <div uk-grid>
-                        <div class="uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
+                        <div class="nano-address-monospace uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
                           <span *ngIf="repLabel" class="uk-label uk-label-danger">{{ repLabel }}</span> 
                           <app-nano-account-id [accountID]="!account ? '':account.representative"></app-nano-account-id>
                         </div>
@@ -203,12 +203,14 @@
                 <td class="uk-visible-toggle">
                   <div uk-grid>
                     <div class="uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
-                      <a [routerLink]="'/account/' + pending.account" class="uk-link-text" title="View Account Details" uk-tooltip>
-                        <span *ngIf="pending.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ pending.addressBookName }}</span> 
-                        <app-nano-account-id [accountID]="pending.account" middle="off"></app-nano-account-id>
+                      <a [routerLink]="'/account/' + pending.account" class="account-container uk-link-text" title="View Account Details" uk-tooltip>
+                        <span *ngIf="pending.addressBookName" class="account-label uk-margin-small-right">{{ pending.addressBookName }}</span>
+                        <span class="nano-address-clickable nano-address-monospace">
+                          <app-nano-account-id [accountID]="pending.account" middle="off"></app-nano-account-id>
+                        </span>
                       </a>
                     </div>
-                    <div class="uk-width-auto" style="padding-left: 10px;">
+                    <div class="nano-address-actions uk-width-auto">
                       <ul class="uk-iconnav">
                         <li><a ngxClipboard [cbContent]="pending.account" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                       </ul>
@@ -228,12 +230,14 @@
                 <td class="uk-visible-toggle">
                   <div uk-grid>
                     <div class="uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
-                      <a [routerLink]="'/account/' + (history.link_as_account || history.account)" class="uk-link-text" title="View Account Details" uk-tooltip>
-                        <span *ngIf="history.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ history.addressBookName }}</span> 
-                        <app-nano-account-id [accountID]="history.link_as_account || history.account" middle="off"></app-nano-account-id>
+                      <a [routerLink]="'/account/' + (history.link_as_account || history.account)" class="account-container uk-link-text" title="View Account Details" uk-tooltip>
+                        <span *ngIf="history.addressBookName" class="account-label uk-margin-small-right">{{ history.addressBookName }}</span>
+                        <span class="nano-address-clickable nano-address-monospace">
+                          <app-nano-account-id [accountID]="history.link_as_account || history.account" middle="off"></app-nano-account-id>
+                        </span>
                       </a>
                     </div>
-                    <div class="uk-width-auto" style="padding-left: 10px;">
+                    <div class="nano-address-actions uk-width-auto">
                       <ul class="uk-iconnav">
                         <li><a ngxClipboard [cbContent]="history.link_as_account || history.account" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                       </ul>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -217,7 +217,7 @@
                     </div>
                   </div>
                 </td>
-                <td class="uk-text-muted">
+                <td class="uk-text-muted" title="Incoming Transaction">
                   +{{ pending.amount | rai: settings.settings.displayDenomination }}*
                 </td>
                 <td class="uk-text-truncate"><a [routerLink]="'/transaction/' + pending.hash" class="uk-link-text" title="View Block Details" uk-tooltip>{{ pending.hash }}</a></td>
@@ -268,7 +268,7 @@
       </div>
     </div>
 
-    <div class="uk-width-1-1 uk-text-center uk-text-muted uk-text-small" *ngIf="pendingBlocks.length">
+    <div class="uk-width-1-1 uk-text-center uk-text-muted uk-text-small uk-margin-medium-bottom" *ngIf="pendingBlocks.length">
       * Incoming Transaction
     </div>
 

--- a/src/app/components/accounts/accounts.component.css
+++ b/src/app/components/accounts/accounts.component.css
@@ -14,12 +14,15 @@
 
 .copy-icons {
 	align-self: end;
-	margin-bottom: 3px;
 }
 
 .account-amounts-column {
 	white-space: nowrap;
 	vertical-align: middle;
+}
+
+.account-container:hover .nano-address-clickable {
+	border-color: transparent;
 }
 
 .account-container .account-label {

--- a/src/app/components/accounts/accounts.component.css
+++ b/src/app/components/accounts/accounts.component.css
@@ -1,27 +1,33 @@
-.account-index {
-  margin-right: 5px;
+.account-container.narrow {
+	max-width: calc(100% - 35px);
 }
 
-.account-index:hover {
-  color: #333;
-}
-
-.account-container {
-  max-width: calc(100% - 35px);
-}
-
-.account-container-wide {
-  max-width: calc(100% - 100px);
+.account-container.wide {
+	max-width: calc(100% - 100px);
 }
 
 .copy-container {
-  padding-left: 10px;
-  padding-bottom: 3px;
-  display: grid;
+	padding-left: 10px;
+	padding-bottom: 3px;
+	display: grid;
 }
 
 .copy-icons {
-  align-self: end;
+	align-self: end;
+	margin-bottom: 3px;
+}
+
+.account-amounts-column {
+	white-space: nowrap;
+	vertical-align: middle;
+}
+
+.account-container .account-label {
+	margin-bottom: 3px;
+}
+
+.account-amounts-column .account-amounts-primary {
+	margin-bottom: 3px;
 }
 
 .incoming-label {

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -37,16 +37,16 @@
         <tr *ngFor="let account of accounts" class="uk-visible-toggle">
           <td class="uk-visible-toggle uk-text-truncate">
             <div uk-grid>
-              <div [class]="[ 'uk-width-auto', 'uk-text-truncate', !isLedgerWallet ? 'account-container' : 'account-container-wide' ]">
+              <a [routerLink]="'/account/' + account.id" [class]="[ 'uk-width-auto', 'uk-text-truncate', 'account-container', !isLedgerWallet ? 'narrow' : 'wide' ]">
                 <div class="uk-width-1-1">
-                  <a class="uk-label uk-label-default account-index" [routerLink]="'/account/' + account.id" title="View Account Details" uk-tooltip>
+                  <div class="account-label" >
                     {{ account.addressBookName ? account.addressBookName : 'Account #' + account.index }}
-                  </a>
+                  </div>
                 </div>
-                <a [routerLink]="'/account/' + account.id" class="uk-link-text" title="View Account Details" uk-tooltip>
+                <div class="nano-address-clickable nano-address-monospace">
                   <app-nano-account-id [accountID]="account.id" middle="on"></app-nano-account-id>
-                </a>
-              </div>
+                </div>
+              </a>
               <div class="uk-width-auto copy-container">
                 <ul class="uk-iconnav copy-icons">
                   <li><a ngxClipboard [cbContent]="account.id" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
@@ -55,8 +55,8 @@
               </div>
             </div>
           </td>
-          <td class="uk-text-right" style="white-space: nowrap;">
-            <div class="uk-width-1-1">
+          <td class="account-amounts-column uk-text-right">
+            <div class="account-amounts-primary uk-width-1-1">
               <div *ngIf="account.pending.gt(0)" class="incoming-label">
                 <div class="text-snippet">New</div>
                 <div class="text-full">+{{ account.pending | rai: settings.settings.displayDenomination + ',true' }}</div>
@@ -84,8 +84,6 @@
         </tbody>
       </table>
     </div>
-
-    <p class="uk-text-center uk-text-small">Click on an account to view more details!</p>
 
   </div>
 </div>

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -39,7 +39,7 @@
             <div uk-grid>
               <a [routerLink]="'/account/' + account.id" [class]="[ 'uk-width-auto', 'uk-text-truncate', 'account-container', !isLedgerWallet ? 'narrow' : 'wide' ]">
                 <div class="uk-width-1-1">
-                  <div class="account-label" >
+                  <div class="account-label">
                     {{ account.addressBookName ? account.addressBookName : 'Account #' + account.index }}
                   </div>
                 </div>

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -47,7 +47,7 @@
                   <app-nano-account-id [accountID]="account.id" middle="on"></app-nano-account-id>
                 </div>
               </a>
-              <div class="uk-width-auto copy-container">
+              <div class="nano-address-actions uk-width-auto copy-container">
                 <ul class="uk-iconnav copy-icons">
                   <li><a ngxClipboard [cbContent]="account.id" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                   <li *ngIf="isLedgerWallet"><a uk-icon="icon: commenting" title="Confirm Address On Ledger" (click)="showLedgerAddress(account)" uk-tooltip></a></li>

--- a/src/app/components/address-book/address-book.component.css
+++ b/src/app/components/address-book/address-book.component.css
@@ -1,0 +1,7 @@
+.nano-address-actions {
+    margin-top: 2px;
+}
+
+.edit-name-icon {
+	margin-top: 3px;
+}

--- a/src/app/components/address-book/address-book.component.html
+++ b/src/app/components/address-book/address-book.component.html
@@ -38,10 +38,11 @@
               <div uk-grid>
                 <div class="uk-width-2-5 uk-text-truncate uk-visible-toggle">
                   <div uk-grid>
-                    <div class="uk-width-expand uk-text-truncate">
-                      <a (click)="editEntry(addressBook)" class="uk-link-text" title="Edit Account Label" uk-tooltip>{{ addressBook.name }}</a>
+                    <div class="uk-width-expand uk-text-truncate uk-margin-small-right">
+                      {{ addressBook.name }}
                     </div>
-                    <ul class="uk-iconnav uk-width-auto" style="padding-left: 0;">
+                    <ul class="uk-iconnav uk-width-auto">
+                      <li><a (click)="editEntry(addressBook)" title="Edit Account Label" uk-tooltip uk-icon="icon: pencil;" class="edit-name-icon"></a></li>
                       <li><span class="uk-sortable-handle uk-margin-small-right" uk-icon="icon: table"></span></li>
                     </ul>
                   </div>
@@ -49,11 +50,11 @@
                 <div class="uk-width-expand uk-text-truncate uk-visible-toggle">
                   <div uk-grid>
                     <div class="uk-width-expand uk-text-truncate">
-                      <a [routerLink]="'/account/' + addressBook.account" class="uk-link-text uk-display-block" title="View Account Details" uk-tooltip>
+                      <a [routerLink]="'/account/' + addressBook.account" class="nano-address-clickable nano-address-monospace uk-display-block" title="View Account Details" uk-tooltip>
                         <app-nano-account-id [accountID]="addressBook.account"></app-nano-account-id>
                       </a>
                     </div>
-                    <ul class="uk-iconnav" style="padding-left: 10px;">
+                    <ul class="nano-address-actions uk-iconnav">
                       <li><a ngxClipboard [cbContent]="addressBook.account" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                     </ul>
                   </div>

--- a/src/app/components/manage-representatives/manage-representatives.component.css
+++ b/src/app/components/manage-representatives/manage-representatives.component.css
@@ -1,3 +1,7 @@
+.nano-address-actions {
+    margin-top: 2px;
+}
+
 .circle:before {
   content: ' \25CF';
   font-size: 16px;

--- a/src/app/components/manage-representatives/manage-representatives.component.html
+++ b/src/app/components/manage-representatives/manage-representatives.component.html
@@ -50,11 +50,11 @@
                 <div class="uk-width-expand uk-text-truncate uk-visible-toggle">
                   <div uk-grid>
                     <div class="uk-width-expand uk-text-truncate">
-                      <a [routerLink]="'/account/' + representative.id" class="uk-link-text uk-display-block" title="View Account Details" uk-tooltip>
+                      <a [routerLink]="'/account/' + representative.id" class="nano-address-clickable nano-address-monospace uk-display-block" title="View Account Details" uk-tooltip>
                         <app-nano-account-id [accountID]="representative.id"></app-nano-account-id>
                       </a>
                     </div>
-                    <ul class="uk-iconnav" style="padding-left: 0;">
+                    <ul class="nano-address-actions uk-iconnav">
                       <li><a ngxClipboard [cbContent]="representative.id" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                     </ul>
                   </div>

--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -1,3 +1,7 @@
+.nano-address-actions {
+    margin-top: 2px;
+}
+
 .narrow-div {
     margin-top: 20px;
 }

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -32,7 +32,7 @@
       <div *ngIf="qrCodeImage" class="uk-width-1-1@s narrow-div">
         <img [src]="qrCodeImage" alt="QR code"><br>
         <div class="uk-flex">
-          <app-nano-account-id [accountID]="pendingAccountModel" class="uk-width-auto" style="max-width: 90%;"></app-nano-account-id>
+          <app-nano-account-id [accountID]="pendingAccountModel" class="nano-address-monospace uk-width-auto" style="max-width: 90%;"></app-nano-account-id>
           <a class="span-icon" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
         </div>
       </div>
@@ -52,11 +52,11 @@
               <td *ngIf="block.account == pendingAccountModel || pendingAccountModel === '0'" class="uk-visible-toggle">
                 <div uk-grid>
                   <div class="uk-width-auto uk-text-truncate">
-                    <a [routerLink]="'/account/' + block.account" class="uk-link-text" title="View Account Details" uk-tooltip>
+                    <a [routerLink]="'/account/' + block.account" class="nano-address-clickable nano-address-monospace uk-link-text" title="View Account Details" uk-tooltip>
                       <app-nano-account-id [accountID]="block.account" middle="off"></app-nano-account-id>
                     </a>
                   </div>
-                  <div class="uk-width-auto" style="padding-left: 10px;">
+                  <div class="nano-address-actions uk-width-auto">
                     <ul class="uk-iconnav">
                       <li><a ngxClipboard [cbContent]="block.account" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                     </ul>
@@ -66,11 +66,11 @@
               <td *ngIf="block.account == pendingAccountModel || pendingAccountModel === '0'" class="uk-visible-toggle">
                 <div uk-grid>
                   <div class="uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
-                    <a [routerLink]="'/account/' + block.source" class="uk-link-text" title="View Account Details" uk-tooltip>
+                    <a [routerLink]="'/account/' + block.source" class="nano-address-clickable nano-address-monospace uk-link-text" title="View Account Details" uk-tooltip>
                       <app-nano-account-id [accountID]="block.source" middle="off"></app-nano-account-id>
                     </a>
                   </div>
-                  <div class="uk-width-auto" style="padding-left: 10px;">
+                  <div class="nano-address-actions uk-width-auto">
                     <ul class="uk-iconnav">
                       <li><a ngxClipboard [cbContent]="block.source" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                     </ul>

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -42,7 +42,7 @@
                   <div class="uk-width-expand uk-text-truncate" (click)="addSelectedAccounts(rep.accounts)" style="cursor: pointer;" uk-tooltip title="Select the accounts which are using this representative">
                     <span class="circle circle-online" *ngIf="rep.status.online" uk-tooltip title="Representative is online"></span>
                     <span class="circle circle-offline" *ngIf="!rep.status.online" uk-tooltip title="Representative is offline"></span>
-                    <span *ngIf="rep.label">{{ rep.label }}</span> <span *ngIf="!rep.label"><app-nano-account-id [accountID]="rep.id" middle="on"></app-nano-account-id></span>
+                    <span *ngIf="rep.label">{{ rep.label }}</span> <span *ngIf="!rep.label"><app-nano-account-id [accountID]="rep.id" middle="on" class="nano-address-monospace"></app-nano-account-id></span>
                   </div>
                   <div class="uk-width-1-4">
                     {{ rep.delegatedWeight | rai: 'mnano' }}
@@ -84,7 +84,7 @@
                       <div uk-grid>
                         <div class="uk-width-5-6 uk-text-truncate">
                           <span *ngIf="account.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ account.addressBookName }}</span> 
-                          <span *ngIf="account.id !== 'All Current Accounts'"><app-nano-account-id [accountID]="account.id" middle="on"></app-nano-account-id></span>
+                          <span *ngIf="account.id !== 'All Current Accounts'"><app-nano-account-id [accountID]="account.id" middle="on" class="nano-address-monospace"></app-nano-account-id></span>
                           <span *ngIf="account.id === 'All Current Accounts'">{{ account.id }}</span>
                         </div>
                         <div class="uk-width-1-6 uk-text-center" style="padding-left: 0;">

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -83,7 +83,7 @@
                     <li *ngFor="let account of selectedAccounts">
                       <div uk-grid>
                         <div class="uk-width-5-6 uk-text-truncate">
-                          <span *ngIf="account.addressBookName" class="uk-margin-small-right uk-label uk-label-default">{{ account.addressBookName }}</span> 
+                          <span *ngIf="account.addressBookName" class="uk-margin-small-right account-label blue">{{ account.addressBookName }}</span> 
                           <span *ngIf="account.id !== 'All Current Accounts'"><app-nano-account-id [accountID]="account.id" middle="on" class="nano-address-monospace"></app-nano-account-id></span>
                           <span *ngIf="account.id === 'All Current Accounts'">{{ account.id }}</span>
                         </div>

--- a/src/app/components/send/send.component.css
+++ b/src/app/components/send/send.component.css
@@ -1,3 +1,11 @@
+.form-select-source, .form-input-destination {
+	max-width: 800px;
+}
+
+.form-amount {
+	max-width: 450px;
+}
+
 .confirm-title {
   font-weight: bolder;
   display: block;

--- a/src/app/components/send/send.component.css
+++ b/src/app/components/send/send.component.css
@@ -7,13 +7,11 @@
 }
 
 .confirm-title {
-  font-weight: bolder;
   display: block;
   font-size: 24px;
 }
 
 .confirm-currency {
-  font-weight: bolder;
   display: block;
   font-size: 20px;
 }

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -103,12 +103,12 @@
 
                 <span class="confirm-title uk-text-truncate">
                   <div *ngIf="fromAddressBook">
-                    <span class="confirm-title">{{ fromAddressBook }}</span>
+                    <span class="confirm-title uk-text-truncate">{{ fromAddressBook }}</span>
                     <span class="confirm-subtitle">From Account</span>
-                    <span class="uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
+                    <span class="nano-address-monospace uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
                   </div>
                   <div *ngIf="!fromAddressBook">
-                    <span class="confirm-title uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
+                    <span class="nano-address-monospace confirm-title uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
                     <span class="confirm-subtitle">From Account</span>
                     <br class="br-spacer" />
                   </div>
@@ -134,12 +134,12 @@
 
                 <span class="confirm-title uk-text-truncate">
                   <div *ngIf="toAddressBook">
-                    <span class="confirm-title">{{ toAddressBook }}</span>
+                    <span class="confirm-title uk-text-truncate">{{ toAddressBook }}</span>
                     <span class="confirm-subtitle">To Account</span>
-                    <span class="uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
+                    <span class="nano-address-monospace uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
                   </div>
                   <div *ngIf="!toAddressBook">
-                    <span class="confirm-title uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
+                    <span class="nano-address-monospace confirm-title uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
                     <span class="confirm-subtitle">To Account</span>
                     <br class="br-spacer" />
                   </div>

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -14,7 +14,7 @@
               <div class="uk-margin">
                 <label class="uk-form-label" for="form-horizontal-select">From Account</label>
                 <div class="uk-form-controls">
-                  <select class="uk-select" [(ngModel)]="fromAccountID" (change)="resetRaw()" id="form-horizontal-select">
+                  <select class="form-select-source uk-select" [(ngModel)]="fromAccountID" (change)="resetRaw()" id="form-horizontal-select">
                     <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: settings.settings.displayDenomination }})</option>
                   </select>
                 </div>
@@ -23,7 +23,7 @@
               <div class="uk-margin">
                 <label class="uk-form-label" for="form-horizontal-text2">To Account</label>
                 <div class="uk-form-controls">
-                  <div class="uk-inline uk-width-1-1">
+                  <div class="form-input-destination uk-inline uk-width-1-1">
                     <a class="uk-form-icon uk-form-icon-flip" uk-icon="icon: camera" (click)="openQR('account1','account')" uk-tooltip title="Scan from QR code"></a>
                     <input (blur)="validateDestination()" (keyup)="searchAddressBook()" (focus)="searchAddressBook()" [(ngModel)]="toAccountID" [ngClass]="{ 'uk-form-success': toAccountStatus === 2, 'uk-form-danger': toAccountStatus === 0 }" class="uk-input" id="form-horizontal-text2" type="text" placeholder="Account to send to" autocomplete="off">
 
@@ -41,7 +41,7 @@
 
                 <div class="uk-form-controls" *ngIf="addressBookMatch">
                   <div class="uk-inline uk-width-1-1">
-                    <span class="uk-label uk-label-primary">{{ addressBookMatch }}</span>
+                    <span class="account-label blue uk-margin-small-top">{{ addressBookMatch }}</span>
                   </div>
                 </div>
               </div>
@@ -49,7 +49,7 @@
               <div uk-grid>
                 <div class="uk-width-1-1">
                   <label class="uk-form-label" for="form-horizontal-text">Amount</label>
-                  <div class="uk-form-controls">
+                  <div class="form-amount uk-form-controls">
                     <div uk-grid>
                       <div class="uk-width-1-1">
                         <div class="uk-inline uk-width-1-1">

--- a/src/app/components/sign/sign.component.css
+++ b/src/app/components/sign/sign.component.css
@@ -1,11 +1,9 @@
 .confirm-title {
-  font-weight: bolder;
   display: block;
   font-size: 24px;
 }
 
 .confirm-currency {
-  font-weight: bolder;
   display: block;
   font-size: 20px;
 }

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -21,12 +21,12 @@
               <div class="uk-card-header uk-text-left" style="padding: 20px 20px; line-height: 22px;">
                 <span class="confirm-title uk-text-truncate">
                   <div *ngIf="fromAddressBook">
-                    <span class="confirm-title">{{ fromAddressBook }}</span>
+                    <span class="confirm-title uk-text-truncate">{{ fromAddressBook }}</span>
                     <span class="confirm-subtitle">From Account</span>
-                    <span class="uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
+                    <span class="nano-address-monospace uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
                   </div>
                   <div *ngIf="!fromAddressBook">
-                    <span class="confirm-title uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
+                    <span class="nano-address-monospace confirm-title uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
                     <span class="confirm-subtitle">From Account</span>
                     <br class="br-spacer" />
                   </div>
@@ -55,12 +55,12 @@
 
                 <span class="confirm-title uk-text-truncate">
                   <div *ngIf="toAddressBook">
-                    <span class="confirm-title">{{ toAddressBook }}</span>
+                    <span class="confirm-title uk-text-truncate">{{ toAddressBook }}</span>
                     <span class="confirm-subtitle">To Account</span>
-                    <span class="uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
+                    <span class="nano-address-monospace uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
                   </div>
                   <div *ngIf="!toAddressBook">
-                    <span class="confirm-title uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
+                    <span class="nano-address-monospace confirm-title uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
                     <span class="confirm-subtitle">To Account</span>
                     <br class="br-spacer" />
                   </div>

--- a/src/app/services/representative.service.ts
+++ b/src/app/services/representative.service.ts
@@ -184,9 +184,10 @@ export class RepresentativeService {
         label = knownRepNinja.alias;
       }
 
+      const uptimeIntervalDays = 7;
+
       if (knownRepNinja && !repStatus.trusted) {
         let uptimeIntervalValue = knownRepNinja.uptime_over.week;
-        const uptimeIntervalDays = 7;
 
         // temporary fix for knownRepNinja.uptime_over.week always returning 0
         // uptimeIntervalValue = knownRepNinja.uptime_over.month;
@@ -231,6 +232,7 @@ export class RepresentativeService {
         status = 'alert';
         repStatus.uptime = 0;
         repStatus.veryLowUptime = true;
+        repStatus.daysSinceLastVoted = uptimeIntervalDays;
         repStatus.warn = true;
         repStatus.changeRequired = true;
       } else {

--- a/src/index.html
+++ b/src/index.html
@@ -19,7 +19,7 @@
   <script src="assets/lib/base/uikit.min.js"></script>
   <script src="assets/lib/base/uikit-icons.min.js"></script>
 
-  <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,500,700|Open+Sans:300,400&display=swap" rel="stylesheet"> 
+  <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,500,700|Open+Sans:300,400|Roboto+Mono:400&display=swap" rel="stylesheet"> 
 
   <script type="text/javascript" src="assets/lib/blake2b/blake2b.js"></script>
   <script type="text/javascript" src="assets/lib/tweetnacl/nacl.js"></script>

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -124,7 +124,7 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
         text-decoration: none;
     }
 
-    &:hover {
+    &.interactable:hover, &.blue {
         .account-label-hover-styles();
     }
 }

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -36,7 +36,7 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
   }
 
 .uk-card-body > ul > li > a {
-	color: #676686;
+	color: @global-color;
 }
 
 .uk-button-default:disabled, .uk-button-primary:disabled, .uk-button-secondary:disabled, .uk-button-danger:disabled {
@@ -101,6 +101,66 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
 			padding: 15px;
 		}
 	}
+}
+
+.account-label-hover-styles() {
+    border-color: @global-primary-background;
+    background: @global-primary-background;
+    color: #FFF;
+}
+
+.account-label {
+    display: inline-block;
+    background: #F1F1F1;
+    border-radius: 6px;
+    padding: 2px 10px;
+    font-size: 13px;
+    text-transform: uppercase;
+    border: 2px solid transparent;
+    transition: border-color 100ms ease-in-out;
+
+    &, &:hover {
+        color: #515151;
+        text-decoration: none;
+    }
+
+    &:hover {
+        .account-label-hover-styles();
+    }
+}
+
+.nano-address-monospace {
+    font-family: 'Roboto Mono', monospace;
+}
+
+.nano-address-clickable {
+    display: inline-block;
+    border-bottom: 2px solid transparent;
+    transition: border-color 100ms ease-in-out;
+    padding-bottom: 2px;
+
+    &, &:hover {
+        color: @global-color;
+        text-decoration: none;
+    }
+
+    &:hover {
+        .nano-address-clickable-hover-styles();
+    }
+}
+
+.nano-address-clickable-hover-styles() {
+    border-color: @global-primary-background;
+}
+
+.account-container:hover {
+    .account-label {
+        .account-label-hover-styles();
+    }
+
+    .nano-address-clickable {
+        .nano-address-clickable-hover-styles();
+    }
 }
 
 // custom classes

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -149,6 +149,11 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
     }
 }
 
+.nano-address-actions {
+    margin-bottom: 3px !important;
+    padding-left: 10px;
+}
+
 .nano-address-clickable-hover-styles() {
     border-color: @global-primary-background;
 }


### PR DESCRIPTION
improved layout and click area of the Accounts page
all nano addresses are now shown in a monospace font (all characters with equal width)
fixed reps not known by MyNanoNinja reported as "offline for the past 0 days"
fixed long account names not being truncated on send/sign confirmation pages
reduced max width of the form elements on the send page
added pencil icon to the address book entries to make it easier to tell the labels can be changed
added a hover hint to incoming balance amount so scrolling down to find out what the asterisk means isn't required