### PR TITLE
Wallet unlock form improvements

### DIFF
--- a/src/app/components/wallet-widget/wallet-widget.component.css
+++ b/src/app/components/wallet-widget/wallet-widget.component.css
@@ -6,5 +6,17 @@
   margin-left: 10px;
 }
 .uk-text-top {
-    margin-right: 5px;
+  margin-right: 5px;
+}
+
+.password-input {
+  transition: border-color 100ms ease-in-out, background 100ms ease-in-out;
+}
+.password-input.uk-form-danger {
+  border-color: #F79743;
+  background: #FFF9F4;
+  color: #F79743;
+}
+.password-input.uk-form-danger::placeholder {
+  color: #F79743;
 }

--- a/src/app/components/wallet-widget/wallet-widget.component.html
+++ b/src/app/components/wallet-widget/wallet-widget.component.html
@@ -62,11 +62,15 @@
       <h2 class="uk-modal-title">Unlock Wallet</h2>
     </div>
     <div class="uk-modal-body">
-      <input autofocus type="password" [(ngModel)]="unlockPassword" (keyup.enter)="unlockWallet()" class="uk-input" placeholder="Enter wallet password">
+      <input #passwordInput autofocus type="password" [(ngModel)]="unlockPassword" (keyup.enter)="unlockWallet()"
+        [class]="{ 'uk-input': true, 'password-input': true, 'uk-form-danger': !mayAttemptUnlock }"
+        [placeholder]="( mayAttemptUnlock ? 'Enter wallet password' : 'Incorrect password' )"
+        [disabled]="!mayAttemptUnlock"
+      >
     </div>
     <div class="uk-modal-footer uk-text-right nlt-button-group">
       <button class="uk-button uk-button-default uk-modal-close" type="button">Cancel</button>
-      <button class="uk-button uk-button-primary" type="button" (click)="unlockWallet()">Unlock</button>
+      <button class="uk-button uk-button-primary" type="button" (click)="unlockWallet()" [disabled]="!mayAttemptUnlock">Unlock</button>
     </div>
   </div>
 </div>

--- a/src/app/components/wallet-widget/wallet-widget.component.ts
+++ b/src/app/components/wallet-widget/wallet-widget.component.ts
@@ -93,7 +93,7 @@ export class WalletWidgetComponent implements OnInit {
 
     this.timeoutIdAllowingUnlock = setTimeout(
       () => {
-        this.allowUnlock({ focusInputElement: true })
+        this.allowUnlock({ focusInputElement: true });
       },
       500
     );

--- a/src/app/components/wallet-widget/wallet-widget.component.ts
+++ b/src/app/components/wallet-widget/wallet-widget.component.ts
@@ -17,6 +17,8 @@ export class WalletWidgetComponent implements OnInit {
   unlockPassword = '';
 
   modal: any = null;
+  shouldDelayUnlockAttempt: boolean = false;
+  timeoutIdDisablingDelay: any = null;
 
   constructor(
     public walletService: WalletService,
@@ -67,7 +69,24 @@ export class WalletWidgetComponent implements OnInit {
   }
 
   async unlockWallet() {
-    await new Promise(resolve => setTimeout(resolve, 500)); // brute force delay
+    if (this.shouldDelayUnlockAttempt === true) {
+      await new Promise(resolve => setTimeout(resolve, 500)); // brute force delay
+    }
+
+    this.shouldDelayUnlockAttempt = true;
+
+    if (this.timeoutIdDisablingDelay !== null) {
+      clearTimeout(this.timeoutIdDisablingDelay);
+    }
+
+    this.timeoutIdDisablingDelay = setTimeout(
+      () => {
+        this.shouldDelayUnlockAttempt = false;
+        this.timeoutIdDisablingDelay = null;
+      },
+      2000
+    );
+
     const unlocked = await this.walletService.unlockWallet(this.unlockPassword);
 
     if (unlocked) {

--- a/src/app/components/wallet-widget/wallet-widget.component.ts
+++ b/src/app/components/wallet-widget/wallet-widget.component.ts
@@ -17,7 +17,7 @@ export class WalletWidgetComponent implements OnInit {
   unlockPassword = '';
 
   modal: any = null;
-  shouldDelayUnlockAttempt: boolean = false;
+  shouldDelayUnlockAttempt = false;
   timeoutIdDisablingDelay: any = null;
 
   constructor(


### PR DESCRIPTION
password input and unlock button are now disabled for 0.5s upon unsuccessful unlock attempt, rather than delaying any unlocking attempt by 0.5s (even if the password was entered correctly from the first try, the unlocking process used to be delayed)

![image](https://user-images.githubusercontent.com/29272208/104504456-61625d80-55da-11eb-8ebb-26dd59b50437.png)


also changes wording from "Invalid password" to "Incorrect password"