### PR TITLE
Fix wallet import process when pressing Enter key on a text field

### DIFF
--- a/src/app/components/configure-wallet/configure-wallet.component.html
+++ b/src/app/components/configure-wallet/configure-wallet.component.html
@@ -69,7 +69,7 @@
         </p>
         <div class="uk-inline uk-width-1-1">
           <a class="uk-form-icon uk-form-icon-flip" uk-icon="icon: camera" (click)="openQR('seed1','hash')" uk-tooltip title="Scan from QR code"></a>
-          <input type="text" class="uk-input" (keyup.enter)="importExistingWallet()" [(ngModel)]="importSeedModel" placeholder="64 character Nano Backup Seed">
+          <input type="text" class="uk-input" (keyup.enter)="setPasswordInit()" [(ngModel)]="importSeedModel" placeholder="64 character Nano Backup Seed">
         </div>
       </div>
     </div>
@@ -80,7 +80,7 @@
         </p>
         <div class="uk-inline uk-width-1-1">
           <a class="uk-form-icon uk-form-icon-flip" uk-icon="icon: camera" (click)="openQR('mnemo1','mnemonic')" uk-tooltip title="Scan from QR code"></a>
-          <textarea class="uk-textarea" rows="3" (keyup.enter)="importExistingWallet()" [(ngModel)]="importSeedMnemonicModel" placeholder="24-words mnemonic"></textarea>
+          <textarea class="uk-textarea" rows="3" [(ngModel)]="importSeedMnemonicModel" placeholder="24-words mnemonic"></textarea>
         </div>
       </div>
     </div>
@@ -95,7 +95,7 @@
             <div class="uk-form-controls">
               <div class="uk-inline uk-width-expand">
                 <a class="uk-form-icon uk-form-icon-flip" uk-icon="icon: camera" (click)="openQR('mnemo2','mnemonic')" uk-tooltip title="Scan from QR code"></a>
-                <textarea class="uk-textarea" rows="2" (keyup.enter)="importExistingWallet()" [(ngModel)]="importSeedBip39MnemonicModel" placeholder="12,15,18,21 or 24-words mnemonic" autocomplete="off"></textarea>
+                <textarea class="uk-textarea" rows="2" [(ngModel)]="importSeedBip39MnemonicModel" placeholder="12,15,18,21 or 24-words mnemonic" autocomplete="off"></textarea>
               </div>
            </div>
           </div>
@@ -104,7 +104,7 @@
           <div class="uk-margin">
             <label class="uk-form-label" for="form-horizontal-select">Account Index <span uk-icon="icon: info;" uk-tooltip title="The wallet will be imported as a single private key for the account index you provide."></span></label>
             <div class="uk-form-controls">
-              <input type="text" class="uk-input uk-margin-small-bottom {{validIndex ? '':'uk-form-danger'}}" (keyup.enter)="importExistingWallet()" [(ngModel)]="importSeedBip39MnemonicIndexModel" (ngModelChange)="accountIndexChange(importSeedBip39MnemonicIndexModel)" maxLength="10" placeholder="0 to {{indexMax}}" autocomplete="off">
+              <input type="text" class="uk-input uk-margin-small-bottom {{validIndex ? '':'uk-form-danger'}}" (keyup.enter)="setPasswordInit()" [(ngModel)]="importSeedBip39MnemonicIndexModel" (ngModelChange)="accountIndexChange(importSeedBip39MnemonicIndexModel)" maxLength="10" placeholder="0 to {{indexMax}}" autocomplete="off">
             </div>
           </div>
         </div>
@@ -112,7 +112,7 @@
           <div class="uk-margin">
             <label class="uk-form-label" for="form-horizontal-select">BIP39 Passphrase <span uk-icon="icon: info;" uk-tooltip title="Required only if the BIP39 seed is protected by a password or passphrase."></span></label>
             <div class="uk-form-controls">
-              <input type="password" class="uk-input" (keyup.enter)="importExistingWallet()" [(ngModel)]="importSeedBip39MnemonicPasswordModel" placeholder="Optional" autocomplete="off">
+              <input type="password" class="uk-input" (keyup.enter)="setPasswordInit()" [(ngModel)]="importSeedBip39MnemonicPasswordModel" placeholder="Optional" autocomplete="off">
             </div>
           </div>
         </div>
@@ -146,7 +146,7 @@
         </p>
         <div class="uk-inline uk-width-1-1">
           <a class="uk-form-icon uk-form-icon-flip" uk-icon="icon: camera" (click)="openQR('priv1','hash')" uk-tooltip title="Scan from QR code"></a>
-          <input type="text" class="uk-input" (keyup.enter)="importSingleKeyWallet()" [(ngModel)]="importPrivateKeyModel" placeholder="64 character Nano Private Key">
+          <input type="text" class="uk-input" (keyup.enter)="setPasswordInit()" [(ngModel)]="importPrivateKeyModel" placeholder="64 character Nano Private Key">
         </div>
       </div>
     </div>
@@ -157,7 +157,7 @@
         </p>
         <div class="uk-inline uk-width-1-1">
           <a class="uk-form-icon uk-form-icon-flip" uk-icon="icon: camera" (click)="openQR('expanded1','hash')" uk-tooltip title="Scan from QR code"></a>
-          <input type="text" class="uk-input" (keyup.enter)="importSingleKeyWallet()" [(ngModel)]="importExpandedKeyModel" placeholder="64 or 128 character Nano Expanded Private Key">
+          <input type="text" class="uk-input" (keyup.enter)="setPasswordInit()" [(ngModel)]="importExpandedKeyModel" placeholder="64 or 128 character Nano Expanded Private Key">
         </div>
       </div>
     </div>


### PR DESCRIPTION
When importing a seed, mnemonic, BIP39 seed, private or expanded private key, pressing Enter key on a text field (rather than clicking the appropriate button) results in the following address appearing in the accounts list:
nano_33rhi9bp69i5zaftkyiacjmhwqnz1mcnfm9y6mpk8qx4xpht9cs9dzbxb9gb

While the UI shows "Configure Wallet" signaling that the wallet has not been correctly configured, it's quite dangerous as users might not notice that they do not own the address displayed under "Accounts" (or rather that anyone else can easily access the private keys for those accounts).

**Changes:**

*Mnemonic and BIP39 mnemonic fields:*
Pressing Enter now does nothing other than making a new line (they're multiline fields)

*Seed, BIP39 index, BIP39 passphrase, private key and expanded private key fields:*
Pressing Enter is now identical to clicking the appropriate button