### PR TITLE
Updaded WebHID origin trial token

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
   <meta property="og:url" content="https://nault.cc/" />
   <meta property="og:site_name" content="Nault" />
   <meta property="og:image" content="https://nault.cc/assets/img/preview.png?v=2" />
-  <meta http-equiv="origin-trial" content="AtfEXn+eBR9XWZLpRb4fBQICBD0r4CqNCbnAl4d0Y5mp1FTTOxtycugsWWnQ9d0o+aIPY6iAxsbUueMY5+8neQIAAABbeyJvcmlnaW4iOiJodHRwczovL25hdWx0LmNjOjQ0MyIsImZlYXR1cmUiOiJXZWJISUQiLCJleHBpcnkiOjE2MDk5NzAwNzcsImlzU3ViZG9tYWluIjp0cnVlfQ==">
+  <meta http-equiv="origin-trial" content="Ar1SGaBNCgNxWILG8Ku2fHPl4vB1b3NGxqUefE46R8KBupYLRhAtHFdq/8Mfk30U+kxt0CtvfDfWomjvvHvGug4AAABbeyJvcmlnaW4iOiJodHRwczovL25hdWx0LmNjOjQ0MyIsImZlYXR1cmUiOiJXZWJISUQiLCJleHBpcnkiOjE2MTMyNjUwOTcsImlzU3ViZG9tYWluIjp0cnVlfQ==">
 
   <!-- UIkit -->
   <!-- <link rel="stylesheet" href="assets/lib/base/uikit.min.css" /> -->


### PR DESCRIPTION
The current token for the WebHID origin trial will expire on Jan 6th. I have generated a new token. This one will expire on Feb 14th.

Without the new token WebHID will stop working. We might have to do this one more time in February, but from Chrome 88 onwards no token is needed.