### PR TITLE
Account summary redesign

### DIFF
--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -158,6 +158,10 @@
     position: relative;
 }
 
+.representative-details, .balance-details {
+    min-height: 85px;
+}
+
 @media (max-width: 1199px) {
     /* horizontal separator between rep details and balances */
     .representative-details::after {
@@ -224,6 +228,7 @@
     width: 180px;
     height: 180px;
     background: #FFF;
+    margin-bottom: 0;
 }
 .uk-modal-body .qr-code {
     width: 180px;
@@ -232,6 +237,7 @@
 @media (max-width: 1199px) {
     .uk-modal-body .qr-code-placeholder, .uk-modal-body .qr-code {
         min-width: 180px;
+        min-height: 180px;
         width: 60%;
         height: auto;
     }

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -87,6 +87,8 @@
     padding-bottom: 1px;
     text-transform: uppercase;
     color: #FFF;
+    margin-top: -3px;
+    margin-bottom: -3px;
 }
 
 .incoming-label > .text-full {

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -214,3 +214,12 @@
 .form-amount {
     max-width: 450px;
 }
+
+.qr-code-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 180px;
+    height: 180px;
+    background: #FFF;
+}

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -217,11 +217,28 @@
     max-width: 450px;
 }
 
-.qr-code-placeholder {
+.uk-modal-body .qr-code-placeholder {
     display: flex;
     align-items: center;
     justify-content: center;
     width: 180px;
     height: 180px;
     background: #FFF;
+}
+.uk-modal-body .qr-code {
+    width: 180px;
+    height: 180px;
+}
+@media (max-width: 1199px) {
+    .uk-modal-body .qr-code-placeholder, .uk-modal-body .qr-code {
+        min-width: 180px;
+        width: 60%;
+        height: auto;
+    }
+}
+@media (max-width: 699px) {
+    .uk-modal-body .qr-code-placeholder, .uk-modal-body .qr-code {
+        width: 80%;
+        height: auto;
+    }
 }

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -2,6 +2,13 @@
     margin-top: 2px;
 }
 
+.nano-address-actions li {
+    display: inline-block;
+}
+.nano-address-actions li + li {
+    margin-left: 7px;
+}
+
 .block-qr {
     margin:auto;
     width: 100%;
@@ -55,4 +62,143 @@
 }
 .refresh-disabled {
     color: #bbb;
+}
+
+.incoming-label {
+    display: inline-block;
+    background: #4a90e2;
+    border-radius: 20px;
+    font-size: 12px;
+    padding: 2px 10px;
+    margin-left: 7px;
+    vertical-align: 1px;
+    padding-bottom: 1px;
+    text-transform: uppercase;
+    color: #FFF;
+}
+
+.incoming-label > .text-full {
+    display: inline-block;
+}
+
+.incoming-label > .text-full > .amount-sign {
+    display: inline-block;
+    vertical-align: 1px;
+    margin-right: 1px;
+}
+
+.incoming-label > .text-full > .amount-integer {
+    display: inline-block;
+    font-size: 19px;
+    font-weight: 700;
+}
+
+.incoming-label > .text-full > .amount-fractional {
+    display: inline-block;
+}
+
+.incoming-label > .text-snippet {
+    display: none;
+}
+
+.details-header {
+    text-transform: uppercase;
+    font-size: 13px;
+    margin-bottom: 2px;
+}
+
+.representative-label-container {
+    display: flex;
+    align-items: center;
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+.account-amounts-primary {
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+    margin-top: 8px;
+    margin-bottom: 6px;
+}
+
+.account-amounts-primary-confirmed {
+    font-family: 'Montserrat', Arial, Helvetica, sans-serif;
+    line-height: 1;
+}
+
+.account-amounts-primary-confirmed > .amount-integer {
+    font-size: 26px;
+    font-weight: 700;
+}
+
+.account-amounts-primary-confirmed > .amount-fractional {
+    font-size: 16px;
+}
+
+.account-amounts-converted {
+    color: #81809f;
+}
+
+.representative-details {
+    position: relative;
+}
+
+@media (max-width: 1199px) {
+    /* horizontal separator between rep details and balances */
+    .representative-details::after {
+        content: '';
+        display: block;
+        position: absolute;
+        width: calc(100% + 30px);
+        height: 100%;
+        top: 14px;
+        left: 0;
+        border-bottom: 1px solid #dce9f9;
+    }
+}
+
+.advanced-options-link {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+}
+
+.advanced-options-link .chevron {
+    margin-left: 8px;
+}
+
+.chevron {
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2214%22%20height%3D%2214%22%20viewBox%3D%220%200%2014%2014%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%20%20%3Cpolyline%20fill%3D%22none%22%20stroke%3D%22%23676686%22%20stroke-width%3D%221.1%22%20points%3D%221%204%207%2010%2013%204%22%20%2F%3E%0A%3C%2Fsvg%3E");
+    width: 14px;
+    height: 14px;
+    display: inline-block;
+    margin-left: 4px;
+}
+
+.chevron-up {
+    transform: scaleY(-1);
+}
+
+.advanced-options {
+    margin-top: 20px;
+}
+
+.advanced-option {
+    display: flex;
+    align-items: center;
+    margin-bottom: 4px;
+}
+
+.advanced-option .uk-checkbox {
+    margin-left: 12px;
+    margin-top: -1px;
+}
+
+.form-input-destination {
+    max-width: 800px;
+}
+
+.form-amount {
+    max-width: 450px;
 }

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -9,6 +9,18 @@
     margin-left: 7px;
 }
 
+.icon-qr-code {
+    display: inline-block;
+    width: 19px;
+    height: 19px;
+    vertical-align: -5px;
+    background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACYAAAATCAMAAADLVI+CAAAAAXNSR0IArs4c6QAAAAlQTFRFAAAAZ2aGM3nK67MP8AAAAAN0Uk5TAP//RFDWIQAAALJJREFUKJFlUgEOxDAIAv7/6FsV0eRsu60pU8CCFSBqVqgCQs3efIeFyAL1njoLD+ZcDXubL1HnalhtDDPowgwamLMMOEUV8IO1BPBPAnQkOMhmd0LCOfdwwfcpDxesTxrBUdsKNe/ks4CpyxUwdbXeDrbmeuFWxLUYg7gWY64wMhyvVnOc1h+Hp/XX4Wk9V8603sXqh/R0Saanh2RuyNLLDVl6576F3d63ZbcSYsxKSM0f2zYB9h/lHfIAAAAASUVORK5CYII=');
+    background-position: 0 0;
+}
+.icon-qr-code:hover {
+    background-position: -19px 0;
+}
+
 .block-qr {
     margin:auto;
     width: 100%;

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -66,8 +66,8 @@
 
             <div class="details-header">Representative</div>
 
-            <div *ngIf="(account && account.representative) else repLoading">
-              <div class="nano-address-monospace uk-width-auto uk-text-truncate">
+            <div *ngIf="!loadingAccountDetails else repLoading">
+              <div class="uk-width-auto uk-text-truncate" *ngIf="(account && account.representative) else noRepresentative">
                 <div class="representative-label-container">
                   <div class="account-label rep">{{ repLabel ? repLabel : 'Unknown Rep' }}</div>
                   <div class="uk-width-auto" style="padding-left: 10px;" *ngIf="walletAccount && account && account.representative">
@@ -76,14 +76,17 @@
                     </ul>
                   </div>
                 </div>
-                <div>
+                <div class="nano-address-monospace">
                   <app-nano-account-id [accountID]="account.representative" middle="off"></app-nano-account-id>
                 </div>
               </div>
+              <ng-template #noRepresentative>
+                <div class="uk-text-muted" style="margin-top: 8px;">None</div>
+              </ng-template>
             </div>
             <ng-template #repLoading>
               <div class="uk-margin-small-top">
-                <div uk-spinner="ratio: 0.6;"></div>
+                <div uk-spinner="ratio: 0.5;" style="vertical-align: 2px;"></div>
               </div>
             </ng-template>
 
@@ -114,7 +117,10 @@
               </div>
             </div>
             <div class="account-amounts-converted">
-              {{ !account ? 0 : (account.balanceFiat | fiat: settings.settings.displayCurrency) }}
+              <ng-container *ngIf="!loadingAccountDetails else fiatLoading">
+                <ng-container *ngIf="account">{{ (account.balanceFiat | fiat: settings.settings.displayCurrency) }}</ng-container>
+              </ng-container>
+              <ng-template #fiatLoading><div uk-spinner="ratio: 0.5;" style="vertical-align: 2px;"></div></ng-template>
             </div>
           </div>
 

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -413,7 +413,7 @@
     <button class="uk-modal-close-default" type="button" uk-close></button>
     <div class="uk-modal-body">
       <div class="uk-width-1-1 uk-text-center">
-        <img *ngIf="qrCodeImage else qrCodeGenerating" [src]="qrCodeImage" title="Deposit Address">
+        <img *ngIf="qrCodeImage else qrCodeGenerating" [src]="qrCodeImage" class="qr-code" title="Deposit Address">
         <ng-template #qrCodeGenerating>
           <div class="qr-code-placeholder uk-align-center"><div uk-spinner="ratio: 2;"></div></div>
         </ng-template>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -140,9 +140,6 @@
 
       <div class="uk-card-header uk-form-horizontal" *ngIf="remoteVisible">
 
-        <!-- <img *ngIf="qrCodeImage" [src]="qrCodeImage" alt="QR code"><br />
-        <span class="uk-text-small">Deposit Address</span> -->
-
         <div class="details-header">Remote Signing</div>
 
         <p>Create a new SEND or CHANGE block below. For any incoming transaction in the table: Use REMOTE SIGN.</p>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -427,8 +427,13 @@
             : 'External address'
           )
         }}</div>
-        <div class="nano-address-monospace uk-width-auto">
-          <app-nano-account-id [accountID]="accountID" middle="off"></app-nano-account-id>
+        <div class="uk-width-1-1">
+          <span class="nano-address-monospace">
+            <app-nano-account-id [accountID]="accountID" middle="off"></app-nano-account-id>
+          </span>
+          <span class="nano-address-actions" style="vertical-align: 1px;">
+            <li><a ngxClipboard [cbContent]="accountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
+          </span>
         </div>
       </div>
     </div>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -43,11 +43,12 @@
               </div>
               <div class="uk-width-1-1 uk-margin-small-top">
                 <div uk-grid>
-                  <div class="nano-address-monospace uk-width-auto uk-text-small uk-text-truncate" style="max-width: calc(100% - 35px);">
+                  <div class="nano-address-monospace uk-width-auto uk-text-small uk-text-truncate" style="max-width: calc(100% - 60px);">
                     <app-nano-account-id [accountID]="accountID"></app-nano-account-id>
                   </div>
-                  <div class="uk-width-auto" style="padding-left: 10px; margin-top: -3px;">
+                  <div class="nano-address-actions uk-width-auto" style="margin-top: -3px;">
                     <li><a ngxClipboard [cbContent]="accountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
+                    <li><a (click)="qrModal.show()" title="Show QR Code" uk-tooltip><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAMAAABFjsb+AAAAAXNSR0IArs4c6QAAAAZQTFRFAAAAZ2aG34OOXgAAAAJ0Uk5TAP9bkSK1AAAAX0lEQVQYlV2QCRLAMAgCl/9/uq0KJs1NBkRFNRB8Z8AL6ccCLwb4goGWWCuDDuvPBj0U2sjKULHlcC8tYfReXvmEyeayOV1YR5AuOxG4OUP5le1wShu2dSRDecZj2gAPffgApGlm9NYAAAAASUVORK5CYII=" style="margin-top: -1px;"></a></li>
                   </div>
                 </div>
               </div>
@@ -56,123 +57,100 @@
           </div>
         </div>
       </div>
-      <div class="uk-card-body uk-padding-remove uk-form-horizontal">
 
-        <div class="uk-padding-small" uk-grid>
+      <div class="uk-card-header uk-form-horizontal uk-width-expand">
 
-          <div class="uk-width-3-5@s uk-width-3-4@m">
-            <div uk-grid>
-              <div class="uk-width-1-1">
-                <div uk-grid>
-                  <div class="uk-width-1-3 uk-text-right">
-                    Account Balance
-                  </div>
-                  <div class="uk-width-1-3 uk-text-right">
-                    {{ !account? 0:(account.balance || 0 | rai: settings.settings.displayDenomination) }}
-                    <span *ngIf="account && account.balanceRaw && account.balanceRaw > 0" style="display: block; font-size: 12px;" class="uk-text-muted">+{{ !account? 0:(account.balanceRaw.toString(10)) }} raw</span>
-                  </div>
-                  <div class="uk-width-1-3 uk-text-left">
-                    {{ !account? 0:(account.balanceFiat | fiat: settings.settings.displayCurrency) }}
+        <div uk-grid>
+
+          <div class="representative-details uk-width-1-1@s uk-width-1-2@l">
+
+            <div class="details-header">Representative</div>
+
+            <div *ngIf="(account && account.representative) else repLoading">
+              <div class="nano-address-monospace uk-width-auto uk-text-truncate">
+                <div class="representative-label-container">
+                  <div class="account-label rep">{{ repLabel ? repLabel : 'Unknown Rep' }}</div>
+                  <div class="uk-width-auto" style="padding-left: 10px;" *ngIf="walletAccount && account && account.representative">
+                    <ul class="uk-iconnav">
+                      <li><a uk-icon="icon: pencil;" title="Change Representative" uk-tooltip routerLink="/representatives" [queryParams]="{ hideOverview: true, showRecommended: true, accounts: accountID }"></a></li>
+                    </ul>
                   </div>
                 </div>
-              </div>
-
-              <div class="uk-width-1-1">
-                <div uk-grid>
-                  <div class="uk-width-1-3 uk-text-right">
-                    Incoming Amount
-                  </div>
-                  <div class="uk-width-1-3 uk-text-right">
-                    {{ !account? 0:(account.pending || 0 | rai: settings.settings.displayDenomination) }}
-                    <span *ngIf="account && account.pendingRaw && account.pendingRaw > 0" style="display: block; font-size: 12px;" class="uk-text-muted">+{{ !account? 0:(account.pendingRaw.toString(10)) }} raw</span>
-                  </div>
-                  <div class="uk-width-1-3 uk-text-left">
-                    {{ !account? 0:(account.pendingFiat | fiat: settings.settings.displayCurrency) }}
-                  </div>
-                </div>
-              </div>
-
-              <div class="uk-width-1-1" *ngIf="account && account.representative">
-                <div uk-grid>
-                  <div class="uk-width-1-3 uk-text-right">
-                    Representative
-                  </div>
-                  <div class="uk-width-2-3 uk-text-left">
-                    <div *ngIf="showEditRepresentative">
-                      <div uk-grid>
-                        <div class=" uk-width-1-1">
-                          <div class="uk-margin">
-                            <div class="uk-inline uk-width-1-1">
-                              <a class="uk-form-icon uk-form-icon-flip uk-text-success" (click)="saveRepresentative()" uk-icon="icon: check" uk-tooltip title="Save New Representative"></a>
-                              <a class="uk-form-icon uk-form-icon-flip uk-text-danger" style="margin-right: 26px;" (click)="showEditRepresentative = false" uk-icon="icon: close" uk-tooltip title="Cancel Changes"></a>
-
-                              <input class="uk-input" (keyup.enter)="saveRepresentative()" (blur)="validateRepresentative()" (keyup)="searchRepresentatives()" (focus)="searchRepresentatives()" [(ngModel)]="representativeModel" placeholder="New Representative Account" type="text" style="padding-right: 60px;">
-
-                              <div *ngIf="(representativeResults$ | async).length" [hidden]="!showRepresentatives" class="uk-animation-slide-down-small uk-width-1-1 uk-card uk-card-default uk-card-body uk-position-absolute" style="z-index: 15000">
-                                <ul class="uk-nav uk-nav-default">
-                                  <li class="uk-nav-header">Representative List Results</li>
-                                  <li class="uk-nav-divider"></li>
-                                  <li *ngFor="let rep of representativeResults$ | async">
-                                    <a (click)="selectRepresentative(rep.id)">
-                                      {{ rep.name }}
-                                      <span *ngIf="rep.trusted" uk-icon="icon: star;" class="uk-text-success"></span>
-                                      <span *ngIf="rep.warn" uk-icon="icon: warning;" class="uk-text-warning"></span>
-                                    </a>
-                                  </li>
-                                </ul>
-                              </div>
-
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div *ngIf="!showEditRepresentative">
-                      <div uk-grid>
-                        <div class="nano-address-monospace uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
-                          <span *ngIf="repLabel" class="account-label rep">{{ repLabel }}</span> 
-                          <app-nano-account-id [accountID]="!account ? '':account.representative"></app-nano-account-id>
-                        </div>
-                        <div class="uk-width-auto" style="padding-left: 10px;" *ngIf="walletAccount && account && account.representative">
-                          <ul class="uk-iconnav">
-                            <!--<li><a uk-icon="icon: pencil;" title="Change Representative" uk-tooltip (click)="showEditRepresentative = true"></a></li>-->
-                            <li><a uk-icon="icon: pencil;" title="Change Representative" uk-tooltip routerLink="/representatives" [queryParams]="{ hideOverview: true, showRecommended: true, accounts: accountID }"></a></li>
-                          </ul>
-                        </div>
-                      </div>
-
-                    </div>
-                  </div>
-                  <!--<div class="uk-width-1-3 uk-text-left"></div>-->
-                </div>
-              </div>
-
-              <div *ngIf="settings.settings.serverAPI" class="uk-width-1-1">
-                <div uk-grid>
-                  <div class="uk-width-1-3 uk-text-right">
-                    <label>Enable Remote Signing</label>
-                  </div>
-                  <div class="uk-width-1-3 uk-text-left">
-                    <input class="uk-checkbox uk-margin-medium-left" type="checkbox" name="remoteVisible" value="1" [(ngModel)]="remoteVisible">
-                  </div>
+                <div>
+                  <app-nano-account-id [accountID]="account.representative" middle="off"></app-nano-account-id>
                 </div>
               </div>
             </div>
+            <ng-template #repLoading>
+              <div class="uk-margin-small-top">
+                <div uk-spinner="ratio: 0.6;"></div>
+              </div>
+            </ng-template>
+
           </div>
-          <div class="uk-width-2-5@s uk-width-1-4@m uk-text-center">
-            <img *ngIf="qrCodeImage" [src]="qrCodeImage" alt="QR code"><br />
-            <span class="uk-text-small">Deposit Address</span>
+
+          <div class="uk-width-1-1@s uk-width-1-2@l">
+            <div class="details-header">Balance</div>
+            <div>
+              <div class="account-amounts-primary">
+                <div
+                  class="account-amounts-primary-confirmed"
+                  [title]="( (account && account.balanceRaw && account.balanceRaw.gt(0) ) ? ( '+' + ( account.balanceRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )"
+                >
+                  <span class="amount-integer">{{ !account ? 0 : (account.balance || 0 | rai: settings.settings.displayDenomination) | amountsplit: 0 }}</span>
+                  <span class="amount-fractional">{{ !account ? 0 : (account.balance || 0 | rai: settings.settings.displayDenomination) | amountsplit: 1 }}</span>
+                </div>
+                <div
+                  *ngIf="account && account.pending && (account.pending > 0)"
+                  class="incoming-label"
+                  [title]="( (account && account.pendingRaw && account.pendingRaw.gt(0) ) ? ( '+' + ( account.pendingRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )"
+                >
+                  <div class="text-snippet">New</div>
+                  <div class="text-full">
+                    <div class="amount-sign">+</div>
+                    <div class="amount-integer">{{ account.pending | rai: settings.settings.displayDenomination + ',true' | amountsplit: 0 }}</div>
+                    <div class="amount-fractional">{{ account.pending | rai: settings.settings.displayDenomination + ',true' | amountsplit: 1 }}</div></div>
+                </div>
+              </div>
+            </div>
+            <div class="account-amounts-converted">
+              {{ !account ? 0 : (account.balanceFiat | fiat: settings.settings.displayCurrency) }}
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+      <div class="uk-card-header uk-form-horizontal" *ngIf="settings.settings.serverAPI">
+
+        <div class="details-header advanced-options-link" (click)="showAdvancedOptions = !showAdvancedOptions">
+          Advanced options
+          <div [class]="['chevron', ( showAdvancedOptions ? 'chevron-up' : 'chevron-down' )]"></div>
+        </div>
+
+        <div class="advanced-options" *ngIf="showAdvancedOptions">
+          <div class="advanced-option">
+            <div>Enable Remote Signing</div>
+            <input class="uk-checkbox" type="checkbox" name="remoteVisible" value="1" [(ngModel)]="remoteVisible">
           </div>
         </div>
 
-        <div *ngIf="remoteVisible" uk-grid>
-          <div class="uk-width-1-1">
-            <div class="uk-width-1-1 uk-margin-medium-left">
-              <p>Create a new SEND or CHANGE block below. For any incoming transaction in the table: Use REMOTE SIGN.</p>
-              <button class="uk-button uk-button-primary" (click)="showRemoteModal()">CREATE NEW BLOCK</button>
-            </div>
-          </div>
-        </div>
+      </div>
+
+      <div class="uk-card-header uk-form-horizontal" *ngIf="remoteVisible">
+
+        <!-- <img *ngIf="qrCodeImage" [src]="qrCodeImage" alt="QR code"><br />
+        <span class="uk-text-small">Deposit Address</span> -->
+
+        <div class="details-header">Remote Signing</div>
+
+        <p>Create a new SEND or CHANGE block below. For any incoming transaction in the table: Use REMOTE SIGN.</p>
+        <button class="uk-button uk-button-primary" (click)="showRemoteModal()">CREATE NEW BLOCK</button>
+
+      </div>
+
+      <div>
 
         <div uk-grid style="margin-top: 25px;">
           <div class="uk-width-1-1">
@@ -212,7 +190,7 @@
                     </div>
                   </div>
                 </td>
-                <td class="uk-text-muted" title="Incoming Transaction">
+                <td class="uk-text-muted" [title]="('Incoming Transaction') + ( (pending.amountRaw && (pending.amountRaw > 0) ) ? ( ', +' + ( pending.amountRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )">
                   +{{ pending.amount | rai: settings.settings.displayDenomination }}*
                 </td>
                 <td class="uk-text-truncate"><a [routerLink]="'/transaction/' + pending.hash" class="uk-link-text" title="View Block Details" uk-tooltip>{{ pending.hash }}</a></td>
@@ -315,7 +293,10 @@
         <li><a routerLink="/qr-scan" routerLinkActive="active" class="uk-modal-close">Scan</a> the new signed QR with an online Nault, or copy the "Signed Block" to <a routerLink="/remote-signing" routerLinkActive="active" class="uk-modal-close">Step 3</a>.</li>
       </ol>
 
-      <span><strong>Block Type</strong></span><span uk-icon="icon: info;" uk-tooltip title="The block type to create for remote signing. Receiving can be done from the Recent Transactions below."></span><br>
+      <div class="uk-margin-small-bottom">
+        <strong style="margin-right: 6px;">Block Type</strong>
+        <span uk-icon="icon: info;" uk-tooltip title="The block type to create for remote signing. Receiving can be done from the Recent Transactions below."></span>
+      </div>
       <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="blocktype" value={{blockTypes[0]}} [(ngModel)]="blockTypeSelected"> {{blockTypes[0]}}</label>
       <label class="uk-margin-medium-right"><input class="uk-radio" type="radio" name="blocktype" value={{blockTypes[1]}} [(ngModel)]="blockTypeSelected"> {{blockTypes[1]}}</label>
       <br><br>
@@ -324,7 +305,7 @@
         <div class="uk-margin">
           <label class="uk-form-label" for="form-horizontal-text2">To Account</label>
           <div class="uk-form-controls">
-            <div class="uk-inline uk-width-1-1">
+            <div class="form-input-destination uk-inline uk-width-1-1">
               <a class="uk-form-icon uk-form-icon-flip" uk-icon="icon: camera" (click)="openQR('account1','account')" uk-tooltip title="Scan from QR code"></a>
               <input (blur)="validateDestination()" (keyup)="searchAddressBook()" (focus)="searchAddressBook()" [(ngModel)]="toAccountID" [ngClass]="{ 'uk-form-success': toAccountStatus === 2, 'uk-form-danger': toAccountStatus === 0 }" class="uk-input" id="form-horizontal-text2" type="text" placeholder="Account to send to" autocomplete="off">
 
@@ -342,7 +323,7 @@
 
           <div class="uk-form-controls" *ngIf="addressBookMatch">
             <div class="uk-inline uk-width-1-1">
-              <span class="uk-label uk-label-primary">{{ addressBookMatch }}</span>
+              <span class="account-label blue uk-margin-small-top">{{ addressBookMatch }}</span>
             </div>
           </div>
         </div>
@@ -350,11 +331,11 @@
         <div uk-grid>
           <div class="uk-width-1-1">
             <label class="uk-form-label" for="form-horizontal-text">Amount</label>
-            <div class="uk-form-controls">
+            <div class="form-amount uk-form-controls">
               <div uk-grid>
                 <div class="uk-width-1-1">
                   <div class="uk-inline uk-width-1-1">
-                    <a class="uk-form-icon uk-form-icon-flip" (click)="setMaxAmount()" style="padding-right: 7px;" uk-tooltip title="Set Maximum Amount">Max</a>
+                    <a class="uk-form-icon uk-form-icon-flip form-icon-btn" (click)="setMaxAmount()" style="padding-right: 7px;" uk-tooltip title="Set Maximum Amount">Max</a>
                     <input [(ngModel)]="amount" [ngClass]="{ 'uk-form-danger': amountStatus === 0 }" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="text" placeholder="Amount of {{ selectedAmount.name }} to send" maxlength="40">
                   </div>
                   <div *ngIf="amountRaw.gt(0)" class="uk-width-1-1 uk-width-3-5@m uk-text-small uk-text-muted uk-margin-remove">
@@ -377,7 +358,7 @@
         <div class="uk-margin">
           <label class="uk-form-label" for="form-horizontal-text3">Representative</label>
           <div class="uk-form-controls">
-            <div class="uk-inline uk-width-1-1">
+            <div class="form-input-destination uk-inline uk-width-1-1">
               <a class="uk-form-icon uk-form-icon-flip" uk-icon="icon: camera" (click)="openQR('rep1','account')" uk-tooltip title="Scan from QR code"></a>
               <input (blur)="validateRepresentative()" (keyup)="searchRepresentatives()" (focus)="searchRepresentatives()" (keyup.enter)="generateChange()" [(ngModel)]="representativeModel" class="uk-input" [ngClass]="{ 'uk-form-success': repStatus === 2, 'uk-form-danger': repStatus === 0 }" id="form-horizontal-text3" type="text" placeholder="nano_abc...123" #repInput>
               
@@ -417,8 +398,32 @@
           <li><a ngxClipboard [cbContent]="blockHash" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy" uk-tooltip></a></li>
         </ul>
       </div>
-      <div class="uk-width-1-1 uk-text-center">
+      <div class="uk-width-1-1 uk-text-center uk-margin-small-top">
         <img *ngIf="qrCodeImageBlock" [src]="qrCodeImageBlock" class="block-qr" alt="QR code"><br />
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="qr-code-modal" uk-modal>
+  <div class="uk-modal-dialog uk-margin-auto-vertical">
+    <button class="uk-modal-close-default" type="button" uk-close></button>
+    <div class="uk-modal-body">
+      <div class="uk-width-1-1 uk-text-center">
+        <img *ngIf="qrCodeImage" [src]="qrCodeImage" title="Deposit Address">
+        <hr>
+        <div class="account-label uk-margin-small-bottom">{{
+            addressBookEntry
+          ? addressBookEntry
+          : (
+              walletAccount
+            ? ('Account #' + walletAccount.index)
+            : 'External address'
+          )
+        }}</div>
+        <div class="nano-address-monospace uk-width-auto">
+          <app-nano-account-id [accountID]="accountID" middle="off"></app-nano-account-id>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -92,38 +92,41 @@
 
           </div>
 
-          <div class="uk-width-1-1@s uk-width-1-2@l">
+          <div class="balance-details uk-width-1-1@s uk-width-1-2@l">
             <div class="details-header">Balance</div>
-            <div>
-              <div class="account-amounts-primary">
-                <div
-                  class="account-amounts-primary-confirmed"
-                  [title]="( (account && account.balanceRaw && account.balanceRaw.gt(0) ) ? ( '+' + ( account.balanceRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )"
-                >
-                  <span class="amount-integer">{{ !account ? 0 : (account.balance || 0 | rai: settings.settings.displayDenomination) | amountsplit: 0 }}</span>
-                  <span class="amount-fractional">{{ !account ? 0 : (account.balance || 0 | rai: settings.settings.displayDenomination) | amountsplit: 1 }}</span>
-                </div>
-                <div
-                  *ngIf="account && account.pending && (account.pending > 0)"
-                  class="incoming-label"
-                  [title]="( (account && account.pendingRaw && account.pendingRaw.gt(0) ) ? ( '+' + ( account.pendingRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )"
-                >
-                  <div class="text-snippet">New</div>
-                  <div class="text-full">
-                    <div class="amount-sign">+</div>
-                    <div class="amount-integer">{{ account.pending | rai: settings.settings.displayDenomination + ',true' | amountsplit: 0 }}</div>
-                    <div class="amount-fractional">{{ account.pending | rai: settings.settings.displayDenomination + ',true' | amountsplit: 1 }}</div></div>
+            <ng-container *ngIf="!loadingAccountDetails else balanceLoading">
+              <div>
+                <div class="account-amounts-primary">
+                  <div
+                    class="account-amounts-primary-confirmed"
+                    [title]="( (account && account.balanceRaw && account.balanceRaw.gt(0) ) ? ( '+' + ( account.balanceRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )"
+                  >
+                    <span class="amount-integer">{{ !account ? 0 : (account.balance || 0 | rai: settings.settings.displayDenomination) | amountsplit: 0 }}</span>
+                    <span class="amount-fractional">{{ !account ? 0 : (account.balance || 0 | rai: settings.settings.displayDenomination) | amountsplit: 1 }}</span>
+                  </div>
+                  <div
+                    *ngIf="account && account.pending && (account.pending > 0)"
+                    class="incoming-label"
+                    [title]="( (account && account.pendingRaw && account.pendingRaw.gt(0) ) ? ( '+' + ( account.pendingRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )"
+                  >
+                    <div class="text-snippet">New</div>
+                    <div class="text-full">
+                      <div class="amount-sign">+</div>
+                      <div class="amount-integer">{{ account.pending | rai: settings.settings.displayDenomination + ',true' | amountsplit: 0 }}</div>
+                      <div class="amount-fractional">{{ account.pending | rai: settings.settings.displayDenomination + ',true' | amountsplit: 1 }}</div></div>
+                  </div>
                 </div>
               </div>
-            </div>
-            <div class="account-amounts-converted">
-              <ng-container *ngIf="!loadingAccountDetails else fiatLoading">
+              <div class="account-amounts-converted">
                 <ng-container *ngIf="account">{{ (account.balanceFiat | fiat: settings.settings.displayCurrency) }}</ng-container>
-              </ng-container>
-              <ng-template #fiatLoading><div uk-spinner="ratio: 0.5;" style="vertical-align: 2px;"></div></ng-template>
-            </div>
+              </div>
+            </ng-container>
           </div>
-
+          <ng-template #balanceLoading>
+            <div class="uk-margin-small-top">
+              <div uk-spinner="ratio: 0.5;" style="vertical-align: 2px;"></div>
+            </div>
+          </ng-template>
         </div>
 
       </div>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -48,7 +48,7 @@
                   </div>
                   <div class="nano-address-actions uk-width-auto" style="margin-top: -3px;">
                     <li><a ngxClipboard [cbContent]="accountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
-                    <li><a (click)="qrModal.show()" title="Show QR Code" uk-tooltip><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAMAAABFjsb+AAAAAXNSR0IArs4c6QAAAAZQTFRFAAAAZ2aG34OOXgAAAAJ0Uk5TAP9bkSK1AAAAX0lEQVQYlV2QCRLAMAgCl/9/uq0KJs1NBkRFNRB8Z8AL6ccCLwb4goGWWCuDDuvPBj0U2sjKULHlcC8tYfReXvmEyeayOV1YR5AuOxG4OUP5le1wShu2dSRDecZj2gAPffgApGlm9NYAAAAASUVORK5CYII=" style="margin-top: -1px;"></a></li>
+                    <li><a (click)="qrModal.show()" title="Show QR Code" uk-tooltip class="icon-qr-code"></a></li>
                   </div>
                 </div>
               </div>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -407,7 +407,10 @@
     <button class="uk-modal-close-default" type="button" uk-close></button>
     <div class="uk-modal-body">
       <div class="uk-width-1-1 uk-text-center">
-        <img *ngIf="qrCodeImage" [src]="qrCodeImage" title="Deposit Address">
+        <img *ngIf="qrCodeImage else qrCodeGenerating" [src]="qrCodeImage" title="Deposit Address">
+        <ng-template #qrCodeGenerating>
+          <div class="qr-code-placeholder uk-align-center"><div uk-spinner="ratio: 2;"></div></div>
+        </ng-template>
         <hr>
         <div class="account-label uk-margin-small-bottom">{{
             addressBookEntry

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -39,6 +39,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
 
   qrModal: any = null;
 
+  loadingAccountDetails = false;
   showAdvancedOptions = false;
   showEditAddressBook = false;
   addressBookModel = '';
@@ -220,9 +221,15 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     this.addressBookEntry = this.addressBook.getAccountName(this.accountID);
     this.addressBookModel = this.addressBookEntry || '';
     this.walletAccount = this.wallet.getWalletAccount(this.accountID);
+
+    this.loadingAccountDetails = true;
     this.account = await this.api.accountInfo(this.accountID);
 
-    if (!this.account) return;
+    if (!this.account) {
+      this.loadingAccountDetails = false;
+      return;
+    }
+
     this.updateRepresentativeLabel();
 
     // If there is a pending balance, or the account is not opened yet, load pending transactions
@@ -276,6 +283,8 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
 
     const qrCode = await QRCode.toDataURL(`${this.accountID}`);
     this.qrCodeImage = qrCode;
+
+    this.loadingAccountDetails = false;
   }
 
   ngOnDestroy() {

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -281,7 +281,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     await this.getAccountHistory(this.accountID);
 
 
-    const qrCode = await QRCode.toDataURL(`${this.accountID}`);
+    const qrCode = await QRCode.toDataURL(`${this.accountID}`, { errorCorrectionLevel: 'M', scale: 16 });
     this.qrCodeImage = qrCode;
 
     this.loadingAccountDetails = false;

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -163,6 +163,17 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     });
   }
 
+  clearAccountVars() {
+    this.accountHistory = [];
+    this.pendingBlocks = [];
+    this.accountID = '';
+    this.addressBookEntry = null;
+    this.addressBookModel = '';
+    this.walletAccount = null;
+    this.account = {};
+    this.qrCodeImage = null;
+  }
+
   clearRemoteVars() {
     this.selectedAmount = this.amounts[0];
     this.amount = null;
@@ -217,12 +228,17 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     setTimeout(() => this.statsRefreshEnabled = true, 5000);
 
     this.pendingBlocks = [];
+
+    if (this.accountID !== this.router.snapshot.params.account) {
+      this.clearAccountVars();
+      this.loadingAccountDetails = true;
+    }
+
     this.accountID = this.router.snapshot.params.account;
     this.addressBookEntry = this.addressBook.getAccountName(this.accountID);
     this.addressBookModel = this.addressBookEntry || '';
     this.walletAccount = this.wallet.getWalletAccount(this.accountID);
 
-    this.loadingAccountDetails = true;
     this.account = await this.api.accountInfo(this.accountID);
 
     if (!this.account) {

--- a/src/app/components/helpers/nano-account-id/nano-account-id.component.html
+++ b/src/app/components/helpers/nano-account-id/nano-account-id.component.html
@@ -1,3 +1,3 @@
 <span style="color: #4A90E2;">{{ firstCharacters }}</span>
 <span [class.uk-text-truncate]="middle === 'auto'" style="min-width: 1.4em;">{{ middleCharacters || '...'}}</span>
-<span style="color: #cba644;">{{ lastCharacters }}</span>
+<span style="color: #D5AF4E;">{{ lastCharacters }}</span>

--- a/src/app/components/sweeper/sweeper.component.html
+++ b/src/app/components/sweeper/sweeper.component.html
@@ -41,7 +41,7 @@
           <div class="uk-width-1-1 narrow-div">
             <div class="uk-form-horizontal">
               <div class="uk-margin">
-                <label class="uk-form-label" for="destination-account">Local Destination<span uk-icon="icon: info;" uk-tooltip title="Local accounts that can be used as destination for the swept funds. Make sure you are able to unlock your Nault wallet."></span></label>
+                <label class="uk-form-label" for="destination-account">Local Destination <span uk-icon="icon: info;" uk-tooltip title="Local accounts that can be used as destination for the swept funds. Make sure you are able to unlock your Nault wallet."></span></label>
                 <div class="uk-form-controls">
                   <select class="uk-select" id="destination-account" [(ngModel)]="myAccountModel" (change)="setDestination(myAccountModel)">
                     <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: settings.settings.displayDenomination }})</option>
@@ -55,7 +55,7 @@
           <div *ngIf="customAccountSelected" class="uk-width-1-1 narrow-div">
             <div class="uk-form-horizontal">
               <div class="uk-margin">
-                <label class="uk-form-label" for="custom-destination">Custom Destination<span uk-icon="icon: info;" uk-tooltip title="The deposit account for the sweps funds. Can be any remote account."></span></label>
+                <label class="uk-form-label" for="custom-destination">Custom Destination <span uk-icon="icon: info;" uk-tooltip title="The deposit account for the sweps funds. Can be any remote account."></span></label>
                 <div class="uk-form-controls">
                   <div uk-grid>
                     <div class="uk-width-1-1">

--- a/src/app/pipes/squeeze.pipe.ts
+++ b/src/app/pipes/squeeze.pipe.ts
@@ -7,10 +7,15 @@ export class SqueezePipe implements PipeTransform {
 
   transform(value: any, args?: any): any {
     const arg = args ? args.split(',') || [] : [];
-    const openingChars = arg[0] || 10;
-    const closingChars = arg[1] || 5;
+    const openingChars = arg[0] ? parseInt( arg[0] ) : 10;
+    const closingChars = arg[1] ? parseInt( arg[1] ) : 5;
     const firstChars = value.split('').slice(0, openingChars).join('');
     const lastChars = value.split('').slice(-closingChars).join('');
+
+    if ( value.length < (openingChars + closingChars) ) {
+    	return value;
+    }
+
     return `${firstChars}...${lastChars}`;
   }
 

--- a/src/app/pipes/squeeze.pipe.ts
+++ b/src/app/pipes/squeeze.pipe.ts
@@ -7,13 +7,13 @@ export class SqueezePipe implements PipeTransform {
 
   transform(value: any, args?: any): any {
     const arg = args ? args.split(',') || [] : [];
-    const openingChars = arg[0] ? parseInt( arg[0] ) : 10;
-    const closingChars = arg[1] ? parseInt( arg[1] ) : 5;
+    const openingChars = arg[0] ? parseInt( arg[0], 10 ) : 10;
+    const closingChars = arg[1] ? parseInt( arg[1], 10 ) : 5;
     const firstChars = value.split('').slice(0, openingChars).join('');
     const lastChars = value.split('').slice(-closingChars).join('');
 
     if ( value.length < (openingChars + closingChars) ) {
-    	return value;
+      return value;
     }
 
     return `${firstChars}...${lastChars}`;

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -34,8 +34,10 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
 }
 
 .uk-panel-scrollable {
+    overflow-x: auto;
+    overflow-y: scroll;
     resize: none;
-  }
+}
 
 .uk-card-body > ul > li > a {
 	color: @global-color;

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -214,6 +214,15 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
     display: block;
 }
 
+// rounded uikit modals
+// ========================================================================
+.uk-modal-dialog,
+.uk-modal-dialog .uk-modal-header,
+.uk-modal-dialog .uk-modal-body,
+.uk-modal-dialog .uk-modal-footer {
+    border-radius: 10px;
+}
+
 // ng-bootstrap modal classes
 // ========================================================================
 .fade {


### PR DESCRIPTION
preview:

![2021-02-01_18-26-54](https://user-images.githubusercontent.com/29272208/106505139-ca454300-64bf-11eb-9ae7-c3e9b51845b4.gif)

also in this PR:

* representative name from mynanoninja is now displayed in account details if no custom label is set
* fixed "+1 raw" being squeezed into "+1...1 raw"
* fixed raw amount not being shown when hovering mouse over incoming transaction amounts
* minor style improvements for the offline signing modal
* removed unused modal/code for changing representative from the account details page