### PR TITLE
Compact the fractional part of NANO amounts

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -22,7 +22,9 @@
           <div class="address nano-address-monospace">{{ wallet.selectedAccount.id }}</div>
         </div>
         <div class="balance-column">
-          <div class="balance primary">{{ wallet.selectedAccount.balance | rai: settings.settings.displayDenomination }}</div>
+          <div class="balance primary">
+            {{ wallet.selectedAccount.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ wallet.selectedAccount.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO
+          </div>
           <div class="balance converted">{{ wallet.selectedAccount.balanceFiat | fiat: settings.settings.displayCurrency }}</div>
         </div>
       </div>
@@ -32,7 +34,7 @@
           <div class="address"> </div>
         </div>
         <div class="balance-column">
-          <div class="balance primary">{{ wallet.balance | rai: settings.settings.displayDenomination }}</div>
+          <div class="balance primary">{{ wallet.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ wallet.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO</div>
           <div class="balance converted">{{ wallet.balanceFiat | fiat: settings.settings.displayCurrency }}</div>
         </div>
       </div>
@@ -46,9 +48,9 @@
             <div class="balance primary">
               <span class="incoming-label" *ngIf="account.pending.gt(0)">
                 <span class="text-snippet">New</span>
-                <span class="text-full">+{{ account.pending | rai: 'mnano,true' }}</span>
+                <span class="text-full">+{{ account.pending | rai: 'mnano,true' | amountsplit: 0 }}{{ account.pending | rai: 'mnano,true' | amountsplit: 1 }} NANO</span>
               </span>
-              {{ account.balance | rai: settings.settings.displayDenomination }}
+              {{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO
             </div>
             <div class="balance converted">{{ account.balanceFiat | fiat: settings.settings.displayCurrency }}</div>
           </div>

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -107,8 +107,13 @@
     font-weight: 700;
 }
 
-.incoming-label > .text-full > .amount-fractional {
+.incoming-label > .text-full > .amount-fractional,
+.incoming-label > .text-full > .amount-currency-name {
     display: inline-block;
+}
+
+.incoming-label > .text-full > .amount-currency-name {
+    margin-left: 4px;
 }
 
 .incoming-label > .text-snippet {
@@ -146,8 +151,13 @@
     font-weight: 700;
 }
 
-.account-amounts-primary-confirmed > .amount-fractional {
+.account-amounts-primary-confirmed > .amount-fractional,
+.account-amounts-primary-confirmed > .amount-currency-name {
     font-size: 16px;
+}
+
+.account-amounts-primary-confirmed > .amount-currency-name {
+    margin-left: 4px;
 }
 
 .account-amounts-converted {

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -101,8 +101,9 @@
                     class="account-amounts-primary-confirmed"
                     [title]="( (account && account.balanceRaw && account.balanceRaw.gt(0) ) ? ( '+' + ( account.balanceRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )"
                   >
-                    <span class="amount-integer">{{ !account ? 0 : (account.balance || 0 | rai: settings.settings.displayDenomination) | amountsplit: 0 }}</span>
-                    <span class="amount-fractional">{{ !account ? 0 : (account.balance || 0 | rai: settings.settings.displayDenomination) | amountsplit: 1 }}</span>
+                    <span class="amount-integer">{{ !account ? 0 : (account.balance || 0 | rai: 'mnano,true') | amountsplit: 0 }}</span>
+                    <span class="amount-fractional">{{ !account ? 0 : (account.balance || 0 | rai: 'mnano,true') | amountsplit: 1 }}</span>
+                    <span class="amount-currency-name">NANO</span>
                   </div>
                   <div
                     *ngIf="account && account.pending && (account.pending > 0)"
@@ -112,8 +113,10 @@
                     <div class="text-snippet">New</div>
                     <div class="text-full">
                       <div class="amount-sign">+</div>
-                      <div class="amount-integer">{{ account.pending | rai: settings.settings.displayDenomination + ',true' | amountsplit: 0 }}</div>
-                      <div class="amount-fractional">{{ account.pending | rai: settings.settings.displayDenomination + ',true' | amountsplit: 1 }}</div></div>
+                      <div class="amount-integer">{{ account.pending | rai: 'mnano,true' | amountsplit: 0 }}</div>
+                      <div class="amount-fractional">{{ account.pending | rai: 'mnano,true' | amountsplit: 1 }}</div>
+                      <div class="amount-currency-name">NANO</div>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -197,7 +200,7 @@
                   </div>
                 </td>
                 <td class="uk-text-muted" [title]="('Incoming Transaction') + ( (pending.amountRaw && (pending.amountRaw > 0) ) ? ( ', +' + ( pending.amountRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )">
-                  +{{ pending.amount | rai: settings.settings.displayDenomination }}*
+                  +{{ pending.amount | rai: 'mnano,true' | amountsplit: 0 }}{{ pending.amount | rai: 'mnano,true' | amountsplit: 1 }} NANO*
                 </td>
                 <td class="uk-text-truncate"><a [routerLink]="'/transaction/' + pending.hash" class="uk-link-text" title="View Block Details" uk-tooltip>{{ pending.hash }}</a></td>
                 <td *ngIf="remoteVisible"><button class="uk-button uk-button-primary uk-text-center uk-width-auto" style="height: 28px; line-height: 28px; padding-top: 0;" type="button" (click)="generateReceive(pending.hash)">REMOTE SIGN</button></td>
@@ -225,7 +228,9 @@
                 </td>
                 <td [ngClass]="{ 'uk-text-success': history.type == 'receive' || history.subtype == 'receive' || history.type == 'open' || history.subtype == 'open', 'uk-text-danger': history.type == 'send' || history.subtype == 'send' }">
                   <span *ngIf="isNaN(history.amount)">NEW REP</span>
-                  <span *ngIf="!isNaN(history.amount)">{{ (history.type == 'send' || history.subtype == 'send') ? '-' : '+' }}{{ history.amount | rai: settings.settings.displayDenomination }}</span>
+                  <span *ngIf="!isNaN(history.amount)">
+                    {{ (history.type == 'send' || history.subtype == 'send') ? '-' : '+' }}{{ history.amount | rai: 'mnano,true' | amountsplit: 0 }}{{ history.amount | rai: 'mnano,true' | amountsplit: 1 }} NANO
+                  </span>
                 </td>
                 <td class="uk-text-truncate"><a [routerLink]="'/transaction/' + history.hash" class="uk-link-text" title="View Block Details" uk-tooltip>{{ history.hash }}</a></td>
               </tr>

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -66,10 +66,10 @@
             <div class="account-amounts-primary uk-width-1-1">
               <div *ngIf="account.pending.gt(0)" class="incoming-label">
                 <div class="text-snippet">New</div>
-                <div class="text-full">+{{ account.pending | rai: settings.settings.displayDenomination + ',true' }}</div>
+                <div class="text-full">+{{ account.pending | rai: 'mnano,true' | amountsplit: 0 }}{{ account.pending | rai: 'mnano,true' | amountsplit: 1 }} NANO</div>
               </div>
               <span [title]="( account.balanceRaw.gt(0) ? ( '+' + ( account.balanceRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )">
-                {{ account.balance | rai: settings.settings.displayDenomination }}
+                {{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO
               </span>
             </div>
             <div class="uk-width-1-1">

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -19,7 +19,7 @@
       <div class="uk-width-3-4@s">
         <select class="uk-select" [(ngModel)]="pendingAccountModel" (change)="changeQRAccount(pendingAccountModel)">
           <option [value]="0">All Accounts</option>
-          <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: settings.settings.displayDenomination }})</option>
+          <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO)</option>
         </select>
       </div>
       <div class="uk-width-auto@s">
@@ -78,7 +78,7 @@
                 </div>
               </td>
               <td *ngIf="block.account == pendingAccountModel || pendingAccountModel === '0'">
-                {{ block.amount | rai: settings.settings.displayDenomination }}
+                {{ block.amount | rai: 'mnano,true' | amountsplit: 0 }}{{ block.amount | rai: 'mnano,true' | amountsplit: 1 }} NANO
                 <div *ngIf="toBigNumber(block.amount).mod(nano).gt(0)">
                   <span *ngIf="toBigNumber(block.amount); let rawAmount" style="display: block; font-size: 12px;" class="uk-text-muted">+{{ rawAmount.mod(nano).toString(10) }} raw</span>
                 </div>
@@ -92,10 +92,10 @@
               <td colspan="4" style="text-align: center;">No incoming transactions</td>
             </tr>
             <tr *ngIf="pendingAccountModel === '0' && pendingBelowThreshold.length > 0 && pendingBelowThreshold[0].gt(0)">
-              <td colspan="4" style="text-align: center;">Some transactions ({{pendingBelowThreshold[0] | rai: settings.settings.displayDenomination}} total) were hidden due to a Minimum Receive Amount of {{minAmount | rai: settings.settings.displayDenomination}} <a routerLink="/configure-app" routerLinkActive="active">(configure)</a></td>
+              <td colspan="4" style="text-align: center;">Some transactions ({{ pendingBelowThreshold[0] | rai: 'mnano,true' | amountsplit: 0 }}{{ pendingBelowThreshold[0] | rai: 'mnano,true' | amountsplit: 1 }} NANO total) were hidden due to a Minimum Receive Amount of {{ minAmount | rai: 'mnano,true' | amountsplit: 0 }}{{ minAmount | rai: 'mnano,true' | amountsplit: 1 }} NANO <a routerLink="/configure-app" routerLinkActive="active">(configure)</a></td>
             </tr>
             <tr *ngIf="pendingAccountModel !== '0' && walletAccount && walletAccount.pendingBelowThreshold.length > 0 && walletAccount.pendingBelowThreshold[0].gt(0)">
-              <td colspan="4" style="text-align: center;">Some transactions ({{walletAccount.pendingBelowThreshold[0] | rai: settings.settings.displayDenomination}} total) were hidden due to a Minimum Receive Amount of {{minAmount | rai: settings.settings.displayDenomination}} <a routerLink="/configure-app" routerLinkActive="active">(configure)</a></td>
+              <td colspan="4" style="text-align: center;">Some transactions ({{ walletAccount.pendingBelowThreshold[0] | rai: 'mnano,true' | amountsplit: 0 }}{{ walletAccount.pendingBelowThreshold[0] | rai: 'mnano,true' | amountsplit: 1 }} NANO total) were hidden due to a Minimum Receive Amount of {{ minAmount | rai: 'mnano,true' | amountsplit: 0 }}{{ minAmount | rai: 'mnano,true' | amountsplit: 1 }} NANO <a routerLink="/configure-app" routerLinkActive="active">(configure)</a></td>
             </tr>
             <tr *ngIf="loadingIncomingTxList">
               <td colspan="4" style="text-align: center;"><span class="uk-margin-right" uk-spinner></span> Loading incoming transactions...</td>

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -57,7 +57,7 @@
                   </td>
                   <td class="voting-weight-column uk-width-1-4">
                     <div class="uk-text-small uk-text-muted">Total</div>
-                    {{ rep.delegatedWeight | rai: 'mnano' }}
+                    {{ rep.delegatedWeight | rai: 'mnano,true' | amountsplit: 0 }}{{ rep.delegatedWeight | rai: 'mnano,true' | amountsplit: 1 }} NANO
                   </td>
                 </tr>
                 <tr class="delegating-account-row" *ngFor="let delegatingAccount of rep.accounts">
@@ -76,7 +76,7 @@
                     </div>
                   </td>
                   <td class="voting-weight-column uk-width-1-4 uk-text-small">
-                    {{ delegatingAccount.balance | rai: 'mnano' }}
+                    {{ delegatingAccount.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ delegatingAccount.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO
                   </td>
                 </tr>
               </ng-container>
@@ -109,7 +109,7 @@
                   <select class="uk-select" [(ngModel)]="changeAccountID" (change)="newAccountID()" id="form-horizontal-select">
                     <option [value]="null">Select Accounts to Change</option>
                     <option [value]="'all'">All Current Accounts</option>
-                    <option *ngFor="let account of walletService.wallet.accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: settings.settings.displayDenomination }})</option>
+                    <option *ngFor="let account of walletService.wallet.accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO)</option>
                   </select>
                   <ul class="uk-list uk-list-striped">
                     <li *ngFor="let account of selectedAccounts">

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -22,7 +22,7 @@
                 <label class="uk-form-label" for="form-horizontal-select">From Account</label>
                 <div class="uk-form-controls">
                   <select class="form-select-source uk-select" [(ngModel)]="fromAccountID" (change)="resetRaw()" id="form-horizontal-select">
-                    <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: settings.settings.displayDenomination }})</option>
+                    <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO)</option>
                   </select>
                 </div>
               </div>
@@ -59,7 +59,7 @@
                   <select required class="form-select-destination uk-select" [(ngModel)]="toOwnAccountID" id="form-horizontal-select">
                     <option value="" disabled selected hidden>Account to transfer to</option>
                     <ng-container *ngFor="let account of accounts">
-                      <option [value]="account.id" *ngIf="account.id !== fromAccountID">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: settings.settings.displayDenomination }})</option>
+                      <option [value]="account.id" *ngIf="account.id !== fromAccountID">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO)</option>
                     </ng-container>
                   </select>
                 </div>
@@ -110,7 +110,7 @@
       <div class="uk-width-1-1">
         <div class="uk-card uk-card-default uk-width-1-1 uk-text-center">
           <span style="display: block; padding-top: 8px;">You are about to send</span>
-          <span style="display:block; font-size: 32px;">{{ rawAmount | rai: 'mnano' }}</span>
+          <span style="display:block; font-size: 32px;">{{ rawAmount | rai: 'mnano,true' | amountsplit: 0 }}{{ rawAmount | rai: 'mnano,true' | amountsplit: 1 }} NANO</span>
           <span style="display:block; font-size: 12px;" *ngIf="amountRaw.gt(0)">+{{ amountRaw.toString(10) }} raw</span>
           <span style="display:block; font-size: 16px; padding-bottom: 5px;" *ngIf="settings.settings.displayCurrency">{{ amountFiat | fiat: settings.settings.displayCurrency }} @ {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO</span>
         </div>
@@ -136,11 +136,11 @@
               <div class="uk-card-body" style="padding: 20px 20px;">
                 <div uk-grid>
                   <div class="uk-width-1-2 uk-text-muted">
-                    <span class="confirm-currency">{{ fromAccount.balance || 0 | rai: 'mnano'}}</span>
+                    <span class="confirm-currency">{{ (fromAccount.balance || 0) | rai: 'mnano,true' | amountsplit: 0 }}{{ (fromAccount.balance || 0) | rai: 'mnano,true' | amountsplit: 1 }} NANO</span>
                     <span class="confirm-subtitle">Current Balance</span>
                   </div>
                   <div class="uk-width-1-2 uk-text-right">
-                    <span class="confirm-currency uk-text-danger">-{{ rawAmount | rai: 'mnano' }}</span>
+                    <span class="confirm-currency uk-text-danger">-{{ rawAmount | rai: 'mnano,true' | amountsplit: 0 }}{{ rawAmount | rai: 'mnano,true' | amountsplit: 1 }} NANO</span>
                   </div>
                 </div>
               </div>
@@ -167,11 +167,11 @@
               <div class="uk-card-body" style="padding: 20px 20px;">
                 <div uk-grid>
                   <div class="uk-width-1-2 uk-text-muted">
-                    <span class="confirm-currency">{{ toAccount.balance || 0 | rai: 'mnano'}}</span>
+                    <span class="confirm-currency">{{ (toAccount.balance || 0) | rai: 'mnano,true' | amountsplit: 0 }}{{ (toAccount.balance || 0) | rai: 'mnano,true' | amountsplit: 1 }} NANO</span>
                     <span class="confirm-subtitle">Current Balance</span>
                   </div>
                   <div class="uk-width-1-2 uk-text-right">
-                    <span class="confirm-currency uk-text-success">+{{ rawAmount | rai: 'mnano' }}</span>
+                    <span class="confirm-currency uk-text-success">+{{ rawAmount | rai: 'mnano,true' | amountsplit: 0 }}{{ rawAmount | rai: 'mnano,true' | amountsplit: 1 }} NANO</span>
                   </div>
                 </div>
               </div>
@@ -197,7 +197,7 @@
       <div class="uk-width-1-1">
         <div class="uk-card uk-card-default uk-width-1-1 uk-text-center">
           <span style="display: block; padding-top: 8px;">You are sending</span>
-          <span style="display:block; font-size: 32px;">{{ rawAmount | rai: 'mnano' }}</span>
+          <span style="display:block; font-size: 32px;">{{ rawAmount | rai: 'mnano,true' | amountsplit: 0 }}{{ rawAmount | rai: 'mnano,true' | amountsplit: 1 }} NANO</span>
           <span style="display:block; font-size: 12px;" *ngIf="amountRaw.gt(0)">+{{ amountRaw.toString(10) }} raw</span>
           <span style="display:block; font-size: 16px; padding-bottom: 5px;" *ngIf="settings.settings.displayCurrency">{{ amountFiat | fiat: settings.settings.displayCurrency }} @ {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO</span>
         </div>

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -11,7 +11,7 @@
           <span *ngIf="qrCodeImageBlock && shouldSign" style="display: block; padding-top: 8px;">You have signed a block to {{txTypeMessage}}</span>
           <span *ngIf="!blockProcessed && !shouldSign" style="display: block; padding-top: 8px;">You are about to {{txTypeMessage}}</span>
           <span *ngIf="blockProcessed && !shouldSign" style="display: block; padding-top: 8px;">You have processed a block to {{txTypeMessage}}</span>
-          <span *ngIf="txType != txTypes.change" style="display:block; font-size: 32px;">{{ rawAmount | rai: 'mnano' }}</span>
+          <span *ngIf="txType != txTypes.change" style="display:block; font-size: 32px;">{{ rawAmount | rai: 'mnano,true' | amountsplit: 0 }}{{ rawAmount | rai: 'mnano,true' | amountsplit: 1 }} NANO</span>
           <span *ngIf="txType == txTypes.change" style="display:block; font-size: 20px;">{{ currentBlock.representative }}</span>
         </div>
         <br>

--- a/src/app/components/sweeper/sweeper.component.html
+++ b/src/app/components/sweeper/sweeper.component.html
@@ -44,7 +44,7 @@
                 <label class="uk-form-label" for="destination-account">Local Destination <span uk-icon="icon: info;" uk-tooltip title="Local accounts that can be used as destination for the swept funds. Make sure you are able to unlock your Nault wallet."></span></label>
                 <div class="uk-form-controls">
                   <select class="uk-select" id="destination-account" [(ngModel)]="myAccountModel" (change)="setDestination(myAccountModel)">
-                    <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: settings.settings.displayDenomination }})</option>
+                    <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO)</option>
                     <option [value]="0">Custom Destination</option>
                   </select>
                 </div>

--- a/src/app/components/transaction-details/transaction-details.component.html
+++ b/src/app/components/transaction-details/transaction-details.component.html
@@ -13,7 +13,7 @@
           <span *ngIf="blockType == 'open'">Receive</span>
           <span *ngIf="blockType == 'receive'">Receive</span>
         </span>
-        <span style="display:block; font-size: 32px;">{{ transaction?.amount | rai: settings.settings.displayDenomination }}</span>
+        <span style="display:block; font-size: 32px;">{{ transaction?.amount | rai: 'mnano,true' | amountsplit: 0 }}{{ transaction?.amount | rai: 'mnano,true' | amountsplit: 1 }} NANO</span>
         <span *ngIf="amountRaw.gt(0)" style="display:block; font-size: 12px;">+{{ amountRaw.toString(10) }} raw</span>
       </div>
       <div class="uk-card uk-card-default uk-width-1-1 uk-text-center" *ngIf="blockType == 'change'">
@@ -28,7 +28,8 @@
 
               <span class="confirm-title">
                 <a [routerLink]="'/account/' + fromAccountID" class="uk-link-reset" uk-tooltip title="View Account Details">
-                  <span class="uk-label" *ngIf="fromAddressBook">{{ fromAddressBook }}</span> {{ fromAccountID }}
+                  <span class="confirm-title uk-text-truncate" *ngIf="fromAddressBook">{{ fromAddressBook }}</span>
+                  <span class="nano-address-monospace uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
                 </a>
               </span>
               <span class="confirm-subtitle" *ngIf="blockType != 'change'">From Account</span>
@@ -41,7 +42,8 @@
             <div class="uk-text-truncate" style="padding: 20px 20px;">
               <span class="confirm-title">
                 <a [routerLink]="'/account/' + toAccountID" class="uk-link-reset" uk-tooltip title="View Account Details">
-                  <span class="uk-label" *ngIf="toAddressBook">{{ toAddressBook }}</span> {{ toAccountID }}
+                  <span class="confirm-title uk-text-truncate" *ngIf="toAddressBook">{{ toAddressBook }}</span>
+                  <span class="nano-address-monospace uk-text-truncate"><app-nano-account-id [accountID]="toAccountID"></app-nano-account-id></span>
                 </a>
               </span>
               <span class="confirm-subtitle" *ngIf="blockType != 'change'">To Account</span>
@@ -77,8 +79,9 @@
         <div class="uk-margin" *ngIf="transaction?.contents?.balance">
           <label class="uk-form-label">Balance:</label>
           <div class="uk-form-controls uk-text-truncate">
-            {{ (isStateBlock ? getBalanceFromDec(transaction?.contents?.balance) : getBalanceFromHex(transaction?.contents?.balance)) | rai: settings.settings.displayDenomination }}<br>
-            <span class="uk-text-small">{{ transaction?.contents?.balance }}</span>
+            {{ ( isStateBlock ? getBalanceFromDec(transaction?.contents?.balance) : getBalanceFromHex(transaction?.contents?.balance )) | rai: 'mnano,true' | amountsplit: 0 }}{{
+              ( isStateBlock ? getBalanceFromDec(transaction?.contents?.balance) : getBalanceFromHex(transaction?.contents?.balance )) | rai: 'mnano,true' | amountsplit: 1 }} NANO<br>
+            <span class="uk-text-small">{{ transaction?.contents?.balance }} raw</span>
           </div>
         </div>
         <div class="uk-margin" *ngIf="transaction?.contents?.representative">

--- a/src/app/pipes/amount-split.pipe.ts
+++ b/src/app/pipes/amount-split.pipe.ts
@@ -18,6 +18,12 @@ export class AmountSplitPipe implements PipeTransform {
       return '';
     }
 
-    return ( '.' + splitAmount );
+    const fractionalAmount = splitAmount.replace(/0+$/g, '');
+
+    if (fractionalAmount === '') {
+      return '';
+    }
+
+    return ( '.' + fractionalAmount );
   }
 }


### PR DESCRIPTION
1.00000 NANO will render as 1 NANO
1.01000 NANO will render as 1.01 NANO

not the cleanest way of doing it layout-wise, but splitting number string into two parts allows styling the integer and fractional parts differently. some of the layouts already require that functionality and more may need it in the future

![image](https://user-images.githubusercontent.com/29272208/108352546-ea267780-71de-11eb-811b-2cdb8f8427f3.png)

![image](https://user-images.githubusercontent.com/29272208/108352568-f27eb280-71de-11eb-97cb-c54b9ca5f845.png)

![image](https://user-images.githubusercontent.com/29272208/108352591-fad6ed80-71de-11eb-9581-01ae51894f3d.png)
