### PR TITLE
Improving the PoW threshold used for different block types

### DIFF
--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -77,7 +77,12 @@ export class ReceiveComponent implements OnInit {
           if (!frontiers.frontiers.hasOwnProperty(account)) {
             continue;
           }
-          this.workPool.addWorkToCache(frontiers.frontiers[account]);
+          // Technically should be 1/64 multiplier here but since we don't know if the pending will be received before
+          // a send or change block is made it's safer to use 1x PoW threshold to be sure the cache will work.
+          // On the other hand, it may be more efficient to use 1/64 and simply let the work cache rework in case a send is made instead
+          // The typical user scenario would be to let the wallet auto receive first
+          console.log('Adding pending to work cache');
+          this.workPool.addWorkToCache(frontiers.frontiers[account], 1 / 64);
         }
       }
     }

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -295,7 +295,7 @@ export class SendComponent implements OnInit {
     // Start precomputing the work...
     this.fromAddressBook = this.addressBookService.getAccountName(this.fromAccountID);
     this.toAddressBook = this.addressBookService.getAccountName(destinationID);
-    this.workPool.addWorkToCache(this.fromAccount.frontier);
+    this.workPool.addWorkToCache(this.fromAccount.frontier, 1);
 
     this.activePanel = 'confirm';
   }

--- a/src/app/components/sign/sign.component.ts
+++ b/src/app/components/sign/sign.component.ts
@@ -385,7 +385,12 @@ export class SignComponent implements OnInit {
         this.notificationService.sendInfo(`Generating Proof of Work...`);
       }
 
-      this.currentBlock.work = await this.workPool.getWork(workBlock);
+      if (this.txType === TxType.receive || this.txType === TxType.open) {
+        this.currentBlock.work = await this.workPool.getWork(workBlock, 1 / 64);
+      } else {
+        this.currentBlock.work = await this.workPool.getWork(workBlock, 1);
+      }
+
       this.workPool.removeFromCache(workBlock);
     }
 

--- a/src/app/components/sweeper/sweeper.component.ts
+++ b/src/app/components/sweeper/sweeper.component.ts
@@ -254,7 +254,7 @@ export class SweeperComponent implements OnInit {
     // make an extra check on valid destination
     if (this.validDestination && nanocurrency.checkAddress(this.destinationAccount)) {
       this.appendLog('Transfer started: ' + address);
-      const work = await this.workPool.getWork(previous);
+      const work = await this.workPool.getWork(previous, 1); // send threshold
       // create the block with the work found
       const block = nanocurrency.createBlock(privKey, {balance: '0', representative: this.representative,
       work: work, link: this.destinationAccount, previous: previous});
@@ -304,7 +304,7 @@ export class SweeperComponent implements OnInit {
         // input hash is the opening address public key
         workInputHash = this.pubKey;
       }
-      const work = await this.workPool.getWork(workInputHash);
+      const work = await this.workPool.getWork(workInputHash, 1 / 64); // receive threshold
       // create the block with the work found
       const block = nanocurrency.createBlock(this.privKey, {balance: this.adjustedBalance, representative: this.representative,
       work: work, link: key, previous: this.previous});

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -78,8 +78,8 @@ export class ApiService {
   async blockCount(): Promise<{count: number, unchecked: number, cemented: number }> {
     return await this.request('block_count', { include_cemented: 'true'});
   }
-  async workGenerate(hash): Promise<{ work: string }> {
-    return await this.request('work_generate', { hash });
+  async workGenerate(hash, difficulty): Promise<{ work: string }> {
+    return await this.request('work_generate', { hash, difficulty });
   }
   async process(block, subtype: TxType): Promise<{ hash: string, error?: string }> {
     return await this.request('process', { block: JSON.stringify(block), watch_work: 'false', subtype: TxType[subtype] });

--- a/src/app/services/nano-block.service.ts
+++ b/src/app/services/nano-block.service.ts
@@ -82,7 +82,7 @@ export class NanoBlockService {
     const processResponse = await this.api.process(blockData, TxType.change);
     if (processResponse && processResponse.hash) {
       walletAccount.frontier = processResponse.hash;
-      this.workPool.addWorkToCache(processResponse.hash); // Add new hash into the work pool
+      this.workPool.addWorkToCache(processResponse.hash, 1); // Add new hash into the work pool, high PoW threshold for change block
       this.workPool.removeFromCache(toAcct.frontier);
       return processResponse.hash;
     } else {
@@ -230,7 +230,7 @@ export class NanoBlockService {
     if (!processResponse || !processResponse.hash) throw new Error(processResponse.error || `Node returned an error`);
 
     walletAccount.frontier = processResponse.hash;
-    this.workPool.addWorkToCache(processResponse.hash); // Add new hash into the work pool
+    this.workPool.addWorkToCache(processResponse.hash, 1); // Add new hash into the work pool, high PoW threshold for send block
     this.workPool.removeFromCache(fromAccount.frontier);
 
     return processResponse.hash;
@@ -296,11 +296,13 @@ export class NanoBlockService {
       this.notifications.sendInfo(`Generating Proof of Work...`);
     }
 
-    blockData.work = await this.workPool.getWork(workBlock);
+    console.log('Get work for receive block');
+    blockData.work = await this.workPool.getWork(workBlock, 1 / 64); // low PoW threshold since receive block
     const processResponse = await this.api.process(blockData, openEquiv ? TxType.open : TxType.receive);
     if (processResponse && processResponse.hash) {
       walletAccount.frontier = processResponse.hash;
-      this.workPool.addWorkToCache(processResponse.hash); // Add new hash into the work pool
+      // Add new hash into the work pool, high PoW threshold since we don't know what the next one will be
+      this.workPool.addWorkToCache(processResponse.hash, 1);
       this.workPool.removeFromCache(workBlock);
 
       // update the rep view via subscription

--- a/src/app/services/nano-block.service.ts
+++ b/src/app/services/nano-block.service.ts
@@ -77,7 +77,7 @@ export class NanoBlockService {
       this.notifications.sendInfo(`Generating Proof of Work...`);
     }
 
-    blockData.work = await this.workPool.getWork(toAcct.frontier);
+    blockData.work = await this.workPool.getWork(toAcct.frontier, 1);
 
     const processResponse = await this.api.process(blockData, TxType.change);
     if (processResponse && processResponse.hash) {
@@ -224,7 +224,7 @@ export class NanoBlockService {
       this.notifications.sendInfo(`Generating Proof of Work...`);
     }
 
-    blockData.work = await this.workPool.getWork(fromAccount.frontier);
+    blockData.work = await this.workPool.getWork(fromAccount.frontier, 1);
 
     const processResponse = await this.api.process(blockData, TxType.send);
     if (!processResponse || !processResponse.hash) throw new Error(processResponse.error || `Node returned an error`);
@@ -302,7 +302,8 @@ export class NanoBlockService {
     if (processResponse && processResponse.hash) {
       walletAccount.frontier = processResponse.hash;
       // Add new hash into the work pool, high PoW threshold since we don't know what the next one will be
-      this.workPool.addWorkToCache(processResponse.hash, 1);
+      // Skip adding new work cache directly, let reloadBalances() check for pending and decide instead
+      // this.workPool.addWorkToCache(processResponse.hash, 1);
       this.workPool.removeFromCache(workBlock);
 
       // update the rep view via subscription

--- a/src/app/services/pow.service.ts
+++ b/src/app/services/pow.service.ts
@@ -167,7 +167,7 @@ export class PowService {
     const newThreshold = this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold);
     console.log('Generating work with multiplier ' + multiplier + ' at threshold ' +
       newThreshold + ' using remote server for hash: ', hash);
-    return await this.api.workGenerate(hash)
+    return await this.api.workGenerate(hash, newThreshold)
     .then(work => work.work)
     .catch(async err => await this.getHashCPUWorker(hash, multiplier));
   }

--- a/src/app/services/pow.service.ts
+++ b/src/app/services/pow.service.ts
@@ -165,7 +165,8 @@ export class PowService {
    */
   async getHashServer(hash, multiplier) {
     const newThreshold = this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold);
-    console.log('Generating work at threshold ' + newThreshold + ' using remote server', hash);
+    console.log('Generating work with multiplier ' + multiplier + ' at threshold ' +
+      newThreshold + ' using remote server for hash: ', hash);
     return await this.api.workGenerate(hash)
     .then(work => work.work)
     .catch(async err => await this.getHashCPUWorker(hash, multiplier));
@@ -211,7 +212,8 @@ export class PowService {
     const newThreshold = this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold);
 
     const work = () => new Promise(resolve => {
-      console.log('Generating work at threshold ' + newThreshold + ' using CPU workers for', hash);
+      console.log('Generating work with multiplier ' + multiplier + ' at threshold ' +
+        newThreshold + ' using CPU workers for hash: ', hash);
       workerList = [];
       for (let i = 0; i < workerCount; i++) {
         // const worker = new Worker()
@@ -245,7 +247,7 @@ export class PowService {
    */
   getHashWebGL(hash, multiplier) {
     const newThreshold = this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold);
-    console.log('Generating work at threshold ' + newThreshold + ' using WebGL for', hash);
+    console.log('Generating work with multiplier ' + multiplier + ' at threshold ' + newThreshold + ' using WebGL for hash: ', hash);
 
     const response = this.getDeferredPromise();
 

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -722,13 +722,6 @@ export class WalletService {
                 }
                 walletPendingReal = walletPendingReal.plus(pending.blocks[block][hash].amount);
                 accountPending = accountPending.plus(pending.blocks[block][hash].amount);
-
-                // Technically should be 1/64 multiplier here but since we don't know if the pending will be received before
-                // a send or change block is made it's safer to use 1x PoW threshold to be sure the cache will work.
-                // On the other hand, it may be more efficient to use 1/64 and simply let the work cache rework
-                // in case a send is made instead. The typical user scenario would be to let the wallet auto receive first
-                console.log('Adding single pending to work cache');
-                this.workPool.addWorkToCache(hash, 1 / 64);
               }
               // Update the actual account pending amount with this above-threshold-value
               walletAccount.pendingBelowThreshold.push(walletAccount.pendingOriginal.minus(accountPending));
@@ -736,6 +729,18 @@ export class WalletService {
               walletAccount.pending = accountPending;
               walletAccount.pendingRaw = accountPending.mod(this.nano);
               walletAccount.pendingFiat = this.util.nano.rawToMnano(accountPending).times(fiatPrice).toNumber();
+
+              // If there is a pending, it means we want to add to work cache as receive-threshold
+              if (walletAccount.pending.gt(0)) {
+                console.log('Adding single pending account within limit to work cache');
+                // Use frontier or public key if open block
+                const hash = walletAccount.frontier || this.util.account.getAccountPublicKey(walletAccount.id);
+                // Technically should be 1/64 multiplier here but since we don't know if the pending will be received before
+                // a send or change block is made it's safer to use 1x PoW threshold to be sure the cache will work.
+                // On the other hand, it may be more efficient to use 1/64 and simply let the work cache rework
+                // in case a send is made instead. The typical user scenario would be to let the wallet auto receive first
+                this.workPool.addWorkToCache(hash, 1 / 64);
+              }
             } else {
               walletAccount.pendingBelowThreshold.push(walletAccount.pendingOriginal);
               walletAccount.pendingBelowThreshold.shift();
@@ -760,7 +765,7 @@ export class WalletService {
     // Make sure any frontiers are in the work pool
     // If they have no frontier, we want to use their pub key?
     const hashes = this.wallet.accounts.map(account => account.frontier || this.util.account.getAccountPublicKey(account.id));
-    console.log('Adding frontiers to work cache');
+    console.log('Adding non-pending frontiers to work cache');
     hashes.forEach(hash => this.workPool.addWorkToCache(hash, 1)); // use high pow here since we don't know what tx type will be next
 
     this.wallet.balance = walletBalance;
@@ -799,6 +804,18 @@ export class WalletService {
       walletAccount.pending = new BigNumber(accounts.balances[accountID].pending);
       walletAccount.pendingRaw = new BigNumber(walletAccount.pending).mod(this.nano);
       walletAccount.pendingFiat = this.util.nano.rawToMnano(walletAccount.pending).times(this.price.price.lastPrice).toNumber();
+
+      // If there is a pending, it means we want to add to work cache as receive-threshold
+      if (walletAccount.pending.gt(0)) {
+        console.log('Adding single pending account to work cache');
+        // Use frontier or public key if open block
+        const hash = walletAccount.frontier || this.util.account.getAccountPublicKey(walletAccount.id);
+        // Technically should be 1/64 multiplier here but since we don't know if the pending will be received before
+        // a send or change block is made it's safer to use 1x PoW threshold to be sure the cache will work.
+        // On the other hand, it may be more efficient to use 1/64 and simply let the work cache rework
+        // in case a send is made instead. The typical user scenario would be to let the wallet auto receive first
+        this.workPool.addWorkToCache(hash, 1 / 64);
+      }
     }
   }
 

--- a/src/app/services/work-pool.service.ts
+++ b/src/app/services/work-pool.service.ts
@@ -58,14 +58,16 @@ export class WorkPoolService {
         await this.sleep(100);
         cached = this.workCache.find(p => p.hash === hash);
       }
-      if (cached && cached.work && this.util.nano.validateWork(hash, this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold), cached.work)) {
+      if (cached && cached.work &&
+          this.util.nano.validateWork(hash, this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold), cached.work)) {
         console.log('Using pre-processed work: ' + cached.work);
         return cached.work;
       }
       // if the work was invalid and removed from cache, also invalidate the response
       console.log('Invalid pre-processed work');
       return null;
-    } else if (cached && cached.work && this.util.nano.validateWork(hash, this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold), cached.work)) {
+    } else if (cached && cached.work &&
+        this.util.nano.validateWork(hash, this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold), cached.work)) {
       console.log('Using cached work: ' + cached.work);
       return cached.work;
     }

--- a/src/app/services/work-pool.service.ts
+++ b/src/app/services/work-pool.service.ts
@@ -21,7 +21,7 @@ export class WorkPoolService {
   }
 
   // A simple helper, which doesn't wait for a response (Used for pre-loading work)
-  public addWorkToCache(hash, multiplier= 1) {
+  public addWorkToCache(hash, multiplier = 1) {
     this.getWork(hash, multiplier);
   }
 
@@ -47,7 +47,7 @@ export class WorkPoolService {
   }
 
   // Get work for a hash.  Uses the cache, or the current setting for generating it.
-  public async getWork(hash, multiplier= 1) {
+  public async getWork(hash, multiplier = 1) {
     let cached = this.workCache.find(p => p.hash === hash);
     const tempWork = '1';
 

--- a/src/app/services/work-pool.service.ts
+++ b/src/app/services/work-pool.service.ts
@@ -10,6 +10,8 @@ export class WorkPoolService {
   cacheLength = 25;
   workCache = [];
 
+  currentlyProcessingHashes = {};
+
   constructor(private pow: PowService, private notifications: NotificationService, private util: UtilService) { }
 
   sleep(ms) {
@@ -48,49 +50,36 @@ export class WorkPoolService {
 
   // Get work for a hash.  Uses the cache, or the current setting for generating it.
   public async getWork(hash, multiplier = 1) {
-    let cached = this.workCache.find(p => p.hash === hash);
-    const tempWork = '1';
-
-    // if work is requested while work is already being processed for this hash
-    if (cached && cached.work === tempWork) {
-      // wait for current pow to finish or fail
-      while (cached && cached.work === tempWork) {
-        await this.sleep(100);
-        cached = this.workCache.find(p => p.hash === hash);
-      }
-      if (cached && cached.work &&
-          this.util.nano.validateWork(hash, this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold), cached.work)) {
-        console.log('Using pre-processed work: ' + cached.work);
-        return cached.work;
-      }
-      // if the work was invalid and removed from cache, also invalidate the response
-      console.log('Invalid pre-processed work');
-      return null;
-    } else if (cached && cached.work &&
-        this.util.nano.validateWork(hash, this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold), cached.work)) {
-      console.log('Using cached work: ' + cached.work);
-      return cached.work;
+    while ( this.currentlyProcessingHashes[hash] === true ) {
+      await this.sleep(100);
     }
 
-    // add temp work to prevent duplicate hashes in the cache due to asynchronous calls during "await"
-    let work = tempWork;
-    this.workCache.push({ hash, work });
+    const cached = this.workCache.find(p => p.hash === hash);
 
-    work = await this.pow.getPow(hash, multiplier);
+    try {
+      if (cached && cached.work &&
+          this.util.nano.validateWork(hash, this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold), cached.work)) {
+        console.log('Using cached work: ' + cached.work);
+        return cached.work;
+      }
+    } catch(err) {
+      console.log('Error validating cached work. ' + err);
+    }
+
+    this.currentlyProcessingHashes[hash] = true;
+
+    const work = await this.pow.getPow(hash, multiplier);
+
     if (!work) {
-      this.notifications.sendWarning(`Failed to retrieve work for ${hash}.  Try a different PoW method.`);
-      // remove temp work (will also break the while loop above for parallel threads)
-      const x = this.workCache.findIndex(p => p.hash === hash && p.work === tempWork);
-      if (x !== -1) this.workCache.splice(x, 1);
+      this.notifications.sendWarning(`Failed to retrieve work for ${hash}. Try a different PoW method.`);
+      delete this.currentlyProcessingHashes[hash];
       return null;
     }
 
     console.log('Work found: ' + work);
 
-    this.workCache.push({ hash, work }); // add the real work
-    // remove temp work (important to remove after push to avoid possible race condition)
-    const index = this.workCache.findIndex(p => p.hash === hash && p.work === tempWork);
-    if (index !== -1) this.workCache.splice(index, 1);
+    this.workCache.push({ hash, work });
+    delete this.currentlyProcessingHashes[hash];
 
     if (this.workCache.length >= this.cacheLength) this.workCache.shift(); // Prune if we are at max length
     this.saveWorkCache();

--- a/src/app/services/work-pool.service.ts
+++ b/src/app/services/work-pool.service.ts
@@ -58,16 +58,14 @@ export class WorkPoolService {
         await this.sleep(100);
         cached = this.workCache.find(p => p.hash === hash);
       }
-      if (cached && cached.work && cached.multiplier === multiplier &&
-        this.util.nano.validateWork(hash, this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold), cached.work)) {
+      if (cached && cached.work && this.util.nano.validateWork(hash, this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold), cached.work)) {
         console.log('Using pre-processed work: ' + cached.work);
         return cached.work;
       }
       // if the work was invalid and removed from cache, also invalidate the response
       console.log('Invalid pre-processed work');
       return null;
-    } else if (cached && cached.work &&
-      this.util.nano.validateWork(hash, this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold), cached.work)) {
+    } else if (cached && cached.work && this.util.nano.validateWork(hash, this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold), cached.work)) {
       console.log('Using cached work: ' + cached.work);
       return cached.work;
     }

--- a/src/app/services/work-pool.service.ts
+++ b/src/app/services/work-pool.service.ts
@@ -62,7 +62,7 @@ export class WorkPoolService {
         console.log('Using cached work: ' + cached.work);
         return cached.work;
       }
-    } catch(err) {
+    } catch (err) {
       console.log('Error validating cached work. ' + err);
     }
 
@@ -77,6 +77,9 @@ export class WorkPoolService {
     }
 
     console.log('Work found: ' + work);
+
+    // remove duplicates
+    this.workCache = this.workCache.filter(entry => (entry.hash !== hash));
 
     this.workCache.push({ hash, work });
     delete this.currentlyProcessingHashes[hash];

--- a/src/app/services/work-pool.service.ts
+++ b/src/app/services/work-pool.service.ts
@@ -58,14 +58,16 @@ export class WorkPoolService {
         await this.sleep(100);
         cached = this.workCache.find(p => p.hash === hash);
       }
-      if (cached && cached.work && this.util.nano.validateWork(hash, baseThreshold, cached.work)) {
+      if (cached && cached.work && cached.multiplier === multiplier &&
+        this.util.nano.validateWork(hash, this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold), cached.work)) {
         console.log('Using pre-processed work: ' + cached.work);
         return cached.work;
       }
       // if the work was invalid and removed from cache, also invalidate the response
       console.log('Invalid pre-processed work');
       return null;
-    } else if (cached && cached.work && this.util.nano.validateWork(hash, baseThreshold, cached.work)) {
+    } else if (cached && cached.work &&
+      this.util.nano.validateWork(hash, this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold), cached.work)) {
       console.log('Using cached work: ' + cached.work);
       return cached.work;
     }

--- a/src/assets/lib/pow/nano-webgl-pow.js
+++ b/src/assets/lib/pow/nano-webgl-pow.js
@@ -327,7 +327,7 @@ window.NanoWebglPow = calculate;
 // Both width and height must be multiple of 256, (one byte)
 // but do not need to be the same,
 // matching GPU capabilities is the aim
-window.NanoWebglPow.width = 256 * 2;
-window.NanoWebglPow.height = 256 * 2;
+window.NanoWebglPow.width = 256 * 4;
+window.NanoWebglPow.height = 256 * 4;
 
 })();


### PR DESCRIPTION
A first try to reduce the work needed for open/receive blocks.

Problem is Nault is not designed to support this from the beginning and the way it always tries to cache work in advance makes it more or less impossible to solve. When you precache work you don't know what the next block will be so the only time you can take advantage of lower pow is when requesting a receive block with no existing cache.

**There is only one use-case found when that happens (all of these must be fulfilled):**
* User has Nault open with no existing work cache
* A transaction is incoming or has been sent earlier but not yet received (for example when using manual receive)
* Opens the receive screen: Now it will check for pending and cache 1/64 pow since it's most likely that will be the next block

The suggestion from issue 264 was to add 1/64 when a block was requested from the block service here: https://github.com/Nault/Nault/compare/correct-receive-pow?expand=1#diff-19f3dac78ed255aab575eeaf33008b09a262bd8de14b9133294bc771ef68fd24R300

But I can't find a single occurrence when that happens AND there is no cache. Either the 1x work cache has already been added via the [reloadBalances() function](https://github.com/Nault/Nault/compare/correct-receive-pow?expand=1#diff-9346ac0e59e5e9a58990fc61941ecfc327b8584c175198647a67d8536bef9a00R764) (which is called all over the place) or it has been added after a previous receive action here: https://github.com/Nault/Nault/compare/correct-receive-pow?expand=1#diff-19f3dac78ed255aab575eeaf33008b09a262bd8de14b9133294bc771ef68fd24R305

Which means, even when receiving many incoming at once, it will still use 1x pow.

**EDIT**
Now it skips adding new work directly after a receive. It will check for pending and if any pending using 1/64 instead. If there are no more pending, it will use 1x. That means multiple receive (auto or manually) will use the lower pow now (except the first that will use whatever in the cache). The pow API service has been updated to include difficulty as parameter. This will be utilized by bpow backends (proxy.nanos.cc) but not yet dpow.

fixes #264 