### PR TITLE
Fix Ubuntu 20 build

### DIFF
--- a/.github/workflows/electron_hash.yml
+++ b/.github/workflows/electron_hash.yml
@@ -71,7 +71,6 @@ jobs:
           sudo apt-get install build-essential git -y
           sudo apt-get install libudev-dev -y
           sudo apt-get install libusb-1.0-0-dev -y
-          sudo apt-get install gcc-4.8 g++-4.8 -y
 
       - name: Install and Build Desktop App
         run: |

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -24,7 +24,6 @@ jobs:
           sudo apt-get install build-essential git -y
           sudo apt-get install libudev-dev -y
           sudo apt-get install libusb-1.0-0-dev -y
-          sudo apt-get install gcc-4.8 g++-4.8 -y
 
       - name: Install and Build
         run: |


### PR DESCRIPTION
The runner `ubuntu-latest` uses now Ubuntu 20 instead of Ubuntu 18: https://github.com/actions/virtual-environments/issues/1816

With that change the package `gcc-4.8` is now gone, but `gcc` is available via `build-essentials` which is already included.