### PR TITLE
Solving multiple-pow issues

### DIFF
--- a/src/app/services/work-pool.service.ts
+++ b/src/app/services/work-pool.service.ts
@@ -53,12 +53,10 @@ export class WorkPoolService {
 
     // if work is requested while work is already being processed for this hash
     if (cached && cached.work === tempWork) {
-      let count = 0;
       // wait for current pow to finish or fail
       while (cached && cached.work === tempWork) {
         await this.sleep(100);
         cached = this.workCache.find(p => p.hash === hash);
-        count++;
       }
       if (cached && cached.work && this.util.nano.validateWork(hash, baseThreshold, cached.work)) {
         console.log('Using pre-processed work: ' + cached.work);

--- a/src/app/services/work-pool.service.ts
+++ b/src/app/services/work-pool.service.ts
@@ -12,6 +12,10 @@ export class WorkPoolService {
 
   constructor(private pow: PowService, private notifications: NotificationService, private util: UtilService) { }
 
+  sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
   public workExists(hash) {
     return !!this.workCache.find(p => p.hash === hash);
   }
@@ -44,20 +48,50 @@ export class WorkPoolService {
 
   // Get work for a hash.  Uses the cache, or the current setting for generating it.
   public async getWork(hash, multiplier= 1) {
-    const cached = this.workCache.find(p => p.hash === hash);
-    if (cached && cached.work && this.util.nano.validateWork(hash, baseThreshold, cached.work)) {
+    let cached = this.workCache.find(p => p.hash === hash);
+    const tempWork = '1';
+
+    // if work is requested while work is already being processed for this hash
+    if (cached && cached.work === tempWork) {
+      let count = 0;
+      // wait for current pow to finish or fail
+      while (cached && cached.work === tempWork) {
+        await this.sleep(100);
+        cached = this.workCache.find(p => p.hash === hash);
+        count++;
+      }
+      if (cached && cached.work && this.util.nano.validateWork(hash, baseThreshold, cached.work)) {
+        console.log('Using pre-processed work: ' + cached.work);
+        return cached.work;
+      }
+      // if the work was invalid and removed from cache, also invalidate the response
+      console.log('Invalid pre-processed work');
+      return null;
+    } else if (cached && cached.work && this.util.nano.validateWork(hash, baseThreshold, cached.work)) {
       console.log('Using cached work: ' + cached.work);
       return cached.work;
     }
 
-    const work = await this.pow.getPow(hash, multiplier);
+    // add temp work to prevent duplicate hashes in the cache due to asynchronous calls during "await"
+    let work = tempWork;
+    this.workCache.push({ hash, work });
+
+    work = await this.pow.getPow(hash, multiplier);
     if (!work) {
       this.notifications.sendWarning(`Failed to retrieve work for ${hash}.  Try a different PoW method.`);
+      // remove temp work (will also break the while loop above for parallel threads)
+      const x = this.workCache.findIndex(p => p.hash === hash && p.work === tempWork);
+      if (x !== -1) this.workCache.splice(x, 1);
       return null;
     }
 
     console.log('Work found: ' + work);
-    this.workCache.push({ hash, work });
+
+    this.workCache.push({ hash, work }); // add the real work
+    // remove temp work (important to remove after push to avoid possible race condition)
+    const index = this.workCache.findIndex(p => p.hash === hash && p.work === tempWork);
+    if (index !== -1) this.workCache.splice(index, 1);
+
     if (this.workCache.length >= this.cacheLength) this.workCache.shift(); // Prune if we are at max length
     this.saveWorkCache();
 


### PR DESCRIPTION
Fixing #247 

This function as a workaround to allow multiple concurrent async calls to request work without creating duplicate cache entries. To properly solve the logic the whole wallet service would need to be rebuilt from scratch more or less. Many functions depend on the PoW call and now the cache stays clean at least. Send + Receive is now 2 PoW instead of 6. Done plenty of transaction tests.