### PR TITLE
Remove duplicate reps when searching

### DIFF
--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -135,6 +135,10 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     await this.loadAccountDetails();
     this.addressBook.loadAddressBook();
 
+    // add the localReps to the list
+    const localReps = this.repService.getSortedRepresentatives();
+    this.representativeList.push(...localReps);
+
     // populate representative list
     if (!this.settings.settings.serverAPI) return;
     const verifiedReps = await this.ninja.recommendedRandomized();
@@ -147,10 +151,6 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
 
       this.representativeList.push(temprep);
     }
-
-    // add the localReps to the list
-    const localReps = this.repService.getSortedRepresentatives();
-    this.representativeList.push(...localReps);
 
     this.repService.walletReps$.subscribe(async reps => {
       if ( reps[0] === null ) {
@@ -403,6 +403,8 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
 
     const matches = this.representativeList
       .filter(a => a.name.toLowerCase().indexOf(search.toLowerCase()) !== -1)
+      // remove duplicate accounts
+      .filter((item, pos, self) => this.util.array.findWithAttr(self, 'id', item.id) === pos)
       .slice(0, 5);
 
     this.representativeResults$.next(matches);

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -174,6 +174,10 @@ export class ConfigureAppComponent implements OnInit {
     if (!this.serverAPI) return;
     const verifiedReps = await this.ninja.recommendedRandomized();
 
+    // add the localReps to the list
+    const localReps = this.repService.getSortedRepresentatives();
+    this.representativeList.push(...localReps);
+
     for (const representative of verifiedReps) {
       const temprep = {
         id: representative.account,
@@ -182,10 +186,6 @@ export class ConfigureAppComponent implements OnInit {
 
       this.representativeList.push(temprep);
     }
-
-    // add the localReps to the list
-    const localReps = this.repService.getSortedRepresentatives();
-    this.representativeList.push(...localReps);
   }
 
   async updateNodeStats(refresh= false) {
@@ -411,6 +411,8 @@ export class ConfigureAppComponent implements OnInit {
 
     const matches = this.representativeList
       .filter(a => a.name.toLowerCase().indexOf(search.toLowerCase()) !== -1)
+      // remove duplicate accounts
+      .filter((item, pos, self) => this.util.array.findWithAttr(self, 'id', item.id) === pos)
       .slice(0, 5);
 
     this.representativeResults$.next(matches);

--- a/src/app/components/representatives/representatives.component.ts
+++ b/src/app/components/representatives/representatives.component.ts
@@ -96,6 +96,10 @@ export class RepresentativesComponent implements OnInit {
     // populate representative list
     const verifiedReps = await this.ninja.recommendedRandomized();
 
+    // add the localReps to the list
+    const localReps = this.representativeService.getSortedRepresentatives();
+    this.representativeList.push(...localReps);
+
     for (const representative of verifiedReps) {
       const temprep = {
         id: representative.account,
@@ -104,10 +108,6 @@ export class RepresentativesComponent implements OnInit {
 
       this.representativeList.push(temprep);
     }
-
-    // add the localReps to the list
-    const localReps = this.representativeService.getSortedRepresentatives();
-    this.representativeList.push(...localReps);
 
     await this.loadRecommendedReps();
   }
@@ -178,6 +178,8 @@ export class RepresentativesComponent implements OnInit {
 
     const matches = this.representativeList
       .filter(a => a.name.toLowerCase().indexOf(search.toLowerCase()) !== -1)
+      // remove duplicate accounts
+      .filter((item, pos, self) => this.util.array.findWithAttr(self, 'id', item.id) === pos)
       .slice(0, 5);
 
     this.representativeResults$.next(matches);
@@ -369,5 +371,4 @@ export class RepresentativesComponent implements OnInit {
     }, () => {}
     );
   }
-
 }

--- a/src/app/services/util.service.ts
+++ b/src/app/services/util.service.ts
@@ -82,7 +82,8 @@ export class UtilService {
     multiplierFromDifficulty: multiplierFromDifficulty,
   };
   array = {
-    shuffle: shuffle
+    shuffle: shuffle,
+    findWithAttr: findWithAttr
   };
 
 }
@@ -463,6 +464,15 @@ function equal_arrays (array1, array2) {
   return true;
 }
 
+// find the position in an array given an attribute and value
+function findWithAttr(array, attr, value) {
+  for (let i = 0; i < array.length; i += 1) {
+      if (array[i][attr] === value) {
+          return i;
+      }
+  }
+  return -1;
+}
 
 function generateSeedBytes() {
   return nacl.randomBytes(32);
@@ -524,5 +534,9 @@ const util = {
     validateWork: validateWork,
     difficultyFromMultiplier: difficultyFromMultiplier,
     multiplierFromDifficulty: multiplierFromDifficulty,
+  },
+  array: {
+    shuffle: shuffle,
+    findWithAttr: findWithAttr
   }
 };


### PR DESCRIPTION
Fixes #261 

If a search matches both "known reps" and "ninja reps" it will prefer the "known reps" when displaying the result.
That's why it now adds local reps to the full list before it adds ninja reps, in order for the duplicate removal filter to be correct.

Important notice is if you now click in the search field without typing it will display the first 5 "known reps" now instead of the first 5 "ninja reps". I think that's better?

Before:
![image](https://user-images.githubusercontent.com/2406720/107500045-fe8ec280-6b95-11eb-9e94-ddd0ce38312a.png)


After:
![image](https://user-images.githubusercontent.com/2406720/107500202-30078e00-6b96-11eb-8988-80a5acf6c1eb.png)


Before:
![image](https://user-images.githubusercontent.com/2406720/107500311-4f062000-6b96-11eb-9d49-1242e844ad55.png)


After:
![image](https://user-images.githubusercontent.com/2406720/107500351-59281e80-6b96-11eb-94b1-7fe1d953e939.png)
