### PR TITLE
Automatic ledger protocol fallback

### DIFF
--- a/src/app/services/ledger.service.ts
+++ b/src/app/services/ledger.service.ts
@@ -66,13 +66,13 @@ export class LedgerService {
   desktopMessage$ = new Subject();
 
   constructor(private api: ApiService,
-    private desktop: DesktopService,
-    private notifications: NotificationService) {
-      if (this.isDesktop) {
-        this.configureDesktop();
-      } else {
-        this.checkBrowserSupport();
-      }
+              private desktop: DesktopService,
+              private notifications: NotificationService) {
+    if (this.isDesktop) {
+      this.configureDesktop();
+    } else {
+      this.checkBrowserSupport();
+    }
   }
 
   // Scraps binding to any existing transport/nano object

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,7 @@
   <meta property="og:url" content="https://nault.cc/" />
   <meta property="og:site_name" content="Nault" />
   <meta property="og:image" content="https://nault.cc/assets/img/preview.png?v=2" />
+  <meta http-equiv="origin-trial" content="AtfEXn+eBR9XWZLpRb4fBQICBD0r4CqNCbnAl4d0Y5mp1FTTOxtycugsWWnQ9d0o+aIPY6iAxsbUueMY5+8neQIAAABbeyJvcmlnaW4iOiJodHRwczovL25hdWx0LmNjOjQ0MyIsImZlYXR1cmUiOiJXZWJISUQiLCJleHBpcnkiOjE2MDk5NzAwNzcsImlzU3ViZG9tYWluIjp0cnVlfQ==">
 
   <!-- UIkit -->
   <!-- <link rel="stylesheet" href="assets/lib/base/uikit.min.css" /> -->


### PR DESCRIPTION
- Due to apparent stability issues with WebUSB on Windows, we will instead prefer WebHID for Windows only, if supported.
- If one of the USB transports fail, they will be temporarily blacklisted and it will automatically detect the next-best option. As always, U2F is the last fallback.
- Added Nault to WebHID origin trial, which should enable WebHID for all users of Chrome 86 to 88. Once Chrome 89 is released in February 2021, it will be enabled automatically for everyone and the meta tag can be removed. This will only work on Nault.cc, not localhost. For localhost you will need to enable Chrome experimental features.

`chrome://flags/#enable-experimental-web-platform-features`