### PR TITLE
New rep summary page

### DIFF
--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -130,7 +130,7 @@
                     <div *ngIf="!showEditRepresentative">
                       <div uk-grid>
                         <div class="nano-address-monospace uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
-                          <span *ngIf="repLabel" class="uk-label uk-label-danger">{{ repLabel }}</span> 
+                          <span *ngIf="repLabel" class="account-label rep">{{ repLabel }}</span> 
                           <app-nano-account-id [accountID]="!account ? '':account.representative"></app-nano-account-id>
                         </div>
                         <div class="uk-width-auto" style="padding-left: 10px;" *ngIf="walletAccount && account && account.representative">
@@ -397,8 +397,8 @@
             </div>
           </div>
           <div class="uk-form-controls" *ngIf="representativeListMatch">
-            <div class="uk-inline uk-width-1-1">
-              <span class="uk-label uk-label-danger">{{ representativeListMatch }}</span>
+            <div class="uk-inline uk-width-1-1 uk-margin-small-top">
+              <span class="account-label rep">{{ representativeListMatch }}</span>
             </div>
           </div>
         </div>

--- a/src/app/components/configure-app/configure-app.component.html
+++ b/src/app/components/configure-app/configure-app.component.html
@@ -171,8 +171,8 @@
                 </div>
 
                 <div class="uk-form-controls" *ngIf="representativeListMatch">
-                  <div class="uk-inline uk-width-1-1">
-                    <span class="uk-label uk-label-danger">{{ representativeListMatch }}</span>
+                  <div class="uk-inline uk-width-1-1 uk-margin-small-top">
+                    <span class="account-label rep">{{ representativeListMatch }}</span>
                   </div>
                 </div>
               </div>

--- a/src/app/components/manage-representatives/manage-representatives.component.html
+++ b/src/app/components/manage-representatives/manage-representatives.component.html
@@ -3,16 +3,19 @@
 
     <div class="uk-margin-bottom" uk-grid>
       <div class="uk-width-expand@s uk-width-1-1">
-        <h2 class="uk-heading-divider">Representatives List</h2>
+        <h2 class="uk-heading-divider">
+          Representatives Book
+          <a [routerLink]="'/representatives'" style="font-size: 12px; margin-left: 25px;">BACK TO REPRESENTATIVES OVERVIEW</a>
+        </h2>
       </div>
-      <div class="uk-width-auto@s uk-width-1-1 uk-text-right">
-        <button class="uk-button uk-button-secondary uk-align-right uk-width-auto@s" (click)="activePanel = 1;">Add New Rep</button>
+      <div class="uk-width-auto@s uk-width-1-1 uk-text-right" *ngIf="activePanel == 0">
+        <button class="uk-button uk-button-secondary uk-align-right uk-width-auto@s" (click)="activePanel = 1;">Add Representative</button>
       </div>
     </div>
 
-    <div class="uk-width-1-1 nlt-page-intro">
+    <div class="uk-width-1-1 nlt-page-intro" *ngIf="activePanel == 0">
       <p>
-        You can use the representatives list to store a label and other information for representatives you use.
+        You can use this page as a notebook for representatives. Here you can set custom display names to be shown throughout the application, mark representatives as trusted (please note that this will suppress warnings), or mark representatives that should be avoided.
       </p>
     </div>
 
@@ -25,7 +28,7 @@
               <div uk-grid style="color: #999; text-transform: uppercase; font-size: .875rem; font-weight: 400;">
                 <div class="uk-width-2-5">Name</div>
                 <div class="uk-width-expand">Account ID</div>
-                <div class="uk-width-1-6 uk-text-center" style="padding-left: 0;">Options</div>
+                <div class="uk-width-1-6 uk-text-center" style="padding-left: 0;">Actions</div>
               </div>
             </li>
           </ul>
@@ -36,8 +39,6 @@
                 <div class="uk-width-2-5 uk-text-truncate uk-visible-toggle">
                   <div uk-grid>
                     <div class="uk-width-expand uk-text-truncate">
-                      <span class="circle circle-online" *ngIf="representative.online" uk-tooltip title="Representative is online"></span>
-                      <span class="circle circle-offline" *ngIf="!representative.online" uk-tooltip title="Representative is offline"></span>
                       <a (click)="editEntry(representative)" class="uk-link-text" title="Edit Representative" uk-tooltip>{{ representative.name }}</a>
                     </div>
                     <ul class="uk-iconnav uk-width-auto" style="padding-left: 0;">
@@ -79,7 +80,7 @@
       <div class="uk-width-1-1">
         <div class="uk-card uk-card-default">
           <div class="uk-card-header">
-            <h2 class="uk-card-title">Create New Representative</h2>
+            <h2 class="uk-card-title">Add Representative</h2>
           </div>
           <div class="uk-card-body">
             <div class="uk-form-horizontal">
@@ -102,10 +103,10 @@
                 <div class="uk-form-controls">
                   <div uk-grid>
                     <div class="uk-width-1-1">
-                      <label style="cursor: pointer;" uk-tooltip title="Make a representative appear at the top of your list as a recommended option"><input type="checkbox" class="uk-checkbox" [(ngModel)]="newRepTrusted"> &nbsp; Trusted Representative</label>
+                      <label style="cursor: pointer;" uk-tooltip title="Suppress all warnings about this representative"><input type="checkbox" class="uk-checkbox" [(ngModel)]="newRepTrusted"> &nbsp; Trusted Representative</label>
                     </div>
                     <div class="uk-width-1-1 uk-margin-small-top">
-                      <label style="cursor: pointer;" uk-tooltip title="Warn the user when using this representative"><input type="checkbox" class="uk-checkbox" [(ngModel)]="newRepWarn"> &nbsp; Avoid Representative</label>
+                      <label style="cursor: pointer;" uk-tooltip title="Warn when using this representative"><input type="checkbox" class="uk-checkbox" [(ngModel)]="newRepWarn"> &nbsp; Avoid Representative</label>
                     </div>
                   </div>
 

--- a/src/app/components/representatives/representatives.component.css
+++ b/src/app/components/representatives/representatives.component.css
@@ -1,14 +1,3 @@
-.circle:before {
-  content: ' \25CF';
-  font-size: 16px;
-}
-.circle-online {
-	color: #00d60f;
-}
-.circle-offline {
-	color: #F00;
-}
-
 .view-all-reps-link {
 	float: right;
 	margin-top: 5px;
@@ -19,4 +8,119 @@
 
 .uk-pagination > li > a {
 	padding: 5px 10px;
+}
+
+.representative-health-column-header, .representative-health-column {
+	min-width: 120px;
+}
+
+.voting-weight-column-header {
+	white-space: nowrap;
+	vertical-align: middle;
+}
+
+.representative-health-column {
+	vertical-align: middle;
+}
+
+.representative-health-status {
+	display: flex;
+	align-items: center;
+	line-height: 1;
+}
+
+.representative-health-status > .health-icon {
+	display: flex;
+	width: 15px;
+	height: 15px;
+	border-radius: 100%;
+	margin-right: 6px;
+}
+
+.representative-health-status > .label {
+	font-size: 14px;
+	margin-bottom: -1px;
+}
+
+.representative-health-status.health-green {
+	color: #32D296;
+}
+.representative-health-status.health-green > .health-icon {
+	background-color: #32D296;
+}
+
+.representative-health-status.health-yellow {
+	color: #FAA05A;
+}
+.representative-health-status.health-yellow > .health-icon {
+	background-color: #FAA05A;
+}
+
+.representative-health-status.health-red {
+	color: #F0506E;
+}
+.representative-health-status.health-red > .health-icon {
+	background-color: #F0506E;
+}
+
+.representative-health-status.health-unknown {
+	color: #868AB0;
+}
+.representative-health-status.health-unknown > .health-icon {
+	background-color: #868AB0;
+}
+
+.representative-name-column > .account-label {
+	margin-bottom: 3px;
+}
+
+.voting-weight-column {
+	white-space: nowrap;
+	vertical-align: middle;
+	text-align: right;
+}
+
+.representative-row {
+	border-bottom: none !important;
+}
+
+.delegating-account-row {
+	border-top: none !important;
+}
+
+.delegating-account-row > td {
+	padding-top: 3px;
+}
+
+.delegating-account {
+	display: flex;
+}
+
+.delegating-account > .descendant-icon {
+	margin-bottom: 10px;
+	margin-right: 5px;
+	width: 18px;
+	min-width: 18px;
+	height: 13px;
+	border-left: 1px solid #777;
+	border-bottom: 1px solid #777;
+	border-radius: 0 0 0 2px;
+}
+
+.delegating-account > .descendant-details {
+	display: flex;
+	flex-direction: column;
+}
+
+.delegating-account > .descendant-details > .descendant-label {
+	flex-grow: 0;
+	margin-bottom: 3px;
+}
+
+.delegating-account > .descendant-details > .descendant-address {
+	font-size: 0.8em;
+}
+
+.delegating-account-row > .voting-weight-column {
+	vertical-align: bottom;
 }

--- a/src/app/components/representatives/representatives.component.css
+++ b/src/app/components/representatives/representatives.component.css
@@ -137,3 +137,9 @@
 .change-representative-form .account-label {
 	margin-bottom: 3px;
 }
+
+.change-representative-form .action-remove {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+}

--- a/src/app/components/representatives/representatives.component.css
+++ b/src/app/components/representatives/representatives.component.css
@@ -90,6 +90,15 @@
 
 .delegating-account-row {
 	border-top: none !important;
+	border-bottom: none !important;
+}
+
+.delegating-account-row + .representative-row {
+	border-top: 1px solid #DCE9F9 !important;
+}
+
+.delegating-account-row:last-child {
+	border-bottom: 1px solid #DCE9F9 !important;
 }
 
 .delegating-account-row > td {

--- a/src/app/components/representatives/representatives.component.css
+++ b/src/app/components/representatives/representatives.component.css
@@ -132,3 +132,7 @@
 .delegating-account-details-column {
 	cursor: pointer;
 }
+
+.change-representative-form .account-label {
+	margin-bottom: 3px;
+}

--- a/src/app/components/representatives/representatives.component.css
+++ b/src/app/components/representatives/representatives.component.css
@@ -101,6 +101,7 @@
 }
 
 .delegating-account > .descendant-icon {
+	margin-left: 2px;
 	margin-bottom: 10px;
 	margin-right: 5px;
 	width: 18px;

--- a/src/app/components/representatives/representatives.component.css
+++ b/src/app/components/representatives/representatives.component.css
@@ -70,6 +70,10 @@
 	background-color: #868AB0;
 }
 
+.representative-name-column {
+	cursor: pointer;
+}
+
 .representative-name-column > .account-label {
 	margin-bottom: 3px;
 }
@@ -123,4 +127,8 @@
 
 .delegating-account-row > .voting-weight-column {
 	vertical-align: bottom;
+}
+
+.delegating-account-details-column {
+	cursor: pointer;
 }

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -98,7 +98,7 @@
             <p class="uk-text-lead uk-text-center">Change your representatives</p>
 
 
-            <div class="uk-form-horizontal">
+            <div class="change-representative-form uk-form-horizontal">
 
               <div class="uk-margin">
                 <label class="uk-form-label" for="form-horizontal-select">Accounts to Change</label>
@@ -112,9 +112,11 @@
                     <li *ngFor="let account of selectedAccounts">
                       <div uk-grid>
                         <div class="uk-width-5-6 uk-text-truncate">
-                          <span *ngIf="account.addressBookName" class="uk-margin-small-right account-label blue">{{ account.addressBookName }}</span> 
-                          <span *ngIf="account.id !== 'All Current Accounts'"><app-nano-account-id [accountID]="account.id" middle="on" class="nano-address-monospace"></app-nano-account-id></span>
-                          <span *ngIf="account.id === 'All Current Accounts'">{{ account.id }}</span>
+                          <div *ngIf="(account.id === 'All Current Accounts')">{{ account.id }}</div>
+                          <ng-container *ngIf="(account.id !== 'All Current Accounts')">
+                            <div class="uk-margin-small-right account-label blue">{{ account.addressBookName ? account.addressBookName : 'Account' }}</div>
+                            <app-nano-account-id [accountID]="account.id" middle="on" class="nano-address-monospace"></app-nano-account-id>
+                          </ng-container>
                         </div>
                         <div class="uk-width-1-6 uk-text-center" style="padding-left: 0;">
                           <a (click)="removeSelectedAccount(account)" class="uk-text-danger" title="Remove From List" uk-tooltip><span uk-icon="icon: close;"></span></a>
@@ -151,8 +153,8 @@
                 </div>
 
                 <div class="uk-form-controls" *ngIf="representativeListMatch">
-                  <div class="uk-inline uk-width-1-1">
-                    <span class="uk-label uk-label-danger">{{ representativeListMatch }}</span>
+                  <div class="uk-inline uk-width-1-1 uk-margin-small-top">
+                    <span class="account-label rep">{{ representativeListMatch }}</span>
                   </div>
                 </div>
 

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -3,62 +3,91 @@
     
     <div class="uk-margin-bottom" uk-grid>
       <div class="uk-width-expand@s uk-width-1-1">
-        <h2 class="uk-heading-divider">Representatives Overview</h2>
+        <h2 class="uk-heading-divider">Representatives</h2>
       </div>
       <div class="uk-width-auto@s uk-width-1-1 uk-text-right">
         <a routerLink="/manage-representatives" class="uk-button uk-button-secondary uk-align-right uk-width-auto@s">Manage Known Reps</a>
       </div>
     </div>
 
-    <!-- Send Panel -->
     <div uk-grid class="uk-animation-slide-left-small uk-margin-remove-top">
       <div class="uk-width-1-1">
 
-        <div class="uk-card uk-card-default" *ngIf="!hideOverview">
-          <div class="uk-card-body uk-padding-remove-bottom">
-            <p class="uk-text-lead uk-text-center">You have delegated voting weight to the following representatives</p>
-
-
-            <ul class="uk-list uk-list-striped" style="margin-bottom: 0;">
-              <li style="background: #fff; border-bottom: 0;">
-                <div uk-grid style="color: #999; text-transform: uppercase; font-size: .875rem; font-weight: 400;">
-                  <div class="uk-width-1-5">Status</div>
-                  <div class="uk-width-expand">Representative</div>
-                  <div class="uk-width-1-4">Weight</div>
-                </div>
-              </li>
-            </ul>
-            <ul class="uk-list uk-list-striped" style="margin-top: 0;">
-              <li *ngFor="let rep of representativeOverview">
-                <div uk-grid class="">
-
-                  <div class="uk-width-1-5" [ngClass]="{ 'uk-text-danger': rep.statusText === 'alert', 'uk-text-warning': rep.statusText === 'warn', 'uk-text-success': rep.statusText === 'trusted', 'uk-text-primary': rep.statusText === 'ok' }">
-                    <span *ngIf="rep.statusText === 'alert'" uk-tooltip title="This is an unknown or official representative, or it's marked because of bad uptime or high (3%+ of online) voting weight.  It is recommended to change to a new representative!"><span uk-icon="icon: warning"></span> Change</span>
-                    <span *ngIf="rep.statusText === 'warn'" uk-tooltip title="This representative has a bad uptime or a high (2%+ of online) voting weight.  Consider changing to a new representative."><span uk-icon="icon: warning"></span> Change</span>
-                    <span *ngIf="rep.statusText === 'trusted'" uk-tooltip title="This representative is marked as trusted.  No change is needed."><span uk-icon="icon: star"></span> Trusted</span>
-                    <span *ngIf="rep.statusText === 'ok'" uk-tooltip title="This representative is saved in your list, as long as it is online, no change is needed."><span uk-icon="icon: check"></span> Okay</span>
-                    <span *ngIf="rep.statusText === 'none'" uk-tooltip title="This representative is not known, consider switching to a known one or add this one to your list"><span uk-icon="icon: question"></span> Unknown</span>
-                  </div>
-                  <div class="uk-width-expand uk-text-truncate" (click)="addSelectedAccounts(rep.accounts)" style="cursor: pointer;" uk-tooltip title="Select the accounts which are using this representative">
-                    <span class="circle circle-online" *ngIf="rep.status.online" uk-tooltip title="Representative is online"></span>
-                    <span class="circle circle-offline" *ngIf="!rep.status.online" uk-tooltip title="Representative is offline"></span>
-                    <span *ngIf="rep.label">{{ rep.label }}</span> <span *ngIf="!rep.label"><app-nano-account-id [accountID]="rep.id" middle="on" class="nano-address-monospace"></app-nano-account-id></span>
-                  </div>
-                  <div class="uk-width-1-4">
+        <div class="uk-card uk-overflow-auto" *ngIf="!hideOverview">
+          <table class="uk-table uk-table-striped uk-table-small">
+            <thead>
+              <tr>
+                <th scope="col" class="representative-health-column-header">Status</th>
+                <th scope="col" class="uk-width-expand">Representative</th>
+                <th scope="col" class="voting-weight-column-header uk-width-1-4 uk-text-right">Voting Weight</th>
+              </tr>
+            </thead>
+            <tbody>
+              <ng-container *ngFor="let rep of representativeOverview">
+                <tr class="representative-row">
+                  <td class="representative-health-column uk-visible-toggle uk-text-truncate">
+                    <ng-container [ngSwitch]="true">
+                      <div class="representative-health-status health-green" *ngSwitchCase="(rep.statusText == 'trusted')">
+                        <div class="health-icon"></div>
+                        <div class="label">Good</div>
+                      </div>
+                      <div class="representative-health-status health-green" *ngSwitchCase="(rep.statusText == 'ok')">
+                        <div class="health-icon"></div>
+                        <div class="label">Good</div>
+                      </div>
+                      <div class="representative-health-status health-yellow" *ngSwitchCase="(rep.statusText == 'warn')">
+                        <div class="health-icon"></div>
+                        <div class="label">Acceptable</div>
+                      </div>
+                      <div class="representative-health-status health-red" *ngSwitchCase="(rep.statusText == 'alert')">
+                        <div class="health-icon"></div>
+                        <div class="label">Bad</div>
+                      </div>
+                      <div class="representative-health-status health-unknown" *ngSwitchDefault>
+                        <div class="health-icon"></div>
+                        <div class="label">Unknown</div>
+                      </div>
+                    </ng-container>
+                  </td>
+                  <td class="representative-name-column uk-text-truncate" (click)="addSelectedAccounts(rep.accounts)" style="cursor: pointer;">
+                    <div class="account-label rep">{{ rep.label ? rep.label : 'Unknown Rep' }}</div><div class="uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="rep.id" middle="on" class="nano-address-monospace"></app-nano-account-id></div>
+                  </td>
+                  <td class="voting-weight-column uk-width-1-4">
+                    <div class="uk-text-small uk-text-muted">Total</div>
                     {{ rep.delegatedWeight | rai: 'mnano' }}
-                  </div>
-
-                </div>
-              </li>
-              <li *ngIf="!representativeOverview || !representativeOverview.length" class="uk-text-center">
-                None of your accounts have delegated any voting weight yet, you must receive a transaction to change your representative!
-              </li>
-            </ul>
-            <p class="uk-text-center uk-margin-small-bottom">
-              <small>Click on a representative to select all of the accounts delegated to it</small>
-            </p>
-          </div>
+                  </td>
+                </tr>
+                <tr class="delegating-account-row" *ngFor="let delegatingAccount of rep.accounts">
+                  <td class="representative-health-column"></td>
+                  <td class="uk-text-truncate">
+                    <div class="delegating-account">
+                      <div class="descendant-icon"></div>
+                      <div class="descendant-details uk-text-truncate">
+                        <div class="descendant-label">
+                          <div class="account-label">{{
+                              delegatingAccount.addressBookName
+                            ? delegatingAccount.addressBookName
+                            : 'Account'
+                          }}</div>
+                        </div>
+                        <div class="descendant-address uk-text-truncate">
+                          <app-nano-account-id [accountID]="delegatingAccount.id" middle="on" class="nano-address-monospace"></app-nano-account-id>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="voting-weight-column uk-width-1-4 uk-text-small">
+                    {{ delegatingAccount.balance | rai: 'mnano' }}
+                  </td>
+                </tr>
+              </ng-container>
+              <tr *ngIf="!representativeOverview || !representativeOverview.length" class="uk-text-center">
+                <td colspan="3" style="text-align: center;">None of your accounts have delegated any voting weight yet, you must receive a transaction to change your representative!</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
+
       </div>
 
 

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -23,6 +23,7 @@
               </tr>
             </thead>
             <tbody>
+              <ng-container *ngIf="!loadingRepresentatives">
               <ng-container *ngFor="let rep of representativeOverview">
                 <tr class="representative-row">
                   <td class="representative-health-column uk-visible-toggle uk-text-truncate">
@@ -81,8 +82,12 @@
                   </td>
                 </tr>
               </ng-container>
-              <tr *ngIf="!representativeOverview || !representativeOverview.length" class="uk-text-center">
+              </ng-container>
+              <tr *ngIf="!loadingRepresentatives && ( !representativeOverview || !representativeOverview.length )" class="uk-text-center">
                 <td colspan="3" style="text-align: center;">None of your accounts have delegated any voting weight yet, you must receive a transaction to change your representative!</td>
+              </tr>
+              <tr *ngIf="loadingRepresentatives">
+                <td colspan="3" style="text-align: center;"><span class="uk-margin-right" uk-spinner></span> Fetching information about your representatives...</td>
               </tr>
             </tbody>
           </table>

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -14,6 +14,8 @@
       <div class="uk-width-1-1">
 
         <div class="uk-card uk-overflow-auto" *ngIf="!hideOverview">
+          <p>Representatives participate in the Nano consensus protocol on your behalf. You can change them at any time.</p>
+
           <table class="uk-table uk-table-striped uk-table-small">
             <thead>
               <tr>
@@ -120,10 +122,10 @@
                           <div *ngIf="(account.id === 'All Current Accounts')">{{ account.id }}</div>
                           <ng-container *ngIf="(account.id !== 'All Current Accounts')">
                             <div class="uk-margin-small-right account-label blue">{{ account.addressBookName ? account.addressBookName : 'Account' }}</div>
-                            <app-nano-account-id [accountID]="account.id" middle="on" class="nano-address-monospace"></app-nano-account-id>
+                            <div class="uk-text-truncate"><app-nano-account-id [accountID]="account.id" middle="on" class="nano-address-monospace"></app-nano-account-id></div>
                           </ng-container>
                         </div>
-                        <div class="uk-width-1-6 uk-text-center" style="padding-left: 0;">
+                        <div class="action-remove uk-width-1-6 uk-text-center">
                           <a (click)="removeSelectedAccount(account)" class="uk-text-danger" title="Remove From List" uk-tooltip><span uk-icon="icon: close;"></span></a>
                         </div>
                       </div>

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -49,7 +49,7 @@
                       </div>
                     </ng-container>
                   </td>
-                  <td class="representative-name-column uk-text-truncate" (click)="addSelectedAccounts(rep.accounts)" style="cursor: pointer;">
+                  <td class="representative-name-column uk-text-truncate rep-container" (click)="addSelectedAccounts(rep.accounts)">
                     <div class="account-label rep">{{ rep.label ? rep.label : 'Unknown Rep' }}</div><div class="uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="rep.id" middle="on" class="nano-address-monospace"></app-nano-account-id></div>
                   </td>
                   <td class="voting-weight-column uk-width-1-4">
@@ -59,7 +59,7 @@
                 </tr>
                 <tr class="delegating-account-row" *ngFor="let delegatingAccount of rep.accounts">
                   <td class="representative-health-column"></td>
-                  <td class="uk-text-truncate">
+                  <td class="delegating-account-details-column uk-text-truncate account-container" (click)="addSelectedAccounts([ delegatingAccount ])">
                     <div class="delegating-account">
                       <div class="descendant-icon"></div>
                       <div class="descendant-details uk-text-truncate">

--- a/src/app/components/representatives/representatives.component.ts
+++ b/src/app/components/representatives/representatives.component.ts
@@ -42,6 +42,7 @@ export class RepresentativesComponent implements OnInit {
   recommendedRepsLoading = false;
   selectedRecommendedRep = null;
   showRecommendedReps = false;
+  loadingRepresentatives = false;
 
   repsPerPage = 5;
   currentRepPage = 0;
@@ -82,6 +83,7 @@ export class RepresentativesComponent implements OnInit {
       }
     });
 
+    this.loadingRepresentatives = true;
     let repOverview = await this.representativeService.getRepresentativesOverview();
     // Sort by weight delegated
     repOverview = repOverview.sort(
@@ -89,6 +91,7 @@ export class RepresentativesComponent implements OnInit {
     );
     this.representativeOverview = repOverview;
     repOverview.forEach(o => this.fullAccounts.push(...o.accounts));
+    this.loadingRepresentatives = false;
 
     // populate representative list
     const verifiedReps = await this.ninja.recommendedRandomized();
@@ -327,7 +330,9 @@ export class RepresentativesComponent implements OnInit {
 
     // If the overview panel is displayed, reload its data now
     if (!this.hideOverview) {
+      this.loadingRepresentatives = true;
       this.representativeOverview = await this.representativeService.getRepresentativesOverview();
+      this.loadingRepresentatives = false;
       useCachedReps = true;
     }
 

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -2,6 +2,8 @@
 
 @nlt-intro-margin:                        40px;
 
+@rep-label-color:                      #9A71D5;
+
 // extensions
 // ========================================================================
 
@@ -129,7 +131,7 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
     }
 
     &.rep {
-        @rep-label-color: #9A71D5;
+        text-transform: none;
         border-color: @rep-label-color;
         background: @rep-label-color;
         color: #FFF;
@@ -172,6 +174,14 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
 
     .nano-address-clickable {
         .nano-address-clickable-hover-styles();
+    }
+}
+
+.rep-container:hover {
+    .account-label.rep {
+        border: 2px solid @rep-label-color;
+        background: transparent;
+        color: @rep-label-color;
     }
 }
 

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -127,6 +127,13 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
     &.interactable:hover, &.blue {
         .account-label-hover-styles();
     }
+
+    &.rep {
+        @rep-label-color: #9A71D5;
+        border-color: @rep-label-color;
+        background: @rep-label-color;
+        color: #FFF;
+    }
 }
 
 .nano-address-monospace {


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/29272208/105192316-dfb98500-5b2f-11eb-9ec4-dd39e1707339.png)

after:

![image](https://user-images.githubusercontent.com/29272208/105196438-86ebeb80-5b33-11eb-9e15-022d6af3d2ed.png)

i wasn't able to show account indexes here e.g. `Account #7`, as the index isn't part of the account object. perhaps someone could implement that later on

\-

reps book also undertook some changes, mostly to provide clarity and avoid possible confusion with the list of used reps

before:

![image](https://user-images.githubusercontent.com/29272208/105193174-5b1b3680-5b30-11eb-8390-d84ec1d45cfc.png)

after:

![image](https://user-images.githubusercontent.com/29272208/105193358-666e6200-5b30-11eb-948e-88792680334f.png)

\-

fixes #188
