### PR TITLE
Alert on long PoW and allow cancellation

### DIFF
--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -325,6 +325,13 @@ export class ConfigureAppComponent implements OnInit {
       if (newPoW !== 'clientWebGL' && newPoW !== 'clientCPU' && newPoW !== 'custom') {
         this.selectedMultiplierOption = this.multiplierOptions[0].value;
       }
+      // Cancel ongoing PoW if the old method was local PoW
+      if (this.appSettings.settings.powSource === 'clientWebGL' || this.appSettings.settings.powSource === 'clientCPU') {
+        // Check if work is ongoing, and cancel it
+        if (this.pow.cancelAllPow(false)) {
+          reloadPending = true; // force reload balance => re-work pow
+        }
+      }
     }
 
     // reset work cache so that the new PoW will be used but only if larger than before

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -332,6 +332,12 @@ export class ConfigureAppComponent implements OnInit {
           reloadPending = true; // force reload balance => re-work pow
         }
       }
+    } else if ((newPoW === 'clientWebGL' || newPoW === 'clientCPU') &&
+      newMultiplier < this.appSettings.settings.multiplierSource) {
+      // Cancel pow and re-work if multiplier is lower than earlier
+      if (this.pow.cancelAllPow(false)) {
+        reloadPending = true;
+      }
     }
 
     // reset work cache so that the new PoW will be used but only if larger than before

--- a/src/app/components/wallet-widget/wallet-widget.component.html
+++ b/src/app/components/wallet-widget/wallet-widget.component.html
@@ -27,6 +27,16 @@
   </div>
 </div>
 
+<div class="nav-status-row" *ngIf="powAlert">
+  <div class="status-icon">
+    <span class="uk-text-warning" uk-icon="icon: warning; ratio: 1.2;"></span>
+  </div>
+  <div class="status-labels">
+    <div class="label primary uk-text-warning">Proof of Work is taking a while...</div>
+    <div class="label secondary"><a routerLink="/configure-app" routerLinkActive="active"><div class="label"></div>Change PoW method</a> or <a (click)="cancelPow()">cancel PoW</a></div>
+  </div>
+</div>
+
 <ng-container *ngIf="walletService.isConfigured() && !walletService.isLedgerWallet()">
   <div class="nav-status-row half-muted interactable" (click)="modal.show()" *ngIf="walletService.isLocked()">
     <div class="status-icon">

--- a/src/app/components/wallet-widget/wallet-widget.component.html
+++ b/src/app/components/wallet-widget/wallet-widget.component.html
@@ -33,7 +33,7 @@
   </div>
   <div class="status-labels">
     <div class="label primary uk-text-warning">Proof of Work is taking a while...</div>
-    <div class="label secondary"><a routerLink="/configure-app" routerLinkActive="active"><div class="label"></div>Change PoW method</a> or <a (click)="cancelPow()">cancel PoW</a></div>
+    <div class="label secondary"><a routerLink="/configure-app" routerLinkActive="active">Change PoW method</a> and/or <a (click)="cancelPow()">cancel PoW</a></div>
   </div>
 </div>
 

--- a/src/app/components/wallet-widget/wallet-widget.component.html
+++ b/src/app/components/wallet-widget/wallet-widget.component.html
@@ -33,7 +33,7 @@
   </div>
   <div class="status-labels">
     <div class="label primary uk-text-warning">Proof of Work is taking a while...</div>
-    <div class="label secondary"><a routerLink="/configure-app" routerLinkActive="active">Change PoW method</a> and/or <a (click)="cancelPow()">cancel PoW</a></div>
+    <div class="label secondary"><a routerLink="/configure-app" routerLinkActive="active">Change PoW method</a> or <a (click)="cancelPow()">cancel PoW</a></div>
   </div>
 </div>
 

--- a/src/app/components/wallet-widget/wallet-widget.component.ts
+++ b/src/app/components/wallet-widget/wallet-widget.component.ts
@@ -3,6 +3,7 @@ import {WalletService} from '../../services/wallet.service';
 import {NotificationService} from '../../services/notification.service';
 import {LedgerService, LedgerStatus} from '../../services/ledger.service';
 import {AppSettingsService} from '../../services/app-settings.service';
+import {PowService} from '../../services/pow.service';
 
 @Component({
   selector: 'app-wallet-widget',
@@ -13,6 +14,7 @@ export class WalletWidgetComponent implements OnInit {
   wallet = this.walletService.wallet;
 
   ledgerStatus = 'not-connected';
+  powAlert = false;
 
   unlockPassword = '';
 
@@ -24,7 +26,8 @@ export class WalletWidgetComponent implements OnInit {
     public walletService: WalletService,
     private notificationService: NotificationService,
     public ledgerService: LedgerService,
-    public settings: AppSettingsService) { }
+    public settings: AppSettingsService,
+    private powService: PowService) { }
 
   @ViewChild('passwordInput') passwordInput: ElementRef;
 
@@ -35,6 +38,14 @@ export class WalletWidgetComponent implements OnInit {
 
     this.ledgerService.ledgerStatus$.subscribe((ledgerStatus: any) => {
       this.ledgerStatus = ledgerStatus.status;
+    });
+    // Detect if a PoW is taking too long and alert
+    this.powService.powAlert$.subscribe(async shouldAlert => {
+      if (shouldAlert) {
+        this.powAlert = true;
+      } else {
+        this.powAlert = false;
+      }
     });
   }
 
@@ -115,6 +126,10 @@ export class WalletWidgetComponent implements OnInit {
     } else {
       this.notificationService.sendError(`Incorrect password, please try again!`);
     }
+  }
+
+  cancelPow() {
+    this.powService.cancelAllPow();
   }
 
 }

--- a/src/app/components/wallet-widget/wallet-widget.component.ts
+++ b/src/app/components/wallet-widget/wallet-widget.component.ts
@@ -129,7 +129,7 @@ export class WalletWidgetComponent implements OnInit {
   }
 
   cancelPow() {
-    this.powService.cancelAllPow();
+    this.powService.cancelAllPow(true);
   }
 
 }

--- a/src/app/services/pow.service.ts
+++ b/src/app/services/pow.service.ts
@@ -11,7 +11,7 @@ const mod = window['Module'];
 export const baseThreshold = 'fffffff800000000'; // threshold since v21 epoch update
 const hardwareConcurrency = window.navigator.hardwareConcurrency || 2;
 const workerCount = Math.max(hardwareConcurrency - 1, 1);
-const workerList = [];
+let workerList = [];
 
 @Injectable()
 export class PowService {
@@ -274,6 +274,7 @@ export class PowService {
       this.cpuWorkerReject = reject;
       console.log('Generating work with multiplier ' + multiplier + ' at threshold ' +
         newThreshold + ' using CPU workers for hash: ', hash);
+      workerList = [];
       for (let i = 0; i < workerCount; i++) {
         // const worker = new Worker()
         const worker = new (Worker as any)();

--- a/src/app/services/pow.service.ts
+++ b/src/app/services/pow.service.ts
@@ -19,7 +19,7 @@ export class PowService {
   webGLAvailable = false;
   webGLTested = false;
 
-  powAlertLimit = 10; // alert long pow after X sec
+  powAlertLimit = 60; // alert long pow after X sec
   PoWPool = [];
   parallelQueue = false;
   processingQueueItem = false;

--- a/src/app/services/pow.service.ts
+++ b/src/app/services/pow.service.ts
@@ -12,7 +12,7 @@ export const baseThreshold = 'fffffff800000000'; // threshold since v21 epoch up
 const hardwareConcurrency = window.navigator.hardwareConcurrency || 2;
 const workerCount = Math.max(hardwareConcurrency - 1, 1);
 let workerList = [];
-export enum workState {'success', 'cancelled', 'error'};
+export enum workState {'success', 'cancelled', 'error'}
 
 @Injectable()
 export class PowService {
@@ -168,7 +168,7 @@ export class PowService {
       }
     }
 
-    let work = {state: null, work: ''};
+    const work = {state: null, work: ''};
     switch (powSource) {
       default:
       case 'server':
@@ -184,7 +184,7 @@ export class PowService {
         try {
           work.work = await this.getHashCPUWorker(queueItem.hash, localMultiplier);
           work.state = workState.success;
-        } catch(state) {
+        } catch (state) {
           work.state = state;
         }
         break;
@@ -192,7 +192,7 @@ export class PowService {
         try {
           work.work = await this.getHashWebGL(queueItem.hash, localMultiplier);
           work.state = workState.success;
-        } catch(state) {
+        } catch (state) {
           work.state = state;
         }
         break;

--- a/src/app/services/pow.service.ts
+++ b/src/app/services/pow.service.ts
@@ -132,6 +132,7 @@ export class PowService {
     if (!this.PoWPool.length) return; // Nothing in the queue?
     this.processingQueueItem = true;
     const queueItem = this.PoWPool[0];
+    this.powAlert$.next(false); // extra safety to ensure the alert is always reset
 
     let powSource = this.appSettings.settings.powSource;
     const multiplierSource: Number = this.appSettings.settings.multiplierSource;

--- a/src/app/services/pow.service.ts
+++ b/src/app/services/pow.service.ts
@@ -5,12 +5,13 @@ import {NotificationService} from './notification.service';
 import { PoWSource } from './app-settings.service';
 import Worker from 'worker-loader!./../../assets/lib/cpupow.js';
 import {UtilService} from './util.service';
+import {BehaviorSubject} from 'rxjs';
 
 const mod = window['Module'];
 export const baseThreshold = 'fffffff800000000'; // threshold since v21 epoch update
 const hardwareConcurrency = window.navigator.hardwareConcurrency || 2;
 const workerCount = Math.max(hardwareConcurrency - 1, 1);
-let workerList = [];
+const workerList = [];
 
 @Injectable()
 export class PowService {
@@ -18,9 +19,16 @@ export class PowService {
   webGLAvailable = false;
   webGLTested = false;
 
+  powAlertLimit = 10; // alert long pow after X sec
   PoWPool = [];
   parallelQueue = false;
   processingQueueItem = false;
+  currentProcessTime = 0; // start timestamp for PoW
+  powAlert$: BehaviorSubject<boolean|false> = new BehaviorSubject(false);
+  public shouldContinueQueue = true; // set to false to disable further processing
+  cpuWorkerResolve = null; // global worker promise to allow termination
+  cpuWorkerReject = null; // global worker promise to allow termination
+  shouldAbortGpuPow = false; // set to true to abort GPU pow
 
   constructor(
     private appSettings: AppSettingsService,
@@ -121,8 +129,8 @@ export class PowService {
    * Uses the latest app settings to determine which type of PoW to use
    */
   private async processNextQueueItem() {
-    this.processingQueueItem = true;
     if (!this.PoWPool.length) return; // Nothing in the queue?
+    this.processingQueueItem = true;
     const queueItem = this.PoWPool[0];
 
     let powSource = this.appSettings.settings.powSource;
@@ -162,13 +170,21 @@ export class PowService {
     switch (powSource) {
       default:
       case 'server':
-        work = this.getHashServer(queueItem.hash, queueItem.multiplier);
+        work = await this.getHashServer(queueItem.hash, queueItem.multiplier);
         break;
       case 'clientCPU':
-        work = await this.getHashCPUWorker(queueItem.hash, localMultiplier);
+        try {
+          work = await this.getHashCPUWorker(queueItem.hash, localMultiplier);
+        } catch {
+          work = null;
+        }
         break;
       case 'clientWebGL':
-        work = await this.getHashWebGL(queueItem.hash, localMultiplier);
+        try {
+          work = await this.getHashWebGL(queueItem.hash, localMultiplier);
+        } catch {
+          work = null;
+        }
         break;
       case 'custom':
         const workServer = this.appSettings.settings.customWorkServer;
@@ -180,18 +196,21 @@ export class PowService {
         break;
     }
 
+    this.currentProcessTime = 0; // Reset timer
     this.PoWPool.shift(); // Remove this item from the queue
     this.processingQueueItem = false;
 
     if (!work) {
-      this.notifications.sendError(`Unable to generate work for ${queueItem.hash} using ${powSource}`);
+      // this.notifications.sendError(`Unable to generate work for ${queueItem.hash} using ${powSource}`);
       queueItem.promise.reject(null);
     } else {
       queueItem.work = work;
       queueItem.promise.resolve(work);
     }
 
-    this.processQueue();
+    if (this.shouldContinueQueue) {
+      this.processQueue();
+    }
 
     return queueItem;
   }
@@ -206,7 +225,9 @@ export class PowService {
       newThreshold + ' using ' + serverString + ' server for hash: ', hash);
     return await this.api.workGenerate(hash, newThreshold, workServer)
     .then(work => work.work)
-    .catch(async err => await this.getHashCPUWorker(hash, multiplier));
+    // Do not fallback to CPU pow. Let the user decide
+    // .catch(async err => await this.getHashCPUWorker(hash, multiplier))
+    .catch(err => null);
   }
 
   /**
@@ -229,6 +250,7 @@ export class PowService {
    * Generate PoW using CPU and WebWorkers
    */
   async getHashCPUWorker(hash, multiplier) {
+    this.checkPowProcessLength(); // start alert timer
     // console.log('Generating work using CPU for', hash);
 
     const response = this.getDeferredPromise();
@@ -247,11 +269,11 @@ export class PowService {
 
     // calculate threshold from multiplier
     const newThreshold = this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold);
-
-    const work = () => new Promise(resolve => {
+    const work = () => new Promise<void>((resolve, reject) => {
+      this.cpuWorkerResolve = resolve;
+      this.cpuWorkerReject = reject;
       console.log('Generating work with multiplier ' + multiplier + ' at threshold ' +
         newThreshold + ' using CPU workers for hash: ', hash);
-      workerList = [];
       for (let i = 0; i < workerCount; i++) {
         // const worker = new Worker()
         const worker = new (Worker as any)();
@@ -264,17 +286,16 @@ export class PowService {
         worker.onmessage = (workerwork) => {
           console.log(`CPU Worker: Found work (${workerwork.data}) for ${hash} after ${(Date.now() - start) / 1000} seconds [${workerCount} Workers]`);
           response.resolve(workerwork.data);
-          for (const workerIndex in workerList) {
-            if (Object.prototype.hasOwnProperty.call(workerList, workerIndex)) {
-              workerList[workerIndex].terminate();
-            }
-          }
-          resolve();
+          this.terminateCpuWorkers(true);
         };
         workerList.push(worker);
       }
     });
-    await work();
+    try {
+      await work();
+    } catch (msg) {
+      response.reject('cancelled');
+    }
 
     return response.promise;
   }
@@ -283,6 +304,7 @@ export class PowService {
    * Generate PoW using WebGL
    */
   getHashWebGL(hash, multiplier) {
+    this.checkPowProcessLength(); // start alert timer
     const newThreshold = this.util.nano.difficultyFromMultiplier(multiplier, baseThreshold);
     console.log('Generating work with multiplier ' + multiplier + ' at threshold ' + newThreshold + ' using WebGL for hash: ', hash);
 
@@ -294,15 +316,20 @@ export class PowService {
           console.log(`WebGL Worker: Found work (${work}) for ${hash} after ${(Date.now() - start) / 1000} seconds [${n} iterations]`);
           response.resolve(work);
         },
-        n => {},
+        n => {
+          if (this.shouldAbortGpuPow) {
+            this.shouldAbortGpuPow = false;
+            response.reject('cancelled');
+            return true;
+          }
+        },
         '0x' + newThreshold.substring(0, 8).toUpperCase() // max threshold for webglpow is currently ffffffff00000000
       );
     } catch (error) {
       if (error.message === 'webgl2_required') {
         this.webGLAvailable = false;
       }
-      response.resolve(null);
-      // response.reject(error);
+      response.reject('cancelled');
     }
 
     return response.promise;
@@ -323,6 +350,47 @@ export class PowService {
     });
 
     return defer;
+  }
+
+  // Check if pow takes longer than limit, then notify user
+  async checkPowProcessLength() {
+    this.shouldAbortGpuPow = false;
+    this.currentProcessTime = Date.now();
+    while (this.currentProcessTime !== 0) {
+      // display alert of PoW has been running more than X ms
+      if (Date.now() - this.currentProcessTime >= this.powAlertLimit * 1000) {
+        this.powAlert$.next(true);
+      }
+      await this.sleep(1000);
+    }
+    this.powAlert$.next(false);
+  }
+
+  sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  // Interupt running pow and empty the queue
+  public cancelAllPow() {
+    this.currentProcessTime = 0; // reset timer
+    this.powAlert$.next(false); // announce alert to close
+    this.shouldContinueQueue = false; // disable further processing
+    this.terminateCpuWorkers(false); // abort CPU worker if running
+    this.shouldAbortGpuPow = true; // abort GPU pow if running
+    this.notifications.sendInfo(`Ongoing Proof of Work successfully cancelled`);
+  }
+
+  terminateCpuWorkers(successful) {
+    for (const workerIndex in workerList) {
+      if (Object.prototype.hasOwnProperty.call(workerList, workerIndex)) {
+        workerList[workerIndex].terminate();
+      }
+    }
+    if (successful && this.cpuWorkerResolve) {
+      this.cpuWorkerResolve();
+    } else if (!successful && this.cpuWorkerReject) {
+      this.cpuWorkerReject('cancelled');
+    }
   }
 
 }

--- a/src/app/services/pow.service.ts
+++ b/src/app/services/pow.service.ts
@@ -20,7 +20,7 @@ export class PowService {
   webGLAvailable = false;
   webGLTested = false;
 
-  powAlertLimit = 5; // alert long pow after X sec
+  powAlertLimit = 60; // alert long pow after X sec
   PoWPool = [];
   parallelQueue = false;
   processingQueueItem = false;

--- a/src/app/services/work-pool.service.ts
+++ b/src/app/services/work-pool.service.ts
@@ -76,7 +76,7 @@ export class WorkPoolService {
     let work;
     try {
       work = await this.pow.getPow(hash, multiplier);
-    } catch(workState) {
+    } catch (workState) {
       work = workState;
     }
 

--- a/src/app/services/work-pool.service.ts
+++ b/src/app/services/work-pool.service.ts
@@ -91,19 +91,18 @@ export class WorkPoolService {
       return null;
     }
 
-    const workString = work.work;
-    console.log('Work found: ' + workString);
+    console.log('Work found: ' + work.work);
 
     // remove duplicates
     this.workCache = this.workCache.filter(entry => (entry.hash !== hash));
 
-    this.workCache.push({ hash, workString });
+    this.workCache.push({ hash, work: work.work });
     delete this.currentlyProcessingHashes[hash];
 
     if (this.workCache.length >= this.cacheLength) this.workCache.shift(); // Prune if we are at max length
     this.saveWorkCache();
 
-    return workString;
+    return work.work;
   }
 
   /**


### PR DESCRIPTION
* If local PoW takes longer than 60sec, alert in the sidebar
* Link to PoW methods or let user cancel
* Disabled CPU pow fallback on failed server PoW. Automatic fallback could lead to excessive CPU usage on both desktop and mobile devices. For example, if you have 20 accounts, it could take forever and drain the mobile battery. I think it's better to let the user change pow method if needed via the warning notification. Then the user won't end up waiting forever on pow.
* Changing pow method while local work is ongoing will be cancelled, and remade using new method
* Server pow or custom pow server is currently not monitored regarding long process time. It may be possible to cancel HTTP requests on demand but it's complicated and couldn't figure it out right now

![image](https://user-images.githubusercontent.com/2406720/107924466-3ec5ba80-6f73-11eb-8c15-71020debbacf.png)

**Typical test scenario - PASS**

1. Create an empty wallet with two accounts (will require two PoW)
2. Select CPU as pow method and 64x multiplier
3. Clear the work cache
4. Reload the whole wallet or go to receive screen and press "find incoming" -> wait 60sec -> cancel work in the alert. It should cancel any work in the pipeline with a warning
5. Go to receive screen and press "find incoming". That should trigger pow calculation again. The expected behaviour is that it will retry calculate both pow again. Repeat 4 and 5 or select another pow method.

Fixes #277 
