### PR TITLE
Receive amount in fiat

### DIFF
--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -55,12 +55,6 @@
     bottom: 3px;
 }
 
-#refresh {
-    cursor: pointer;
-    margin-left: 10px;
-    position: relative;
-    bottom: 3px;
-}
 .refresh-disabled {
     color: #bbb;
 }

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -169,8 +169,11 @@
 
     </div>
 
-    <div class="uk-width-1-1">
-      <h3 class="uk-text-center uk-margin-small-bottom">Transactions<span class="{{statsRefreshEnabled ? '':'refresh-disabled'}}" id="refresh" uk-icon="icon: refresh;" (click)="loadAccountDetails(true)" uk-tooltip title="Reload the transaction history from the network."></span></h3>
+    <div class="uk-width-1-1 uk-flex uk-flex-center uk-flex-middle uk-margin-small-bottom">
+      <h3 class="uk-margin-remove-bottom">Transactions</h3>
+      <ul class="uk-width-auto uk-iconnav uk-margin-remove-left" style="margin-top: -1px;">
+        <li><a [class]="{ 'refresh-disabled': !statsRefreshEnabled }" uk-icon="icon: refresh;" (click)="loadAccountDetails(true)" uk-tooltip title="Reload the transaction history from the network."></a></li>
+      </ul>
     </div>
 
     <div class="uk-overflow-hidden">

--- a/src/app/components/helpers/nano-account-id/nano-account-id.component.ts
+++ b/src/app/components/helpers/nano-account-id/nano-account-id.component.ts
@@ -7,7 +7,7 @@ import {Component, Input, OnChanges, HostBinding} from '@angular/core';
 })
 export class NanoAccountIdComponent implements OnChanges {
 
-  @HostBinding('class') classes: string
+  @HostBinding('class') classes: string;
   @Input() accountID: string;
   @Input() middle: 'on'|'off'|'auto'|'break' = 'auto';
 
@@ -19,7 +19,7 @@ export class NanoAccountIdComponent implements OnChanges {
 
   ngOnChanges() {
     if (this.middle === 'auto') this.classes = 'uk-flex';
-    if (this.middle === 'break') this.classes = 'nano-address-breakable'
+    if (this.middle === 'break') this.classes = 'nano-address-breakable';
     const accountID = this.accountID;
     const openingChars = 10;
     const closingChars = 5;

--- a/src/app/components/helpers/nano-account-id/nano-account-id.component.ts
+++ b/src/app/components/helpers/nano-account-id/nano-account-id.component.ts
@@ -7,9 +7,9 @@ import {Component, Input, OnChanges, HostBinding} from '@angular/core';
 })
 export class NanoAccountIdComponent implements OnChanges {
 
-  @HostBinding('class.uk-flex') isFlex: boolean;
+  @HostBinding('class') classes: string
   @Input() accountID: string;
-  @Input() middle: 'on'|'off'|'auto' = 'auto';
+  @Input() middle: 'on'|'off'|'auto'|'break' = 'auto';
 
   firstCharacters = '';
   middleCharacters = '';
@@ -18,7 +18,8 @@ export class NanoAccountIdComponent implements OnChanges {
   constructor() { }
 
   ngOnChanges() {
-    this.isFlex = this.middle === 'auto';
+    if (this.middle === 'auto') this.classes = 'uk-flex';
+    if (this.middle === 'break') this.classes = 'nano-address-breakable'
     const accountID = this.accountID;
     const openingChars = 10;
     const closingChars = 5;

--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -15,9 +15,90 @@
     border-radius: 15px;
     max-width: 270px;
     max-height: 270px;
+    overflow: hidden;
+    position: relative;
 }
 @media (max-width: 959px) {
     .qr-code {
         margin: 0 auto;
+    }
+}
+
+.qr-confirmation {
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    width: 150%;
+    height: 150%;
+    margin: -25%;
+    background: #16A670;
+    transition: all 0.3s cubic-bezier(0.6, 0, 1, 1);
+    transform: scale(0);
+    border-radius: 50%;
+    color: #FFF;
+    padding: 30%;
+    box-sizing: border-box;
+}
+.qr-confirmation.in {
+    transform: scale(1);
+}
+.qr-confirmation.in > :first-child {
+    animation: slidedown 0.7s;
+}
+.qr-confirmation.in > :last-child {
+    animation: slideup 1.4s;
+}
+.qr-confirmation.out {
+    animation: fadeout 5s;
+}
+
+@keyframes slidedown {
+    0% {
+        transform: translateY(-50px);
+        opacity: 0;
+    }
+    50% {
+        transform: translateY(-50px);
+        opacity: 0;
+    }
+    100% {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+@keyframes slideup {
+    0% {
+        transform: translateY(50px);
+        opacity: 0;
+    }
+    50% {
+        transform: translateY(50px);
+        opacity: 0;
+    }
+    100% {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+@keyframes fadeout {
+    0% {
+        transform: scale(1);
+        opacity: 1;
+    }
+    98% {
+        transform: scale(1);
+        opacity: 0;
+    }
+    99% {
+        transform: scale(0);
+        opacity: 0;
+    }
+    100% {
+        transform: scale(0);
+        opacity: 1;
     }
 }

--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -54,6 +54,7 @@
     overflow: hidden;
     position: relative;
     margin: 0 auto;
+    box-sizing: border-box;
 }
 @media (max-width: 959px) {
     .qr-code {

--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -35,6 +35,7 @@
     }
     .qr-column {
         width: 0;
+        max-width: 360px;
         margin-right: 20px;
     }
 }

--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -10,17 +10,27 @@
     margin-left: 5px;
 }
 
+.form-account {
+	max-width: 800px;
+}
+
+.form-amount {
+	max-width: 450px;
+}
+
 .qr-code {
     display: block;
-    border-radius: 15px;
-    max-width: 270px;
-    max-height: 270px;
+    border-radius: 20px;
+    max-width: 315px;
+    max-height: 315px;
     overflow: hidden;
     position: relative;
 }
 @media (max-width: 959px) {
     .qr-code {
         margin: 0 auto;
+        max-width: 250px;
+        max-height: 250px;
     }
 }
 
@@ -48,7 +58,7 @@
     animation: slidedown 0.7s;
 }
 .qr-confirmation.in > :last-child {
-    animation: slideup 1.4s;
+    animation: slideup 1.2s;
 }
 .qr-confirmation.out {
     animation: fadeout 5s;

--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -18,6 +18,13 @@
 	max-width: 450px;
 }
 
+.icon-nano-logo {
+    margin: 11px 6px;
+    background-color: currentcolor;
+    -webkit-mask-image: url('assets/img/nano-mark-simple.svg');
+    mask-image: url('assets/img/nano-mark-simple.svg');
+}
+
 .qr-code {
     display: block;
     border-radius: 20px;

--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -9,3 +9,15 @@
 .span-icon {
     margin-left: 5px;
 }
+
+.qr-code {
+    display: block;
+    border-radius: 15px;
+    max-width: 270px;
+    max-height: 270px;
+}
+@media (max-width: 959px) {
+    .qr-code {
+        margin: 0 auto;
+    }
+}

--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -25,6 +25,20 @@
     mask-image: url('assets/img/nano-mark-simple.svg');
 }
 
+.receive-columns {
+    display: flex;
+    flex-direction: column;
+}
+@media (min-width: 640px) {
+    .receive-columns {
+        flex-direction: row-reverse;
+    }
+    .qr-column {
+        width: 0;
+        margin-right: 20px;
+    }
+}
+
 .qr-code {
     display: block;
     border-radius: 20px;
@@ -32,10 +46,10 @@
     max-height: 315px;
     overflow: hidden;
     position: relative;
+    margin: 0 auto;
 }
 @media (max-width: 959px) {
     .qr-code {
-        margin: 0 auto;
         max-width: 250px;
         max-height: 250px;
     }

--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -1,3 +1,8 @@
+.label-block {
+    margin-left: 10px;
+    margin-bottom: 10px;
+}
+
 .nano-address-actions {
     margin-top: 2px;
 }

--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -19,7 +19,8 @@
 }
 
 .icon-nano-logo {
-    margin: 11px 6px;
+    margin: 13px 11px;
+    width: 32px;
     background-color: currentcolor;
     -webkit-mask-image: url('assets/img/nano-mark-simple.svg');
     mask-image: url('assets/img/nano-mark-simple.svg');

--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -49,8 +49,8 @@
 .qr-code {
     display: block;
     border-radius: 20px;
-    max-width: 315px;
-    max-height: 315px;
+    max-width: 290px;
+    max-height: 290px;
     overflow: hidden;
     position: relative;
     margin: 0 auto;
@@ -60,6 +60,14 @@
         max-width: 250px;
         max-height: 250px;
     }
+}
+.qr-placeholder {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    background: #FFF;
+    padding: 20px;
 }
 
 .qr-confirmation {

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -5,49 +5,49 @@
 
     <div class="uk-card uk-card-default uk-margin">
       <div class="uk-card-body">
-        <div class="uk-form-horizontal">
+        <div class="uk-form-horizontal receive-columns">
 
-          <div class="uk-margin">
-            <label for="form-horizontal-select" class="uk-form-label">Account</label>
-            <div class="uk-form-controls form-account">
-              <select id="form-horizontal-select" class="uk-select" [(ngModel)]="pendingAccountModel" (change)="changeQRAccount(pendingAccountModel)">
-                <option [value]="0">All Accounts</option>
-                <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO)</option>
-              </select>
-            </div>
-          </div>
-
-          <div class="uk-margin">
-            <label for="form-horizontal-amount" class="uk-form-label">Optional Amount</label>
-            <div class="uk-form-controls form-amount">
-              <div class="uk-width-1-1 uk-inline">
-                <label class="uk-form-icon uk-link-reset uk-link-muted icon-nano-logo" for="form-horizontal-amount"></label>
-                <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" style="padding-left: 50px !important;" type="number" placeholder="Amount of NANO to receive" maxlength="40">
+          <div class="uk-flex-1">
+            <div class="uk-margin">
+              <label for="form-horizontal-select" class="uk-form-label">Account</label>
+              <div class="form-account">
+                <select id="form-horizontal-select" class="uk-select" [(ngModel)]="pendingAccountModel" (change)="changeQRAccount(pendingAccountModel)">
+                  <option [value]="0">All Accounts</option>
+                  <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO)</option>
+                </select>
               </div>
-              <div style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
+            </div>
+  
+            <div class="uk-margin">
+              <label for="form-horizontal-amount" class="uk-form-label">Optional Amount</label>
+              <div class="form-amount">
                 <div class="uk-width-1-1 uk-inline">
-                  <a class="uk-form-icon uk-link-reset uk-link-muted" style="padding-left: 7px;" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
-                  <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" autocomplete="off" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
+                  <label class="uk-form-icon uk-link-reset uk-link-muted icon-nano-logo" for="form-horizontal-amount"></label>
+                  <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" style="padding-left: 50px !important;" type="number" placeholder="Amount of NANO to receive" maxlength="40">
+                </div>
+                <div style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
+                  <div class="uk-width-1-1 uk-inline">
+                    <a class="uk-form-icon uk-link-reset uk-link-muted" style="padding-left: 7px;" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
+                    <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" autocomplete="off" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
+                  </div>
                 </div>
               </div>
             </div>
           </div>
 
-          <div class="uk-margin">
-            <div class="uk-form-controls">
-              <div *ngIf="qrCodeImage">
-                <div class="qr-code">
-                  <div class="qr-confirmation" [class]="qrSuccessClass">
-                    <div uk-icon="icon: check; ratio: 5"></div>
-                    <span class="uk-text-large uk-text-center">Nano Received</span>
-                  </div>
-                  <img [src]="qrCodeImage" alt="QR code">
+          <div class="uk-flex-1 uk-margin qr-column">
+            <div *ngIf="qrCodeImage">
+              <div class="qr-code">
+                <div class="qr-confirmation" [class]="qrSuccessClass">
+                  <div uk-icon="icon: check; ratio: 5"></div>
+                  <span class="uk-text-large uk-text-center">Nano Received</span>
                 </div>
-                <br>
-                <div class="uk-flex">
-                  <app-nano-account-id [accountID]="pendingAccountModel" class="nano-address-monospace uk-width-auto" style="max-width: 90%;"></app-nano-account-id>
-                  <a class="span-icon" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
-                </div>
+                <img [src]="qrCodeImage" alt="QR code">
+              </div>
+              <br>
+              <div class="uk-flex uk-flex-center">
+                <app-nano-account-id [accountID]="pendingAccountModel" class="nano-address-monospace uk-width-auto" style="max-width: 90%;"></app-nano-account-id>
+                <a class="span-icon" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
               </div>
             </div>
           </div>

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -45,8 +45,8 @@
                 <img [src]="qrCodeImage" alt="QR code">
               </div>
               <br>
-              <div class="uk-flex uk-flex-center">
-                <app-nano-account-id [accountID]="pendingAccountModel" class="nano-address-monospace uk-width-auto" style="max-width: 90%;"></app-nano-account-id>
+              <div class="uk-flex uk-flex-center uk-flex-middle uk-text-center">
+                <app-nano-account-id [accountID]="pendingAccountModel" middle="break" class="nano-address-monospace uk-width-auto" style="max-width: 90%;"></app-nano-account-id>
                 <a class="span-icon" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
               </div>
             </div>

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -23,12 +23,12 @@
               <div class="form-amount">
                 <div class="uk-width-1-1 uk-inline">
                   <label class="uk-form-icon uk-link-reset uk-link-muted icon-nano-logo" for="form-horizontal-amount"></label>
-                  <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" style="padding-left: 50px !important;" type="number" placeholder="Amount of NANO to receive" maxlength="40">
+                  <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" style="padding-left: 52px !important;" type="number" placeholder="Amount of NANO to receive" maxlength="40">
                 </div>
                 <div style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
                   <div class="uk-width-1-1 uk-inline">
-                    <a class="uk-form-icon uk-link-reset uk-link-muted" style="padding-left: 7px;" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
-                    <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" autocomplete="off" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
+                    <a class="uk-form-icon uk-link-reset uk-link-muted fiat-currency-ticker" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
+                    <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" autocomplete="off" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
                   </div>
                 </div>
               </div>

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -8,7 +8,7 @@
         <div class="uk-form-horizontal">
 
           <div class="uk-margin">
-            <label for="form-horizontal-select" class="uk-form-label">From Account</label>
+            <label for="form-horizontal-select" class="uk-form-label">Account</label>
             <div class="uk-form-controls form-account">
               <select id="form-horizontal-select" class="uk-select" [(ngModel)]="pendingAccountModel" (change)="changeQRAccount(pendingAccountModel)">
                 <option [value]="0">All Accounts</option>
@@ -20,11 +20,11 @@
           <div class="uk-margin">
             <label for="form-horizontal-amount" class="uk-form-label">Optional Amount</label>
             <div class="uk-form-controls form-amount">
-              <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" type="text" placeholder="Amount of NANO to receive" maxlength="40">
+              <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" type="number" placeholder="Amount of NANO to receive" maxlength="40">
               <div style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
                 <div class="uk-width-1-1 uk-inline">
                   <a class="uk-form-icon uk-link-reset uk-link-muted" style="padding-left: 7px;" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
-                  <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" autocomplete="off" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text-fiat" type="text" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
+                  <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" autocomplete="off" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
                 </div>
               </div>
             </div>

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -56,11 +56,11 @@
       </div>
     </div>
 
-    <div class="uk-width-1-1">
-      <h3 class="uk-text-center uk-margin-small-bottom">
-        Incoming Transactions
-        <span id="refresh" class="uk-margin-small-left" uk-icon="icon: refresh;" (click)="getPending()" uk-tooltip title="Reload the transaction history from the network."></span>
-      </h3>
+    <div class="uk-width-1-1 uk-flex uk-flex-center uk-flex-middle uk-margin-small-bottom">
+      <h3 class="uk-margin-remove-bottom">Incoming Transactions</h3>
+      <ul class="uk-width-auto uk-iconnav uk-margin-remove-left" style="margin-top: -1px;">
+        <li><a uk-icon="icon: refresh;" (click)="getPending()" uk-tooltip title="Reload incoming transactions from the network."></a></li>
+      </ul>
     </div>
 
     <div uk-grid>

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -3,58 +3,38 @@
     
     <h2 class="uk-heading-divider">Receive Nano</h2>
 
-    <!-- <div class="uk-width-1-1 nlt-page-intro">
-      <p>
-        Select an account to show the deposit QR.
-      </p>
-      <p>
-        Funds should be received automatically if the wallet is unlocked. If not, you can try find them and receive manually.
-      </p>
-      <p>
-        You can also find full transaction history under <a routerLink="/accounts" routerLinkActive="active">Accounts</a>.
-      </p>
-    </div> -->
-
-
     <div class="uk-card uk-card-default uk-margin">
       <div class="uk-card-body">
         <div class="uk-form-horizontal">
 
           <div class="uk-margin">
             <label for="form-horizontal-select" class="uk-form-label">From Account</label>
-            <div class= uk-form-controls>
+            <div class="uk-form-controls form-account">
               <select id="form-horizontal-select" class="uk-select" [(ngModel)]="pendingAccountModel" (change)="changeQRAccount(pendingAccountModel)">
                 <option [value]="0">All Accounts</option>
                 <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO)</option>
               </select>
             </div>
           </div>
+
           <div class="uk-margin">
             <label for="form-horizontal-amount" class="uk-form-label">Optional Amount</label>
-            <div class="uk-form-controls">
-
-              <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" type="text" placeholder="Amount of NANO to receive" maxlength="40">
-
+            <div class="uk-form-controls form-amount">
+              <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" type="text" placeholder="Amount of NANO to receive" maxlength="40">
               <div style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
                 <div class="uk-width-1-1 uk-inline">
                   <a class="uk-form-icon uk-link-reset uk-link-muted" style="padding-left: 7px;" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
-                  <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text-fiat" type="text" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
+                  <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" autocomplete="off" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text-fiat" type="text" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
                 </div>
               </div>
-
             </div>
           </div>
 
-          <!-- <div class="uk-width-auto@s">
-            <button class="uk-button uk-button-primary uk-width-1-1" (click)="getPending()"> Find Incoming</button>
-          </div> -->
-
           <div class="uk-margin">
             <div class="uk-form-controls">
-
               <div *ngIf="qrCodeImage">
                 <div class="qr-code">
-                  <div class="qr-confirmation">
+                  <div class="qr-confirmation" [class]="qrSuccessClass">
                     <div uk-icon="icon: check; ratio: 5"></div>
                     <span class="uk-text-large uk-text-center">Nano Received</span>
                   </div>
@@ -66,7 +46,6 @@
                   <a class="span-icon" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
                 </div>
               </div>
-
             </div>
           </div>
                   

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -20,7 +20,10 @@
           <div class="uk-margin">
             <label for="form-horizontal-amount" class="uk-form-label">Optional Amount</label>
             <div class="uk-form-controls form-amount">
-              <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" type="number" placeholder="Amount of NANO to receive" maxlength="40">
+              <div class="uk-width-1-1 uk-inline">
+                <label class="uk-form-icon uk-link-reset uk-link-muted icon-nano-logo" for="form-horizontal-amount"></label>
+                <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" style="padding-left: 50px !important;" type="number" placeholder="Amount of NANO to receive" maxlength="40">
+              </div>
               <div style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
                 <div class="uk-width-1-1 uk-inline">
                   <a class="uk-form-icon uk-link-reset uk-link-muted" style="padding-left: 7px;" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -1,41 +1,76 @@
 <div class="uk-animation-slide-left-small" uk-grid>
   <div class="uk-width-1-1">
     
-      <h2 class="uk-heading-divider">Receive Nano</h2>
+    <h2 class="uk-heading-divider">Receive Nano</h2>
 
-      <div class="uk-width-1-1 nlt-page-intro">
-        <p>
-          Select an account to show the deposit QR.
-        </p>
-        <p>
-          Funds should be received automatically if the wallet is unlocked. If not, you can try find them and receive manually.
-        </p>
-        <p>
-          You can also find full transaction history under <a routerLink="/accounts" routerLinkActive="active">Accounts</a>.
-        </p>
-      </div>
+    <!-- <div class="uk-width-1-1 nlt-page-intro">
+      <p>
+        Select an account to show the deposit QR.
+      </p>
+      <p>
+        Funds should be received automatically if the wallet is unlocked. If not, you can try find them and receive manually.
+      </p>
+      <p>
+        You can also find full transaction history under <a routerLink="/accounts" routerLinkActive="active">Accounts</a>.
+      </p>
+    </div> -->
 
-    <div uk-grid>
-      <div class="uk-width-3-4@s">
-        <select class="uk-select" [(ngModel)]="pendingAccountModel" (change)="changeQRAccount(pendingAccountModel)">
-          <option [value]="0">All Accounts</option>
-          <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO)</option>
-        </select>
-      </div>
-      <div class="uk-width-auto@s">
-        <button class="uk-button uk-button-primary uk-width-1-1" (click)="getPending()"> Find Incoming</button>
-      </div>
-              
-      <div *ngIf="qrCodeImage" class="uk-width-3-4@s narrow-div">
-        <input [(ngModel)]="receiveAmount" class="uk-input uk-margin-small-bottom" type="text" (ngModelChange)="changeQRAmount(receiveAmount)" title="Amount to be included in the QR and read by the sending wallet." placeholder="Optional Nano amount">
-      </div>
-      <div *ngIf="qrCodeImage" class="uk-width-1-1@s narrow-div">
-        <img [src]="qrCodeImage" alt="QR code"><br>
-        <div class="uk-flex">
-          <app-nano-account-id [accountID]="pendingAccountModel" class="nano-address-monospace uk-width-auto" style="max-width: 90%;"></app-nano-account-id>
-          <a class="span-icon" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
+
+    <div class="uk-card uk-card-default uk-margin">
+      <div class="uk-card-body">
+        <div class="uk-form-horizontal">
+
+          <div class="uk-margin">
+            <label for="form-horizontal-select" class="uk-form-label">From Account</label>
+            <div class= uk-form-controls>
+              <select id="form-horizontal-select" class="uk-select" [(ngModel)]="pendingAccountModel" (change)="changeQRAccount(pendingAccountModel)">
+                <option [value]="0">All Accounts</option>
+                <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO)</option>
+              </select>
+            </div>
+          </div>
+          <div class="uk-margin">
+            <label for="form-horizontal-amount" class="uk-form-label">Optional amount</label>
+            <div class="uk-form-controls">
+
+              <div *ngIf="qrCodeImage">
+                <input [(ngModel)]="receiveAmount" class="uk-input uk-margin-small-bottom" type="text" (ngModelChange)="changeQRAmount(receiveAmount)" title="Amount to be included in the QR and read by the sending wallet." placeholder="Optional Nano amount">
+              </div>
+
+
+            </div>
+          </div>
+
+          <!-- <div class="uk-width-auto@s">
+            <button class="uk-button uk-button-primary uk-width-1-1" (click)="getPending()"> Find Incoming</button>
+          </div> -->
+
+          <div class="uk-margin">
+            <div class="uk-form-controls">
+
+              <div *ngIf="qrCodeImage" class="uk-width-1-1@s narrow-div">
+                <img [src]="qrCodeImage" alt="QR code"><br>
+                <div class="uk-flex">
+                  <app-nano-account-id [accountID]="pendingAccountModel" class="nano-address-monospace uk-width-auto" style="max-width: 90%;"></app-nano-account-id>
+                  <a class="span-icon" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
+                </div>
+              </div>
+
+            </div>
+          </div>
+                  
         </div>
       </div>
+    </div>
+
+    <div class="uk-width-1-1">
+      <h3 class="uk-text-center uk-margin-small-bottom">
+        Transactions
+        <span id="refresh" class="uk-margin-small-left" uk-icon="icon: refresh;" (click)="getPending()" uk-tooltip title="Reload the transaction history from the network."></span>
+      </h3>
+    </div>
+
+    <div uk-grid>
       <div class="uk-width-1-1">
         <div class="uk-card uk-card-default">
           <table class="uk-table uk-table-striped uk-table-small">

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -23,12 +23,12 @@
               <div class="form-amount">
                 <div class="uk-width-1-1 uk-inline">
                   <label class="uk-form-icon uk-link-reset uk-link-muted icon-nano-logo" for="form-horizontal-amount"></label>
-                  <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" style="padding-left: 52px !important;" type="number" placeholder="Amount of NANO to receive" maxlength="40">
+                  <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" [attr.disabled]="pendingAccountModel == '0' || null" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" style="padding-left: 52px !important;" type="number" placeholder="Amount of NANO to receive" maxlength="40">
                 </div>
                 <div style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
                   <div class="uk-width-1-1 uk-inline">
                     <a class="uk-form-icon uk-link-reset uk-link-muted fiat-currency-ticker" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
-                    <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" autocomplete="off" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
+                    <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" [attr.disabled]="pendingAccountModel == '0' || null" autocomplete="off" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
                   </div>
                 </div>
               </div>
@@ -36,7 +36,7 @@
           </div>
 
           <div class="uk-flex-1 uk-margin qr-column">
-            <div *ngIf="qrCodeImage">
+            <div *ngIf="qrCodeImage; else placeholder">
               <div class="qr-code">
                 <div class="qr-confirmation" [class]="qrSuccessClass">
                   <div uk-icon="icon: check; ratio: 5"></div>
@@ -50,6 +50,12 @@
                 <a class="span-icon" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
               </div>
             </div>
+            <ng-template #placeholder>
+              <div class="qr-code qr-placeholder">
+                <div class="uk-position-absolute text-half-muted">Select an account<br/>to view QR code</div>
+                <div style="padding-top: 100%"></div>
+              </div>
+            </ng-template>
           </div>
                   
         </div>

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -9,7 +9,7 @@
 
           <div class="uk-flex-1">
             <div class="uk-margin">
-              <label for="form-horizontal-select" class="uk-form-label">Account</label>
+              <label for="form-horizontal-select" class="uk-form-label label-block">Account</label>
               <div class="form-account">
                 <select id="form-horizontal-select" class="uk-select" [(ngModel)]="pendingAccountModel" (change)="changeQRAccount(pendingAccountModel)">
                   <option [value]="0">All Accounts</option>
@@ -19,7 +19,7 @@
             </div>
   
             <div class="uk-margin">
-              <label for="form-horizontal-amount" class="uk-form-label">Optional Amount</label>
+              <label for="form-horizontal-amount" class="uk-form-label label-block">Amount <span class="uk-text-muted">(optional)</span></label>
               <div class="form-amount">
                 <div class="uk-width-1-1 uk-inline">
                   <label class="uk-form-icon uk-link-reset uk-link-muted icon-nano-logo" for="form-horizontal-amount"></label>

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -23,12 +23,12 @@
               <div class="form-amount">
                 <div class="uk-width-1-1 uk-inline">
                   <label class="uk-form-icon uk-link-reset uk-link-muted icon-nano-logo" for="form-horizontal-amount"></label>
-                  <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" [attr.disabled]="pendingAccountModel == '0' || null" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" style="padding-left: 52px !important;" type="number" placeholder="Amount of NANO to receive" maxlength="40">
+                  <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" [attr.disabled]="pendingAccountModel == '0' || null" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" style="padding-left: 52px !important;" type="number" step="any" placeholder="Amount of NANO to receive" maxlength="40">
                 </div>
                 <div style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
                   <div class="uk-width-1-1 uk-inline">
                     <a class="uk-form-icon uk-link-reset uk-link-muted fiat-currency-ticker" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
-                    <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" [attr.disabled]="pendingAccountModel == '0' || null" autocomplete="off" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
+                    <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" [attr.disabled]="pendingAccountModel == '0' || null" autocomplete="off" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" step="any" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
                   </div>
                 </div>
               </div>

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -53,8 +53,13 @@
             <div class="uk-form-controls">
 
               <div *ngIf="qrCodeImage">
-                <!-- <div class="qr-code qr-confirmation"><div></div></div> -->
-                <img class="qr-code" [src]="qrCodeImage" alt="QR code">
+                <div class="qr-code">
+                  <div class="qr-confirmation">
+                    <div uk-icon="icon: check; ratio: 5"></div>
+                    <span class="uk-text-large uk-text-center">Nano Received</span>
+                  </div>
+                  <img [src]="qrCodeImage" alt="QR code">
+                </div>
                 <br>
                 <div class="uk-flex">
                   <app-nano-account-id [accountID]="pendingAccountModel" class="nano-address-monospace uk-width-auto" style="max-width: 90%;"></app-nano-account-id>

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -30,13 +30,17 @@
             </div>
           </div>
           <div class="uk-margin">
-            <label for="form-horizontal-amount" class="uk-form-label">Optional amount</label>
+            <label for="form-horizontal-amount" class="uk-form-label">Optional Amount</label>
             <div class="uk-form-controls">
 
-              <div *ngIf="qrCodeImage">
-                <input [(ngModel)]="receiveAmount" class="uk-input uk-margin-small-bottom" type="text" (ngModelChange)="changeQRAmount(receiveAmount)" title="Amount to be included in the QR and read by the sending wallet." placeholder="Optional Nano amount">
-              </div>
+              <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" type="text" placeholder="Amount of NANO to receive" maxlength="40">
 
+              <div style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
+                <div class="uk-width-1-1 uk-inline">
+                  <a class="uk-form-icon uk-link-reset uk-link-muted" style="padding-left: 7px;" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
+                  <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text-fiat" type="text" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
+                </div>
+              </div>
 
             </div>
           </div>
@@ -48,8 +52,10 @@
           <div class="uk-margin">
             <div class="uk-form-controls">
 
-              <div *ngIf="qrCodeImage" class="uk-width-1-1@s narrow-div">
-                <img [src]="qrCodeImage" alt="QR code"><br>
+              <div *ngIf="qrCodeImage">
+                <!-- <div class="qr-code qr-confirmation"><div></div></div> -->
+                <img class="qr-code" [src]="qrCodeImage" alt="QR code">
+                <br>
                 <div class="uk-flex">
                   <app-nano-account-id [accountID]="pendingAccountModel" class="nano-address-monospace uk-width-auto" style="max-width: 90%;"></app-nano-account-id>
                   <a class="span-icon" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
@@ -65,7 +71,7 @@
 
     <div class="uk-width-1-1">
       <h3 class="uk-text-center uk-margin-small-bottom">
-        Transactions
+        Incoming Transactions
         <span id="refresh" class="uk-margin-small-left" uk-icon="icon: refresh;" (click)="getPending()" uk-tooltip title="Reload the transaction history from the network."></span>
       </h3>
     </div>

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -76,6 +76,7 @@ export class ReceiveComponent implements OnInit {
         const rawAmount = new BigNumber(transaction.amount);
         if (transaction.block.link_as_account === this.qrAccount && rawAmount.gte(this.qrAmount || 0)) {
           this.showQrConfirmation();
+          setTimeout(() => this.resetAmount(), 500);
         }
       }
     });
@@ -199,10 +200,16 @@ export class ReceiveComponent implements OnInit {
     }
   }
 
-  async showQrConfirmation() {
+  showQrConfirmation() {
     this.qrSuccessClass = 'in';
     setTimeout(() => { this.qrSuccessClass = 'out'; }, 7000);
     setTimeout(() => { this.qrSuccessClass = ''; }, 12000);
+  }
+
+  resetAmount() {
+    this.amountNano = '';
+    this.amountFiat = '';
+    this.changeQRAmount();
   }
 
   async receivePending(pendingBlock) {

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -34,11 +34,11 @@ export class ReceiveComponent implements OnInit {
   walletAccount: WalletAccount = null;
   selAccountInit = false;
   loadingIncomingTxList = false;
-  amountNano = ''
-  amountFiat = ''
-  validNano = true
-  validFiat = true
-  qrSuccessClass = ''
+  amountNano = '';
+  amountFiat = '';
+  validNano = true;
+  validFiat = true;
+  qrSuccessClass = '';
 
   constructor(
     private walletService: WalletService,
@@ -70,15 +70,15 @@ export class ReceiveComponent implements OnInit {
     }
 
     // Listen as new transactions come in. Ignore the latest transaction that is already present on page load.
-    const latest = this.websocket.newTransactions$.getValue()
+    const latest = this.websocket.newTransactions$.getValue();
     this.websocket.newTransactions$.subscribe(async (transaction) => {
       if (transaction && latest !== transaction) {
-        const rawAmount = new BigNumber(transaction.amount)
+        const rawAmount = new BigNumber(transaction.amount);
         if (transaction.block.link_as_account === this.qrAccount && rawAmount.gte(this.qrAmount || 0)) {
-          this.showQrConfirmation()
+          this.showQrConfirmation();
         }
       }
-    })
+    });
   }
 
   async loadPendingForAll() {
@@ -122,8 +122,8 @@ export class ReceiveComponent implements OnInit {
 
   async nanoAmountChange() {
     if (!this.validateNanoAmount() || Number(this.amountNano) === 0) {
-      this.amountFiat = ''
-      this.changeQRAmount()
+      this.amountFiat = '';
+      this.changeQRAmount();
       return;
     }
     const rawAmount = this.util.nano.mnanoToRaw(this.amountNano || 0);
@@ -132,21 +132,22 @@ export class ReceiveComponent implements OnInit {
     const precision = this.settings.settings.displayCurrency === 'BTC' ? 1000000 : 100;
 
     // Determine fiat value of the amount
-    const fiatAmount = this.util.nano.rawToMnano(rawAmount).times(this.price.price.lastPrice).times(precision).floor().div(precision).toNumber();
+    const fiatAmount = this.util.nano.rawToMnano(rawAmount).times(this.price.price.lastPrice)
+      .times(precision).floor().div(precision).toNumber();
 
     this.amountFiat = fiatAmount.toString();
-    this.changeQRAmount(rawAmount.toFixed())
+    this.changeQRAmount(rawAmount.toFixed());
   }
 
   async fiatAmountChange() {
     if (!this.validateFiatAmount() || Number(this.amountFiat) === 0) {
       this.amountNano = '';
-      this.changeQRAmount()
+      this.changeQRAmount();
       return;
     }
     const rawAmount = this.util.nano.mnanoToRaw(new BigNumber(this.amountFiat).div(this.price.price.lastPrice));
     const nanoVal = this.util.nano.rawToNano(rawAmount).floor();
-    const rawRounded = this.util.nano.nanoToRaw(nanoVal)
+    const rawRounded = this.util.nano.nanoToRaw(nanoVal);
     const nanoAmount = this.util.nano.rawToMnano(rawRounded);
 
     this.amountNano = nanoAmount.toFixed();
@@ -155,8 +156,8 @@ export class ReceiveComponent implements OnInit {
 
   validateNanoAmount() {
     if (!this.amountNano) {
-      this.validNano = true
-      return true
+      this.validNano = true;
+      return true;
     }
     this.validNano = this.amountNano !== '-' && (this.util.account.isValidNanoAmount(this.amountNano) || Number(this.amountNano) === 0);
     return this.validNano;
@@ -164,12 +165,12 @@ export class ReceiveComponent implements OnInit {
 
   validateFiatAmount() {
     if (!this.amountFiat) {
-      this.validFiat = true
-      return true
+      this.validFiat = true;
+      return true;
     }
-    this.validFiat = this.util.string.isNumeric(this.amountFiat) && Number(this.amountFiat) >= 0
-    return this.validFiat
-  } 
+    this.validFiat = this.util.string.isNumeric(this.amountFiat) && Number(this.amountFiat) >= 0;
+    return this.validFiat;
+  }
 
   async changeQRAccount(account) {
     this.walletAccount = this.walletService.wallet.accounts.find(a => a.id === account) || null;
@@ -177,7 +178,7 @@ export class ReceiveComponent implements OnInit {
     let qrCode = null;
     if (account.length > 1) {
       this.qrAccount = account;
-      qrCode = await QRCode.toDataURL('nano:' + account + (this.qrAmount ? '?amount=' + this.qrAmount.toString(10) : ''), { scale: 7 });
+      qrCode = await QRCode.toDataURL(`nano:${account}${this.qrAmount ? `?amount=${this.qrAmount.toString(10)}` : ''}`, { scale: 7 });
     }
     this.qrCodeImage = qrCode;
   }
@@ -191,15 +192,15 @@ export class ReceiveComponent implements OnInit {
       }
     }
     if (this.qrAccount.length > 1) {
-      qrCode = await QRCode.toDataURL('nano:' + this.qrAccount + (this.qrAmount ? '?amount=' + this.qrAmount.toString(10) : ''), { scale: 7 });
+      qrCode = await QRCode.toDataURL(`nano:${this.qrAccount}${this.qrAmount ? `?amount=${this.qrAmount.toString(10)}` : ''}`, { scale: 7 });
       this.qrCodeImage = qrCode;
     }
   }
 
   async showQrConfirmation() {
-    this.qrSuccessClass = 'in'
-    setTimeout(() => { this.qrSuccessClass = 'out' }, 7000)
-    setTimeout(() => { this.qrSuccessClass = '' }, 12000)
+    this.qrSuccessClass = 'in';
+    setTimeout(() => { this.qrSuccessClass = 'out' }, 7000);
+    setTimeout(() => { this.qrSuccessClass = '' }, 12000);
   }
 
   async receivePending(pendingBlock) {

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -178,7 +178,7 @@ export class ReceiveComponent implements OnInit {
     let qrCode = null;
     if (account.length > 1) {
       this.qrAccount = account;
-      qrCode = await QRCode.toDataURL(`nano:${account}${this.qrAmount ? `?amount=${this.qrAmount.toString(10)}` : ''}`, { scale: 7 });
+      qrCode = await QRCode.toDataURL(`nano:${account}${this.qrAmount ? `?amount=${this.qrAmount.toString(10)}` : ''}`, {scale: 7});
     }
     this.qrCodeImage = qrCode;
   }
@@ -192,15 +192,15 @@ export class ReceiveComponent implements OnInit {
       }
     }
     if (this.qrAccount.length > 1) {
-      qrCode = await QRCode.toDataURL(`nano:${this.qrAccount}${this.qrAmount ? `?amount=${this.qrAmount.toString(10)}` : ''}`, { scale: 7 });
+      qrCode = await QRCode.toDataURL(`nano:${this.qrAccount}${this.qrAmount ? `?amount=${this.qrAmount.toString(10)}` : ''}`, {scale: 7});
       this.qrCodeImage = qrCode;
     }
   }
 
   async showQrConfirmation() {
     this.qrSuccessClass = 'in';
-    setTimeout(() => { this.qrSuccessClass = 'out' }, 7000);
-    setTimeout(() => { this.qrSuccessClass = '' }, 12000);
+    setTimeout(() => { this.qrSuccessClass = 'out'; }, 7000);
+    setTimeout(() => { this.qrSuccessClass = ''; }, 12000);
   }
 
   async receivePending(pendingBlock) {

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -137,7 +137,7 @@ export class ReceiveComponent implements OnInit {
 
     this.amountFiat = fiatAmount.toString();
     this.changeQRAmount(rawAmount.toFixed());
-    this.validateFiatAmount()
+    this.validateFiatAmount();
   }
 
   async fiatAmountChange() {
@@ -153,7 +153,7 @@ export class ReceiveComponent implements OnInit {
 
     this.amountNano = nanoAmount.toFixed();
     this.changeQRAmount(rawRounded.toFixed());
-    this.validateNanoAmount()
+    this.validateNanoAmount();
   }
 
   validateNanoAmount() {

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -137,6 +137,7 @@ export class ReceiveComponent implements OnInit {
 
     this.amountFiat = fiatAmount.toString();
     this.changeQRAmount(rawAmount.toFixed());
+    this.validateFiatAmount()
   }
 
   async fiatAmountChange() {
@@ -152,6 +153,7 @@ export class ReceiveComponent implements OnInit {
 
     this.amountNano = nanoAmount.toFixed();
     this.changeQRAmount(rawRounded.toFixed());
+    this.validateNanoAmount()
   }
 
   validateNanoAmount() {

--- a/src/app/components/send/send.component.css
+++ b/src/app/components/send/send.component.css
@@ -54,7 +54,8 @@
 }
 
 .icon-nano-logo {
-  margin: 11px 6px;
+  margin: 13px 11px;
+  width: 32px;
   background-color: currentcolor;
   -webkit-mask-image: url('assets/img/nano-mark-simple.svg');
   mask-image: url('assets/img/nano-mark-simple.svg');

--- a/src/app/components/send/send.component.css
+++ b/src/app/components/send/send.component.css
@@ -52,3 +52,10 @@
 .send-types-tab-active {
   border-color: transparent;
 }
+
+.icon-nano-logo {
+  margin: 11px 6px;
+  background-color: currentcolor;
+  -webkit-mask-image: url('assets/img/nano-mark-simple.svg');
+  mask-image: url('assets/img/nano-mark-simple.svg');
+}

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -73,7 +73,8 @@
                       <div class="uk-width-1-1">
                         <div class="uk-inline uk-width-1-1">
                           <a class="uk-form-icon uk-form-icon-flip form-icon-btn" (click)="setMaxAmount()" style="padding-right: 7px;" uk-tooltip title="Set Maximum Amount">Max</a>
-                          <input [(ngModel)]="amount" [ngClass]="{ 'uk-form-danger': amountStatus === 0 }" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="text" placeholder="Amount of {{ selectedAmount.name }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}" maxlength="40">
+                          <label class="uk-form-icon uk-link-reset uk-link-muted icon-nano-logo" for="form-horizontal-amount"></label>
+                          <input [(ngModel)]="amount" [ngClass]="{ 'uk-form-danger': amountStatus === 0 }" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="text" placeholder="Amount of {{ selectedAmount.name }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}" maxlength="40">
                         </div>
 
                       </div>

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -74,7 +74,7 @@
                         <div class="uk-inline uk-width-1-1">
                           <a class="uk-form-icon uk-form-icon-flip form-icon-btn" (click)="setMaxAmount()" style="padding-right: 7px;" uk-tooltip title="Set Maximum Amount">Max</a>
                           <label class="uk-form-icon uk-link-reset uk-link-muted icon-nano-logo" for="form-horizontal-amount"></label>
-                          <input [(ngModel)]="amount" [ngClass]="{ 'uk-form-danger': amountStatus === 0 }" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="number" placeholder="Amount of {{ selectedAmount.name }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}" maxlength="40">
+                          <input [(ngModel)]="amount" [ngClass]="{ 'uk-form-danger': amountStatus === 0 }" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="number" step="any" placeholder="Amount of {{ selectedAmount.name }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}" maxlength="40">
                         </div>
 
                       </div>
@@ -86,7 +86,7 @@
                       <div class="uk-width-1-1" style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
                         <div class="uk-width-1-1 uk-inline">
                           <a class="uk-form-icon uk-link-reset uk-link-muted fiat-currency-ticker" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
-                          <input [(ngModel)]="amountFiat" (keyup)="syncNanoPrice()" (change)="syncNanoPrice()" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" placeholder="Amount of {{ settings.settings.displayCurrency }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}">
+                          <input [(ngModel)]="amountFiat" (keyup)="syncNanoPrice()" (change)="syncNanoPrice()" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" step="any" placeholder="Amount of {{ settings.settings.displayCurrency }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}">
                         </div>
                       </div>
 

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -74,7 +74,7 @@
                         <div class="uk-inline uk-width-1-1">
                           <a class="uk-form-icon uk-form-icon-flip form-icon-btn" (click)="setMaxAmount()" style="padding-right: 7px;" uk-tooltip title="Set Maximum Amount">Max</a>
                           <label class="uk-form-icon uk-link-reset uk-link-muted icon-nano-logo" for="form-horizontal-amount"></label>
-                          <input [(ngModel)]="amount" [ngClass]="{ 'uk-form-danger': amountStatus === 0 }" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="number" placeholder="Amount of {{ selectedAmount.name }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}" maxlength="40">
+                          <input [(ngModel)]="amount" [ngClass]="{ 'uk-form-danger': amountStatus === 0 }" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="number" placeholder="Amount of {{ selectedAmount.name }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}" maxlength="40">
                         </div>
 
                       </div>
@@ -85,8 +85,8 @@
 
                       <div class="uk-width-1-1" style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
                         <div class="uk-width-1-1 uk-inline">
-                          <a class="uk-form-icon uk-link-reset uk-link-muted" style="padding-left: 7px;" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
-                          <input [(ngModel)]="amountFiat" (keyup)="syncNanoPrice()" (change)="syncNanoPrice()" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" placeholder="Amount of {{ settings.settings.displayCurrency }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}">
+                          <a class="uk-form-icon uk-link-reset uk-link-muted fiat-currency-ticker" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
+                          <input [(ngModel)]="amountFiat" (keyup)="syncNanoPrice()" (change)="syncNanoPrice()" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" placeholder="Amount of {{ settings.settings.displayCurrency }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}">
                         </div>
                       </div>
 

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -74,7 +74,7 @@
                         <div class="uk-inline uk-width-1-1">
                           <a class="uk-form-icon uk-form-icon-flip form-icon-btn" (click)="setMaxAmount()" style="padding-right: 7px;" uk-tooltip title="Set Maximum Amount">Max</a>
                           <label class="uk-form-icon uk-link-reset uk-link-muted icon-nano-logo" for="form-horizontal-amount"></label>
-                          <input [(ngModel)]="amount" [ngClass]="{ 'uk-form-danger': amountStatus === 0 }" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="text" placeholder="Amount of {{ selectedAmount.name }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}" maxlength="40">
+                          <input [(ngModel)]="amount" [ngClass]="{ 'uk-form-danger': amountStatus === 0 }" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="number" placeholder="Amount of {{ selectedAmount.name }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}" maxlength="40">
                         </div>
 
                       </div>
@@ -86,7 +86,7 @@
                       <div class="uk-width-1-1" style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
                         <div class="uk-width-1-1 uk-inline">
                           <a class="uk-form-icon uk-link-reset uk-link-muted" style="padding-left: 7px;" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
-                          <input [(ngModel)]="amountFiat" (keyup)="syncNanoPrice()" (change)="syncNanoPrice()" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text-fiat" type="text" placeholder="Amount of {{ settings.settings.displayCurrency }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}">
+                          <input [(ngModel)]="amountFiat" (keyup)="syncNanoPrice()" (change)="syncNanoPrice()" style="padding-left: 50px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" placeholder="Amount of {{ settings.settings.displayCurrency }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}">
                         </div>
                       </div>
 

--- a/src/assets/img/nano-mark-simple.svg
+++ b/src/assets/img/nano-mark-simple.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="nano-mark.svg"
+   xml:space="preserve"
+   style="enable-background:new 0 0 1770.2 780.1;"
+   viewBox="0 0 1770.2 780.1"
+   y="0px"
+   x="0px"
+   id="Layer_1"
+   version="1.1"><metadata
+   id="metadata17"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs15"><linearGradient
+     id="linearGradient846"
+     inkscape:collect="always"><stop
+       id="stop842"
+       offset="0"
+       style="stop-color:#6ea6e8;stop-opacity:0" /><stop
+       id="stop844"
+       offset="1"
+       style="stop-color:#6ea6e8;stop-opacity:1" /></linearGradient><linearGradient
+     gradientUnits="userSpaceOnUse"
+     y2="392.90436"
+     x2="1228.0087"
+     y1="392.90436"
+     x1="273.53915"
+     id="linearGradient848"
+     xlink:href="#linearGradient846"
+     inkscape:collect="always" /></defs><sodipodi:namedview
+   inkscape:current-layer="Layer_1"
+   inkscape:window-maximized="1"
+   inkscape:window-y="-8"
+   inkscape:window-x="-8"
+   inkscape:cy="390.04999"
+   inkscape:cx="885.09998"
+   inkscape:zoom="0.68862277"
+   showgrid="false"
+   id="namedview13"
+   inkscape:window-height="1017"
+   inkscape:window-width="1920"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0"
+   guidetolerance="10"
+   gridtolerance="10"
+   objecttolerance="10"
+   borderopacity="1"
+   bordercolor="#666666"
+   pagecolor="#ffffff" />
+<style
+   id="style2"
+   type="text/css">
+	.st0{fill:#4A90E2;}
+	.st1{fill:#000034;}
+	.st2{fill:#FFFFFF;}
+</style>
+<g
+   style="fill-opacity:1;"
+   id="g10">
+	<path
+   style="fill-opacity:1;"
+   id="path4"
+   d="M985.7,390c0,55.6-45.1,100.6-100.6,100.6S784.4,445.6,784.4,390c0-75.5-25.2-100.6-100.6-100.6   S583.2,314.6,583.2,390c0,55.6-45.1,100.6-100.6,100.6S381.9,445.6,381.9,390c0-55.6,45.1-100.6,100.6-100.6   c75.5,0,100.6-25.2,100.6-100.6c0-55.6,45.1-100.6,100.6-100.6s100.6,45.1,100.6,100.6c0,75.5,25.2,100.6,100.6,100.6   C940.7,289.4,985.7,334.5,985.7,390z"
+   class="st0" />
+	<circle
+   style="fill-opacity:1;"
+   id="circle6"
+   r="100.6"
+   cy="591.3"
+   cx="281.2"
+   class="st0" />
+	<path
+   style="fill-opacity:1;"
+   id="path8"
+   d="M1589.6,188.7c0,55.6-45.1,100.6-100.6,100.6c-75.5,0-100.6,25.2-100.6,100.6c0,55.6-45.1,100.6-100.6,100.6   c-75.5,0-100.6,25.2-100.6,100.6c0,55.6-45.1,100.6-100.6,100.6c-55.6,0-100.6-45.1-100.6-100.6c0-55.6,45.1-100.6,100.6-100.6   c75.5,0,100.6-25.2,100.6-100.6c0-55.6,45.1-100.6,100.6-100.6c75.5,0,100.6-25.2,100.6-100.6c0-55.6,45.1-100.6,100.6-100.6   C1544.5,88.1,1589.6,133.2,1589.6,188.7z"
+   class="st0" />
+</g>
+</svg>

--- a/src/less/components/dark-mode.less
+++ b/src/less/components/dark-mode.less
@@ -314,6 +314,10 @@
 		border-color: @dark-mode-background-3;
 	}
 
+	.uk-input:disabled::placeholder, .uk-select:disabled::placeholder, .uk-textarea:disabled::placeholder {
+		color: #3E3E48 !important;
+	}
+
 	// General (UIkit Modal)
 	.uk-modal-dialog {
 		background: @dark-mode-background-4;
@@ -405,6 +409,11 @@
 	.send-types-tab-active, .send-types-tab-active:focus, .send-types-tab-active:hover {
 		color: @dark-mode-text-5 !important;
 		background: @dark-mode-background-4;
+	}
+
+	// Receive page
+	.qr-placeholder {
+		background: @dark-mode-background-2 !important;
 	}
 
 	// Representatives page

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -102,6 +102,16 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
 	border-bottom: 1px solid #dce9f9;
 }
 
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type=number] {
+  -moz-appearance: textfield;
+}
+
 @mobile-top-bar-height: 50px;
 
 .mobile-top-bar {

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -106,6 +106,15 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
 	color: #81809f;
 }
 
+a.fiat-currency-ticker {
+	font-family: 'Montserrat', Arial, Helvetica, sans-serif;
+	color: #81809f !important;
+	font-weight: 500;
+	padding-left: 7px;
+	height: 41px;
+	line-height: 1.1;
+}
+
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
 	-webkit-appearance: none;

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -114,6 +114,7 @@ input::-webkit-inner-spin-button {
 
 input[type=number] {
 	-moz-appearance: textfield;
+	box-shadow: none;
 }
 
 @mobile-top-bar-height: 50px;

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -320,6 +320,10 @@ input[type=number] {
 	border-color: @global-primary-background;
 }
 
+.nano-address-breakable {
+	line-break: anywhere;
+}
+
 .account-container .account-index {
 	color: #676686;
 	display: inline-block;


### PR DESCRIPTION
This PR adds a fiat field to the receive screen so both nano and fiat amounts can be entered, making Nault more useful as a POS device. The fields are now also validated.

It also tweaks the UI to be in line with the other pages like the send page. The QR code is bigger and displays an animation on successful payment that makes it easy for both the merchant and the customer to see that payment was successful. This animation is **only** shown if the amount is the same or above specified. So if the customer were to lower the amount in their wallet before sending it will not be shown.

![image](https://user-images.githubusercontent.com/1097444/108627317-3d096480-7455-11eb-9376-15b5d271b417.png)
[Old screenshot for comparison](https://imgur.com/HlKqJ7T)


https://user-images.githubusercontent.com/1097444/108627947-595ad080-7458-11eb-8a7c-9c17186cb85b.mp4



