### PR TITLE
Improve visibility of indexes for own accounts

### DIFF
--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -1,7 +1,7 @@
 <div class="uk-animation-slide-left-small" uk-grid>
   <div class="uk-width-1-1">
 
-    <h2 class="uk-heading-divider">Account Details</h2>
+    <h2 class="uk-heading-divider">{{ walletAccount ? 'Account Details' : 'Network Explorer' }}</h2>
 
     <div class="uk-card uk-card-default uk-margin">
       <div class="uk-card-header uk-visible-toggle">
@@ -10,8 +10,11 @@
 
           <div class="uk-width-expand">
 
-            <div *ngIf="showEditAddressBook" uk-grid>
-              <div class=" uk-width-1-1">
+            <div *ngIf="walletAccount && addressBookEntry">{{ 'Account #' + walletAccount.index }}</div>
+            <div *ngIf="!walletAccount">External address</div>
+
+            <div uk-grid>
+              <div class="uk-width-1-1" *ngIf="showEditAddressBook">
                 <div class="uk-margin">
                   <div class="uk-inline uk-width-1-1">
                     <a class="uk-form-icon uk-form-icon-flip uk-text-success" (click)="saveAddressBook()" uk-icon="icon: check" uk-tooltip title="Save Changes"></a>
@@ -20,39 +23,31 @@
                   </div>
                 </div>
               </div>
-            </div>
-            <div *ngIf="!showEditAddressBook" uk-grid>
-              <div class="uk-width-1-1">
-                <div *ngIf="addressBookEntry || walletAccount">
-                  <div class="uk-width-1-1">
-                    <div uk-grid>
-                    <h3 class="uk-width-auto uk-card-title uk-text-truncate" style="max-width: calc(100% - 35px);">{{ addressBookEntry ? addressBookEntry : ('Account #' + walletAccount.index)}}</h3>
-                      <div class="uk-width-auto" style="padding-left: 10px; margin-top: 3px;">
-                        <li style="display: contents;"><span uk-icon="icon: pencil;" title="Edit Account Label" uk-tooltip (click)="showEditAddressBook = !showEditAddressBook" title="Edit Account Label"></span></li>
-                      </div>
-                    </div>
-                  </div>
+              <div class="uk-width-1-1" *ngIf="!showEditAddressBook">
+                <div class="uk-width-1-1">
                   <div uk-grid>
-                    <div class="nano-address-monospace uk-width-auto uk-text-small uk-text-truncate" style="max-width: calc(100% - 35px);">
-                      <app-nano-account-id [accountID]="accountID"></app-nano-account-id>
-                    </div>
-                    <div class="uk-width-auto" style="padding-left: 10px; margin-top: -3px;">
-                      <li><a ngxClipboard [cbContent]="accountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
+                  <h3 class="uk-width-auto uk-card-title uk-text-truncate" style="max-width: calc(100% - 35px);">{{
+                      addressBookEntry
+                    ? addressBookEntry
+                    : (
+                        walletAccount
+                      ? ('Account #' + walletAccount.index)
+                      : 'No label set'
+                    )
+                  }}</h3>
+                    <div class="uk-width-auto" style="padding-left: 10px; margin-top: 3px;">
+                      <a style="display: contents;"><span uk-icon="icon: pencil;" title="Edit Account Label" uk-tooltip (click)="showEditAddressBook = !showEditAddressBook" title="Edit Account Label"></span></a>
                     </div>
                   </div>
                 </div>
-
-                <div *ngIf="!addressBookEntry && !walletAccount">
-                  <div uk-grid>
-                    <h3 class="nano-address-monospace uk-width-auto uk-card-title uk-text-truncate" style="max-width: calc(100% - 80px);">
-                      <app-nano-account-id [accountID]="accountID"></app-nano-account-id>
-                    </h3>
-                    <div class="uk-width-auto">
-                      <ul class="uk-iconnav" style="margin-top: 5px;">
-                        <li style="display: contents;"><span uk-icon="icon: pencil;" title="Edit Account Label" uk-tooltip (click)="showEditAddressBook = !showEditAddressBook" title="Edit Account Label"></span></li>
-                        <li><a ngxClipboard [cbContent]="accountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
-                      </ul>
-                    </div>
+              </div>
+              <div class="uk-width-1-1 uk-margin-small-top">
+                <div uk-grid>
+                  <div class="nano-address-monospace uk-width-auto uk-text-small uk-text-truncate" style="max-width: calc(100% - 35px);">
+                    <app-nano-account-id [accountID]="accountID"></app-nano-account-id>
+                  </div>
+                  <div class="uk-width-auto" style="padding-left: 10px; margin-top: -3px;">
+                    <li><a ngxClipboard [cbContent]="accountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
                   </div>
                 </div>
               </div>

--- a/src/app/components/accounts/accounts.component.css
+++ b/src/app/components/accounts/accounts.component.css
@@ -30,8 +30,30 @@
 	border-color: transparent;
 }
 
+.account-container:hover .account-index {
+	color: #4A90E2;
+}
+
+.account-container:hover .account-index span {
+	color: #A2CBFA;
+}
+
 .account-container .nano-address-clickable {
 	vertical-align: bottom;
+}
+
+.account-container .account-index {
+	display: inline-block;
+	font-size: 13px;
+	margin-right: 7px;
+	color: #676686;
+}
+
+.account-container .account-index span {
+	color: #AAA;
+	font-size: 15px;
+	vertical-align: -1px;
+	margin-right: 1px;
 }
 
 .account-container .account-label {

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -39,9 +39,16 @@
             <div uk-grid>
               <a [routerLink]="'/account/' + account.id" [class]="[ 'uk-width-auto', 'uk-text-truncate', 'account-container', !isLedgerWallet ? 'narrow' : 'wide' ]">
                 <div class="uk-width-1-1">
-                  <div class="account-label">
-                    {{ account.addressBookName ? account.addressBookName : 'Account #' + account.index }}
-                  </div>
+                  <div class="account-index" *ngIf="viewAdvanced"><span>#</span>{{ account.index }}</div>
+                  <div class="account-label">{{
+                      account.addressBookName
+                    ? account.addressBookName
+                    : (
+                        viewAdvanced
+                      ? 'Account'
+                      : 'Account #' + account.index
+                    )
+                  }}</div>
                 </div>
                 <div class="nano-address-clickable nano-address-monospace uk-text-truncate">
                   <app-nano-account-id [accountID]="account.id" middle="on"></app-nano-account-id>


### PR DESCRIPTION
Fixes #241

adds indexes to the accounts list in the advanced mode

![image](https://user-images.githubusercontent.com/29272208/104139453-8751ed00-53a3-11eb-888b-7f82320a41b7.png)

adds index to the account details page for labeled accounts

![image](https://user-images.githubusercontent.com/29272208/104139463-9a64bd00-53a3-11eb-85e4-71c58057759e.png)

- simplifies code logic, improves layout (includes changes for external address network explorer)
- inline editing label now only hides the label, nano_ address and account index remain visible
- fixes pencil icon not changing the cursor to pointer hand
- addresses not belonging to own wallet are now tagged as External and the page is renamed from Account Details to Network Explorer to reduce chances of users thinking they are looking at an address they own

before:

![image](https://user-images.githubusercontent.com/29272208/104139496-d435c380-53a3-11eb-8bf9-77b8be4866ff.png)

after:

![image](https://user-images.githubusercontent.com/29272208/104139502-db5cd180-53a3-11eb-87da-a43cafd8a648.png)
