### PR TITLE
Replaced HID token

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
   <meta property="og:url" content="https://nault.cc/" />
   <meta property="og:site_name" content="Nault" />
   <meta property="og:image" content="https://nault.cc/assets/img/preview.png?v=2" />
-  <meta http-equiv="origin-trial" content="Ar1SGaBNCgNxWILG8Ku2fHPl4vB1b3NGxqUefE46R8KBupYLRhAtHFdq/8Mfk30U+kxt0CtvfDfWomjvvHvGug4AAABbeyJvcmlnaW4iOiJodHRwczovL25hdWx0LmNjOjQ0MyIsImZlYXR1cmUiOiJXZWJISUQiLCJleHBpcnkiOjE2MTMyNjUwOTcsImlzU3ViZG9tYWluIjp0cnVlfQ==">
+  <meta http-equiv="origin-trial" content="AozrsN92G0WwmBqku7WUVf+xPdSFZfsY1jxIhdALcDQQ/FsvFNCOI2fWPmN9cL8WP6PCdFPlDN4SnNlyZJ1XCA4AAABbeyJvcmlnaW4iOiJodHRwczovL25hdWx0LmNjOjQ0MyIsImZlYXR1cmUiOiJXZWJISUQiLCJleHBpcnkiOjE2MTQxMjQ3OTksImlzU3ViZG9tYWluIjp0cnVlfQ==">
 
   <!-- UIkit -->
   <!-- <link rel="stylesheet" href="assets/lib/base/uikit.min.css" /> -->


### PR DESCRIPTION
Old token expires tomorrow (14th). New token is the last one we need until chrome 89 is rolled out, and after that it can be removed.