### PR TITLE
Fixing stuck processing state

### DIFF
--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -141,7 +141,7 @@ export class ReceiveComponent implements OnInit {
       this.walletService.clearPendingBlocks();
     } else {
       if (!this.walletService.isLedgerWallet()) {
-        this.notificationService.sendError(`There was an error receiving the transaction`);
+        this.notificationService.sendError(`There was a problem receiving the transaction, try manually!`, {length: 10000});
       }
     }
 


### PR DESCRIPTION
The variable processingPending controls if the GUI shows spinning icon and "Processing Transaction...". It was not reset properly on failure.
It solves the issue where two Nault (wallets) trying to receive the same transaction at the same time. I have not yet found any evidence that a cached work can be invalid and a transaction fails for that reason.

Fixes #240 