### PR TITLE
Add representative donation button, various style improvements

### DIFF
--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -2,10 +2,6 @@
     margin-top: 2px;
 }
 
-.text-half-muted {
-    color: #81809f;
-}
-
 .icon-qr-code {
     width: 19px;
     height: 19px;

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -2,6 +2,10 @@
     margin-top: 2px;
 }
 
+.text-half-muted {
+    color: #81809f;
+}
+
 .icon-qr-code {
     width: 19px;
     height: 19px;
@@ -147,10 +151,6 @@
 
 .account-amounts-primary-confirmed > .amount-currency-name {
     margin-left: 4px;
-}
-
-.account-amounts-converted {
-    color: #81809f;
 }
 
 .representative-details {

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -72,9 +72,15 @@
               <div class="uk-width-auto uk-text-truncate" *ngIf="(account && account.representative) else noRepresentative">
                 <div class="representative-label-container">
                   <div class="account-label rep">{{ repLabel ? repLabel : 'Unknown Rep' }}</div>
-                  <div class="uk-width-auto" style="padding-left: 10px;" *ngIf="walletAccount && account && account.representative">
+                  <div class="uk-width-auto uk-flex-inline uk-flex-middle" style="padding-left: 10px;" *ngIf="account && account.representative">
+                    <div class="uk-text-small text-half-muted" style="margin-right: 15px" *ngIf="!repVotingWeight.isZero()">{{ repVotingWeight.toFixed(2) }}%</div>
                     <ul class="uk-iconnav">
-                      <li><a uk-icon="icon: pencil;" title="Change Representative" uk-tooltip routerLink="/representatives" [queryParams]="{ hideOverview: true, showRecommended: true, accounts: accountID }"></a></li>
+                      <li *ngIf="repDonationAddress">
+                        <a class="rep-donation-icon" uk-icon="icon: heart;" title="Donate To Representative" uk-tooltip routerLink="/send" [queryParams]="{ to: repDonationAddress }"></a>
+                      </li>
+                      <li *ngIf="walletAccount">
+                        <a uk-icon="icon: pencil;" title="Change Representative" uk-tooltip routerLink="/representatives" [queryParams]="{ hideOverview: true, showRecommended: true, accounts: accountID }"></a>
+                      </li>
                     </ul>
                   </div>
                 </div>
@@ -122,7 +128,7 @@
                   </div>
                 </div>
               </div>
-              <div class="account-amounts-converted">
+              <div class="account-amounts-converted text-half-muted">
                 <ng-container *ngIf="account">{{ (account.balanceFiat | fiat: settings.settings.displayCurrency) }}</ng-container>
               </div>
             </ng-container>
@@ -224,7 +230,7 @@
           <td class="type-column">
             <span class="type uk-text-small uk-text-success" uk-icon="icon: plus-circle; ratio: 1.2;" *ngIf="(history.type == 'receive' || history.subtype == 'receive' || history.type == 'open')"></span>
             <span class="type uk-text-small uk-text-danger" uk-icon="icon: minus-circle; ratio: 1.2;" *ngIf="(history.type == 'send' || history.subtype == 'send')"></span>
-            <span class="type uk-text-small uk-text-primary" uk-icon="icon: cog; ratio: 1.2;" *ngIf="(history.type == 'change' || history.subtype == 'change')"></span>
+            <span class="type uk-text-small rep-change" uk-icon="icon: cog; ratio: 1.2;" *ngIf="(history.type == 'change' || history.subtype == 'change')"></span>
           </td>
           <td class="account-column uk-text-middle uk-visible-toggle uk-text-truncate">
             <div uk-grid class="uk-flex-nowrap">
@@ -249,7 +255,7 @@
             'uk-text-middle': true,
             'uk-text-success': (history.type == 'receive' || history.subtype == 'receive' || history.type == 'open' || history.subtype == 'open'),
             'uk-text-danger': (history.type == 'send' || history.subtype == 'send'),
-            'uk-text-primary': (history.type == 'change' || history.subtype == 'change')
+            'rep-change': (history.type == 'change' || history.subtype == 'change')
           }">
             <span *ngIf="isNaN(history.amount)">
               <span class="uk-text-small">Rep. Change</span>

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -31,6 +31,9 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
   maxPageSize = 200;
 
   repLabel: any = '';
+  repVotingWeight: BigNumber;
+  repDonationAddress: any = '';
+
   addressBookEntry: any = null;
   account: any = {};
   accountID = '';
@@ -144,7 +147,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
       }
 
       this.representativesOverview = reps;
-      this.updateRepresentativeLabel();
+      this.updateRepresentativeInfo();
     });
   }
 
@@ -204,7 +207,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     this.representativeListMatch = '';
   }
 
-  updateRepresentativeLabel() {
+  updateRepresentativeInfo() {
     if (!this.account) {
       return;
     }
@@ -217,8 +220,13 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
 
     if (representativeFromOverview != null) {
       this.repLabel = representativeFromOverview.label;
+      this.repVotingWeight = representativeFromOverview.percent;
+      this.repDonationAddress = representativeFromOverview.donationAddress;
       return;
     }
+
+    this.repVotingWeight = new BigNumber(0);
+    this.repDonationAddress = null;
 
     const knownRepresentative = this.repService.getRepresentative(this.account.representative);
 
@@ -256,7 +264,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.updateRepresentativeLabel();
+    this.updateRepresentativeInfo();
 
     // If there is a pending balance, or the account is not opened yet, load pending transactions
     if ((!this.account.error && this.account.pending > 0) || this.account.error) {

--- a/src/app/components/accounts/accounts.component.css
+++ b/src/app/components/accounts/accounts.component.css
@@ -46,6 +46,18 @@ th.hidden-column, td.hidden-column {
 	margin-bottom: 3px;
 }
 
+.account-amounts-column .account-amounts-primary .amount-nano {
+	font-family: 'Montserrat', Arial, Helvetica, sans-serif;
+	font-weight: 700;
+	font-size: 16px;
+}
+
+.account-amounts-column .account-amounts-primary .currency-name {
+	font-family: 'Montserrat', Arial, Helvetica, sans-serif;
+	font-weight: 400;
+	margin-left: 5px;
+}
+
 .incoming-label {
 	display: inline-block;
 	background: #4a90e2;

--- a/src/app/components/accounts/accounts.component.css
+++ b/src/app/components/accounts/accounts.component.css
@@ -64,7 +64,7 @@ th.hidden-column, td.hidden-column {
 	border-radius: 20px;
 	font-size: 12px;
 	padding: 2px 10px;
-	margin-right: 2px;
+	margin-right: 7px;
 	vertical-align: 1px;
 	padding-bottom: 1px;
 	text-transform: uppercase;

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -75,10 +75,11 @@
                 <div class="text-full">+{{ account.pending | rai: 'mnano,true' | amountsplit: 0 }}{{ account.pending | rai: 'mnano,true' | amountsplit: 1 }} NANO</div>
               </div>
               <span [title]="( account.balanceRaw.gt(0) ? ( '+' + ( account.balanceRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )">
-                {{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO
+                <span class="amount-nano">{{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }}</span>
+                <span class="currency-name">NANO</span>
               </span>
             </div>
-            <div class="uk-width-1-1">
+            <div class="uk-width-1-1 text-half-muted">
               {{ account.balanceFiat | fiat: settings.settings.displayCurrency }}
             </div>
           </td>

--- a/src/app/components/representatives/representatives.component.css
+++ b/src/app/components/representatives/representatives.component.css
@@ -70,7 +70,7 @@
 	cursor: pointer;
 }
 
-.representative-name-column > .account-label {
+.representative-name-column .account-label {
 	margin-bottom: 3px;
 }
 
@@ -99,8 +99,8 @@
 	width: 18px;
 	min-width: 18px;
 	height: 13px;
-	border-left: 1px solid #777;
-	border-bottom: 1px solid #777;
+	border-left: 1px solid #778;
+	border-bottom: 1px solid #778;
 	border-radius: 0 0 0 2px;
 }
 

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -53,10 +53,16 @@
                     </ng-container>
                   </td>
                   <td class="representative-name-column uk-text-truncate rep-container" (click)="addSelectedAccounts(rep.accounts)">
-                    <div class="account-label rep">{{ rep.label ? rep.label : 'Unknown Rep' }}</div><div class="uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="rep.id" middle="on" class="nano-address-monospace"></app-nano-account-id></div>
+                    <div class="representative-label-container">
+                      <div class="account-label rep">{{ rep.label ? rep.label : 'Unknown Rep' }}</div>
+                      <div class="uk-width-auto uk-flex-inline uk-flex-middle" style="padding-left: 10px;">
+                        <div class="uk-text-small text-half-muted" style="margin-right: 15px" *ngIf="!rep.percent.isZero()">{{ rep.percent.toFixed(2) }}%</div>
+                      </div>
+                    </div>
+                    <div class="uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="rep.id" middle="on" class="nano-address-monospace"></app-nano-account-id></div>
                   </td>
                   <td class="voting-weight-column uk-width-1-4">
-                    <div class="uk-text-small uk-text-muted">Total</div>
+                    <div class="uk-text-small text-half-muted">Total</div>
                     {{ rep.delegatedWeight | rai: 'mnano,true' | amountsplit: 0 }}{{ rep.delegatedWeight | rai: 'mnano,true' | amountsplit: 1 }} NANO
                   </td>
                 </tr>

--- a/src/app/services/representative.service.ts
+++ b/src/app/services/representative.service.ts
@@ -49,6 +49,7 @@ export interface FullRepresentativeOverview extends RepresentativeApiOverview {
   statusText: string;
   label: string|null;
   status: RepresentativeStatus;
+  donationAddress?: string;
 }
 
 
@@ -255,6 +256,7 @@ export class RepresentativeService {
         statusText: status,
         label: label,
         status: repStatus,
+        donationAddress: knownRepNinja?.donation?.account,
       };
 
       const fullRep = { ...representative, ...additionalData };

--- a/src/less/components/dark-mode.less
+++ b/src/less/components/dark-mode.less
@@ -372,6 +372,11 @@
 		border-color: rgba(255, 255, 255, 0.1);
 	}
 
+	// General (Tooltip)
+	.uk-tooltip {
+		background: #4F4F6D;
+	}
+
 	// Unlock Wallet modal
 	.password-input.uk-form-danger {
 		border-color: #F79743;

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -102,6 +102,10 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
 	border-bottom: 1px solid #dce9f9;
 }
 
+.text-half-muted {
+    color: #81809f;
+}
+
 @mobile-top-bar-height: 50px;
 
 .mobile-top-bar {

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -264,6 +264,18 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
 	}
 }
 
+.rep-donation-icon {
+	color: #B08DE3 !important;
+
+	&:hover {
+		color: @rep-label-color !important;
+
+		svg path {
+			fill: @rep-label-color;
+		}
+	}
+}
+
 .nano-address-monospace {
 	font-family: 'Roboto Mono', monospace;
 }
@@ -365,6 +377,10 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
 
 		> .type {
 			margin-top: 35px;
+
+			&.rep-change {
+				color: #A478E3;
+			}
 		}
 	}
 
@@ -410,6 +426,10 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
 			font-family: 'Montserrat', Arial, Helvetica, sans-serif;
 			font-weight: 400;
 			margin-left: 5px;
+		}
+
+		&.rep-change {
+			color: #A478E3;
 		}
 	}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29272208/108601725-f1dc4c80-7395-11eb-9fc6-85daed2bab93.png)

![image](https://user-images.githubusercontent.com/29272208/108601739-09b3d080-7396-11eb-94e9-15bd36a7fe39.png)

Fixes #326 

shown only for reps that opt-in for donations on mynanoninja

\-

rep voting weight is now shown in account details and representatives list

![image](https://user-images.githubusercontent.com/29272208/108601798-61ead280-7396-11eb-91f8-96c2e63d246f.png)

\-

also improved balance style on the accounts page and gave tooltips a little purple-ish tint in the night mode

before:
![image](https://user-images.githubusercontent.com/29272208/108601772-39fb6f00-7396-11eb-8ae9-1b58b8d2b668.png)

after:
![image](https://user-images.githubusercontent.com/29272208/108601759-2c45e980-7396-11eb-8931-fa186afdce29.png)

\-

rep changes are now purple on the tx list rather than blue

![image](https://user-images.githubusercontent.com/29272208/108601872-db82c080-7396-11eb-9b1c-f30a6ba0d8c9.png)
