### PR TITLE
Make deeplinks open the send tab automatically on desktop

### DIFF
--- a/desktop-app/src/desktop-app.ts
+++ b/desktop-app/src/desktop-app.ts
@@ -165,7 +165,7 @@ if (process.platform === 'darwin') {
 // Initialize Ledger device detection
 initialize();
 
-let mainWindow;
+let mainWindow: BrowserWindow;
 
 function createWindow () {
   // Get window state
@@ -240,7 +240,9 @@ if (!appLock) {
 
     // on windows, handle deep links on launch
     if (process.platform === 'win32') {
-      handleDeeplink(process.argv.find(s => s.startsWith('nano:')));
+      const deeplink = process.argv.find(s => s.startsWith('nano:'));
+
+      if (deeplink) handleDeeplink(deeplink);
     }
 
     // Check for any updates on GitHub
@@ -253,7 +255,9 @@ if (!appLock) {
 
       // Detect on windows when the application has been loaded using a nano: link, send it to the wallet to load
       if (process.platform === 'win32') {
-        handleDeeplink(argv.find(s => s.startsWith('nano:')));
+        const deeplink = argv.find(s => s.startsWith('nano:'));
+
+        if (deeplink) handleDeeplink(deeplink);
       }
 
       if (mainWindow.isMinimized()) {

--- a/desktop-app/src/desktop-app.ts
+++ b/desktop-app/src/desktop-app.ts
@@ -228,7 +228,7 @@ function sendStatusToWindow(progressObj) {
   mainWindow.setTitle(`Nault - ${autoUpdater.currentVersion} - Downloading Update: ${Math.round(progressObj.percent)} %`);
 }
 
-
+// run only one app
 const appLock = app.requestSingleInstanceLock();
 
 if (!appLock) {
@@ -238,6 +238,7 @@ if (!appLock) {
     // Once the app is ready, launch the wallet window
     createWindow();
 
+    // on windows, handle deep links on launch
     if (process.platform === 'win32') {
       handleDeeplink(process.argv.slice(-1)[0]);
     }
@@ -250,8 +251,6 @@ if (!appLock) {
   app.on('second-instance', (event, argv, workingDirectory) => {
     if (mainWindow) {
 
-      console.log(argv);
-
       // Detect on windows when the application has been loaded using a nano: link, send it to the wallet to load
       if (process.platform === 'win32') {
         handleDeeplink(argv.slice(-1)[0]);
@@ -260,7 +259,6 @@ if (!appLock) {
       if (mainWindow.isMinimized()) {
         mainWindow.restore();
       }
-
       mainWindow.focus();
     }
   });
@@ -293,6 +291,7 @@ if (!appLock) {
     }
   });
 }
+
 function checkForUpdates() {
   autoUpdater.checkForUpdates();
 }
@@ -427,10 +426,10 @@ function loadExternal(externalurl: string) {
 }
 
 let protocolReady = false;
-
 function handleDeeplink(deeplink: string) {
   if (!deeplink) return;
 
+  // need angular to attach the event handler before we can call it
   if (protocolReady) {
     mainWindow.webContents.executeJavaScript(`window.dispatchEvent(new CustomEvent('protocol-load', { detail: '${deeplink}' }))`);
   } else {

--- a/desktop-app/src/desktop-app.ts
+++ b/desktop-app/src/desktop-app.ts
@@ -240,7 +240,7 @@ if (!appLock) {
 
     // on windows, handle deep links on launch
     if (process.platform === 'win32') {
-      handleDeeplink(process.argv.slice(-1)[0]);
+      handleDeeplink(process.argv.find(s => s.startsWith('nano:')));
     }
 
     // Check for any updates on GitHub
@@ -253,7 +253,7 @@ if (!appLock) {
 
       // Detect on windows when the application has been loaded using a nano: link, send it to the wallet to load
       if (process.platform === 'win32') {
-        handleDeeplink(argv.slice(-1)[0]);
+        handleDeeplink(argv.find(s => s.startsWith('nano:')));
       }
 
       if (mainWindow.isMinimized()) {
@@ -426,8 +426,6 @@ function loadExternal(externalurl: string) {
 }
 
 function handleDeeplink(deeplink: string) {
-  if (!deeplink) return;
-
   ipcMain.once('deeplink-ready', (e) => {
     e.reply('deeplink-reply', deeplink);
   })

--- a/desktop-app/src/desktop-app.ts
+++ b/desktop-app/src/desktop-app.ts
@@ -425,17 +425,10 @@ function loadExternal(externalurl: string) {
   shell.openExternal(externalurl);
 }
 
-let protocolReady = false;
 function handleDeeplink(deeplink: string) {
   if (!deeplink) return;
 
-  // need angular to attach the event handler before we can call it
-  if (protocolReady) {
-    mainWindow.webContents.executeJavaScript(`window.dispatchEvent(new CustomEvent('protocol-load', { detail: '${deeplink}' }))`);
-  } else {
-    ipcMain.once('APP_CHANNEL', (event, args) => {
-      protocolReady = true;
-      if (args === 'protocol-ready') mainWindow.webContents.executeJavaScript(`window.dispatchEvent(new CustomEvent('protocol-load', { detail: '${deeplink}' }))`);
-    });
-  }
+  ipcMain.once('deeplink-ready', (e) => {
+    e.reply('deeplink-reply', deeplink);
+  })
 }

--- a/desktop-app/src/desktop-app.ts
+++ b/desktop-app/src/desktop-app.ts
@@ -240,7 +240,7 @@ if (!appLock) {
 
     // on windows, handle deep links on launch
     if (process.platform === 'win32') {
-      const deeplink = process.argv.find(s => s.startsWith('nano:'));
+      const deeplink = process.argv.find((s) => s.startsWith('nano:'));
 
       if (deeplink) handleDeeplink(deeplink);
     }
@@ -255,7 +255,7 @@ if (!appLock) {
 
       // Detect on windows when the application has been loaded using a nano: link, send it to the wallet to load
       if (process.platform === 'win32') {
-        const deeplink = argv.find(s => s.startsWith('nano:'));
+        const deeplink = argv.find((s) => s.startsWith('nano:'));
 
         if (deeplink) handleDeeplink(deeplink);
       }
@@ -429,8 +429,14 @@ function loadExternal(externalurl: string) {
   shell.openExternal(externalurl);
 }
 
+let deeplinkReady = false;
+ipcMain.once('deeplink-ready', () => deeplinkReady = true);
 function handleDeeplink(deeplink: string) {
-  ipcMain.once('deeplink-ready', (e) => {
-    e.reply('deeplink-reply', deeplink);
-  })
+  if (!deeplinkReady) {
+    ipcMain.once('deeplink-ready', (e) => {
+      mainWindow.webContents.send('deeplink', deeplink);
+    });
+  } else {
+    mainWindow.webContents.send('deeplink', deeplink);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -136,7 +136,12 @@
     "protocols": {
       "name": "nano",
       "schemes": [
-        "nano"
+        "nano",
+        "nanorep",
+        "nanoseed",
+        "nanokey",
+        "nanosign",
+        "nanoprocess"
       ],
       "role": "Viewer"
     }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,7 +11,7 @@ import {RepresentativeService} from './services/representative.service';
 import {NodeService} from './services/node.service';
 import { LedgerService, UtilService } from './services';
 import { environment } from 'environments/environment';
-const { ipcRenderer } = window.require('electron');
+const { ipcRenderer } = window.require('electron'); // import doesn't work
 
 @Component({
   selector: 'app-root',
@@ -150,6 +150,7 @@ export class AppComponent implements OnInit {
       // Soon: Load seed, automatic send page?
     });
 
+    // signal to electron that protocol-load is ready
     ipcRenderer.send('APP_CHANNEL', 'protocol-ready');
 
     // Check how long the wallet has been inactive, and lock it if it's been too long

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -140,7 +140,7 @@ export class AppComponent implements OnInit {
 
     // handle deeplinks
     this.desktop.on('deeplink-reply', (e, deeplink) => {
-      this.deeplinkService.navigate(deeplink);
+      if (!this.deeplinkService.navigate(deeplink)) this.notifications.sendWarning('This URI has an invalid address.', { length: 5000 });
       this.desktop.send('deeplink-ready');
     });
     this.desktop.send('deeplink-ready');

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,7 +9,7 @@ import {WorkPoolService} from './services/work-pool.service';
 import {Router} from '@angular/router';
 import {RepresentativeService} from './services/representative.service';
 import {NodeService} from './services/node.service';
-import { LedgerService, UtilService } from './services';
+import { DesktopService, LedgerService, UtilService } from './services';
 import { environment } from 'environments/environment';
 
 @Component({
@@ -32,6 +32,7 @@ export class AppComponent implements OnInit {
     private ledger: LedgerService,
     public price: PriceService,
     private util: UtilService,
+    private desktop: DesktopService,
     private renderer: Renderer2) {
       router.events.subscribe(() => {
         this.navExpanded = false;
@@ -149,11 +150,8 @@ export class AppComponent implements OnInit {
       // Soon: Load seed, automatic send page?
     });
 
-    // if in electron, tell electron that protocol-load is ready
-    if (navigator.userAgent.toLowerCase().indexOf(' electron/') > -1) {
-      const { ipcRenderer } = window.require('electron');
-      ipcRenderer.send('APP_CHANNEL', 'protocol-ready');
-    }
+    // tell electron that protocol-load is ready
+    this.desktop.send('APP_CHANNEL', 'protocol-ready');
 
     // Check how long the wallet has been inactive, and lock it if it's been too long
     setInterval(() => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,7 +11,6 @@ import {RepresentativeService} from './services/representative.service';
 import {NodeService} from './services/node.service';
 import { LedgerService, UtilService } from './services';
 import { environment } from 'environments/environment';
-const { ipcRenderer } = window.require('electron'); // import doesn't work
 
 @Component({
   selector: 'app-root',
@@ -151,7 +150,10 @@ export class AppComponent implements OnInit {
     });
 
     // signal to electron that protocol-load is ready
-    ipcRenderer.send('APP_CHANNEL', 'protocol-ready');
+    if (navigator.userAgent.toLowerCase().indexOf(' electron/') > -1) {
+      const { ipcRenderer } = window.require('electron');
+      ipcRenderer.send('APP_CHANNEL', 'protocol-ready');
+    }
 
     // Check how long the wallet has been inactive, and lock it if it's been too long
     setInterval(() => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -139,9 +139,8 @@ export class AppComponent implements OnInit {
     });
 
     // handle deeplinks
-    this.desktop.on('deeplink-reply', (e, deeplink) => {
+    this.desktop.on('deeplink', (e, deeplink) => {
       if (!this.deeplinkService.navigate(deeplink)) this.notifications.sendWarning('This URI has an invalid address.', { length: 5000 });
-      this.desktop.send('deeplink-ready');
     });
     this.desktop.send('deeplink-ready');
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -149,7 +149,7 @@ export class AppComponent implements OnInit {
       // Soon: Load seed, automatic send page?
     });
 
-    // signal to electron that protocol-load is ready
+    // if in electron, tell electron that protocol-load is ready
     if (navigator.userAgent.toLowerCase().indexOf(' electron/') > -1) {
       const { ipcRenderer } = window.require('electron');
       ipcRenderer.send('APP_CHANNEL', 'protocol-ready');

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -59,7 +59,7 @@ import { PasswordStrengthMeterModule } from 'angular-password-strength-meter';
 
 // QR code module
 import { ZXingScannerModule } from '@zxing/ngx-scanner';
-import { NinjaService } from './services';
+import { DeeplinkService, NinjaService } from './services';
 import { ConverterComponent } from './components/converter/converter.component';
 import { QrGeneratorComponent } from './components/qr-generator/qr-generator.component';
 
@@ -130,6 +130,7 @@ import { QrGeneratorComponent } from './components/qr-generator/qr-generator.com
     NinjaService,
     NgbActiveModal,
     QrModalService,
+    DeeplinkService,
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/components/qr-scan/qr-scan.component.ts
+++ b/src/app/components/qr-scan/qr-scan.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { BarcodeFormat } from '@zxing/library';
+import { NotificationService } from 'app/services';
 import { BehaviorSubject } from 'rxjs';
 import { DeeplinkService } from '../../services/deeplink.service';
 
@@ -32,6 +33,7 @@ export class QrScanComponent implements OnInit {
 
   constructor(
     private deeplinkService: DeeplinkService,
+    private notificationService: NotificationService,
   ) { }
 
   ngOnInit(): void { }
@@ -48,7 +50,7 @@ export class QrScanComponent implements OnInit {
   onCodeResult(resultString: string) {
     this.qrResultString = resultString;
 
-    if(!this.deeplinkService.navigate(resultString)) this.notifcationService.sendWarning('This QR code is not recognized.', { length: 5000, identifier: 'qr-not-recognized' });;
+    if(!this.deeplinkService.navigate(resultString)) this.notificationService.sendWarning('This QR code is not recognized.', { length: 5000, identifier: 'qr-not-recognized' });;
   }
 
   onDeviceSelectChange(selected: string) {

--- a/src/app/components/qr-scan/qr-scan.component.ts
+++ b/src/app/components/qr-scan/qr-scan.component.ts
@@ -1,11 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
-import { UtilService } from '../../services/util.service';
-import { NotificationService } from '../../services/notification.service';
-import { WalletService } from '../../services/wallet.service';
 import { BarcodeFormat } from '@zxing/library';
 import { BehaviorSubject } from 'rxjs';
-import { RemoteSignService } from '../../services/remote-sign.service';
+import { DeeplinkService } from '../../services/deeplink.service';
 
 @Component({
   selector: 'app-qr-scan',
@@ -13,6 +9,7 @@ import { RemoteSignService } from '../../services/remote-sign.service';
   styleUrls: ['./qr-scan.component.css']
 })
 export class QrScanComponent implements OnInit {
+  [x: string]: any;
 
   availableDevices: MediaDeviceInfo[];
   currentDevice: MediaDeviceInfo = null;
@@ -33,14 +30,8 @@ export class QrScanComponent implements OnInit {
   torchAvailable$ = new BehaviorSubject<boolean>(false);
   tryHarder = false;
 
-  hasAccounts = this.walletService.wallet.accounts.length > 0;
-
   constructor(
-    private router: Router,
-    private notifcationService: NotificationService,
-    private util: UtilService,
-    private walletService: WalletService,
-    private remoteSignService: RemoteSignService,
+    private deeplinkService: DeeplinkService,
   ) { }
 
   ngOnInit(): void { }
@@ -57,81 +48,7 @@ export class QrScanComponent implements OnInit {
   onCodeResult(resultString: string) {
     this.qrResultString = resultString;
 
-    const nano_scheme = /^(nano|nanorep|nanoseed|nanokey|nanosign|nanoprocess|https):.+$/g;
-
-    if (this.util.account.isValidAccount(resultString)) {
-      // Got address, routing to send...
-      this.router.navigate(['send'], {queryParams: {to: resultString}});
-
-    } else if (this.util.nano.isValidSeed(resultString)) {
-      // Seed
-      this.handleSeed(resultString);
-
-    } else if (nano_scheme.test(resultString)) {
-      // This is a valid Nano scheme URI
-      const url = new URL(resultString);
-
-      // check if QR contains a full URL path
-      if (url.protocol === 'https:') {
-        if (url.pathname === '/import-wallet' && url.hash.slice(1).length) {
-          // wallet import
-          this.router.navigate(['import-wallet'], { queryParams: {hostname: url.hostname}, fragment: url.hash.slice(1)});
-        } else if (url.pathname === '/import-address-book' && url.hash.slice(1).length) {
-          // address book import
-          this.router.navigate(['import-address-book'], { queryParams: {hostname: url.hostname}, fragment: url.hash.slice(1)});
-        }
-      } else if (url.protocol === 'nano:' && this.util.account.isValidAccount(url.pathname)) {
-        // Got address, routing to send...
-        const amount = url.searchParams.get('amount');
-        this.router.navigate(['send'], { queryParams: {
-          to: url.pathname,
-          amount: amount ? this.util.nano.rawToMnano(amount) : null
-        }});
-
-      } else if (url.protocol === 'nanorep:' && this.util.account.isValidAccount(url.pathname)) {
-        // Representative change
-        this.router.navigate(['representatives'], { queryParams: {
-          hideOverview: true,
-          accounts: 'all',
-          representative: url.pathname
-        }});
-
-      } else if (url.protocol === 'nanoseed:' && this.util.nano.isValidSeed(url.pathname)) {
-        // Seed
-        this.handleSeed(url.pathname);
-      } else if (url.protocol === 'nanokey:' && this.util.nano.isValidHash(url.pathname)) {
-        // Private key
-        this.handlePrivateKey(url.pathname);
-      } else if (url.protocol === 'nanosign:') {
-          this.remoteSignService.navigateSignBlock(url);
-
-      } else if (url.protocol === 'nanoprocess:') {
-          this.remoteSignService.navigateProcessBlock(url);
-      }
-
-    } else {
-      this.notifcationService.sendWarning('This QR code is not recognized.', { length: 5000, identifier: 'qr-not-recognized' });
-    }
-  }
-
-  handleSeed(seed) {
-    if (this.hasAccounts) {
-      // Wallet already set up, sweeping...
-      this.router.navigate(['sweeper'], { state: { seed: seed } });
-    } else {
-      // No wallet set up, new wallet...
-      this.router.navigate(['configure-wallet'], { state: { seed: seed }});
-    }
-  }
-
-  handlePrivateKey(key) {
-    if (this.hasAccounts) {
-      // Wallet already set up, sweeping...
-      this.router.navigate(['sweeper'], { state: { seed: key } });
-    } else {
-      // No wallet set up, new wallet...
-      this.router.navigate(['configure-wallet'], { state: { key: key }});
-    }
+    if(!this.deeplinkService.navigate(resultString)) this.notifcationService.sendWarning('This QR code is not recognized.', { length: 5000, identifier: 'qr-not-recognized' });;
   }
 
   onDeviceSelectChange(selected: string) {

--- a/src/app/components/qr-scan/qr-scan.component.ts
+++ b/src/app/components/qr-scan/qr-scan.component.ts
@@ -50,7 +50,9 @@ export class QrScanComponent implements OnInit {
   onCodeResult(resultString: string) {
     this.qrResultString = resultString;
 
-    if(!this.deeplinkService.navigate(resultString)) this.notificationService.sendWarning('This QR code is not recognized.', { length: 5000, identifier: 'qr-not-recognized' });;
+    if (!this.deeplinkService.navigate(resultString)) {
+      this.notificationService.sendWarning('This QR code is not recognized.', { length: 5000, identifier: 'qr-not-recognized' });
+    }
   }
 
   onDeviceSelectChange(selected: string) {

--- a/src/app/services/deeplink.service.spec.ts
+++ b/src/app/services/deeplink.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { DeeplinkService } from './deeplink.service';
+
+describe('DeeplinkService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DeeplinkService]
+    });
+  });
+
+  it('should be created', inject([DeeplinkService], (service: DeeplinkService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/services/deeplink.service.ts
+++ b/src/app/services/deeplink.service.ts
@@ -1,0 +1,99 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { UtilService } from './util.service';
+import { NotificationService } from './notification.service';
+import { WalletService } from './wallet.service';
+import { RemoteSignService } from './remote-sign.service';
+
+@Injectable()
+export class DeeplinkService {
+
+  hasAccounts = this.walletService.wallet.accounts.length > 0;
+
+  constructor(
+    private router: Router,
+    private notifcationService: NotificationService,
+    private util: UtilService,
+    private walletService: WalletService,
+    private remoteSignService: RemoteSignService,
+  ) { }
+
+  navigate(deeplink: string): boolean {
+    const nano_scheme = /^(nano|nanorep|nanoseed|nanokey|nanosign|nanoprocess|https):.+$/g;
+
+    if (this.util.account.isValidAccount(deeplink)) {
+      // Got address, routing to send...
+      this.router.navigate(['send'], {queryParams: {to: deeplink}});
+
+    } else if (this.util.nano.isValidSeed(deeplink)) {
+      // Seed
+      this.handleSeed(deeplink);
+
+    } else if (nano_scheme.test(deeplink)) {
+      // This is a valid Nano scheme URI
+      const url = new URL(deeplink);
+
+      // check if deeplink contains a full URL path
+      if (url.protocol === 'https:') {
+        if (url.pathname === '/import-wallet' && url.hash.slice(1).length) {
+          // wallet import
+          this.router.navigate(['import-wallet'], { queryParams: {hostname: url.hostname}, fragment: url.hash.slice(1)});
+        } else if (url.pathname === '/import-address-book' && url.hash.slice(1).length) {
+          // address book import
+          this.router.navigate(['import-address-book'], { queryParams: {hostname: url.hostname}, fragment: url.hash.slice(1)});
+        }
+      } else if (url.protocol === 'nano:' && this.util.account.isValidAccount(url.pathname)) {
+        // Got address, routing to send...
+        const amount = url.searchParams.get('amount');
+        this.router.navigate(['send'], { queryParams: {
+          to: url.pathname,
+          amount: amount ? this.util.nano.rawToMnano(amount) : null
+        }});
+
+      } else if (url.protocol === 'nanorep:' && this.util.account.isValidAccount(url.pathname)) {
+        // Representative change
+        this.router.navigate(['representatives'], { queryParams: {
+          hideOverview: true,
+          accounts: 'all',
+          representative: url.pathname
+        }});
+
+      } else if (url.protocol === 'nanoseed:' && this.util.nano.isValidSeed(url.pathname)) {
+        // Seed
+        this.handleSeed(url.pathname);
+      } else if (url.protocol === 'nanokey:' && this.util.nano.isValidHash(url.pathname)) {
+        // Private key
+        this.handlePrivateKey(url.pathname);
+      } else if (url.protocol === 'nanosign:') {
+          this.remoteSignService.navigateSignBlock(url);
+
+      } else if (url.protocol === 'nanoprocess:') {
+          this.remoteSignService.navigateProcessBlock(url);
+      }
+
+    } else {
+      return false;
+    }
+    return true;
+  }
+
+  handleSeed(seed) {
+    if (this.hasAccounts) {
+      // Wallet already set up, sweeping...
+      this.router.navigate(['sweeper'], { state: { seed: seed } });
+    } else {
+      // No wallet set up, new wallet...
+      this.router.navigate(['configure-wallet'], { state: { seed: seed }});
+    }
+  }
+
+  handlePrivateKey(key) {
+    if (this.hasAccounts) {
+      // Wallet already set up, sweeping...
+      this.router.navigate(['sweeper'], { state: { seed: key } });
+    } else {
+      // No wallet set up, new wallet...
+      this.router.navigate(['configure-wallet'], { state: { key: key }});
+    }
+  }
+}

--- a/src/app/services/deeplink.service.ts
+++ b/src/app/services/deeplink.service.ts
@@ -8,8 +8,6 @@ import { RemoteSignService } from './remote-sign.service';
 @Injectable()
 export class DeeplinkService {
 
-  hasAccounts = this.walletService.wallet.accounts.length > 0;
-
   constructor(
     private router: Router,
     private notifcationService: NotificationService,
@@ -77,8 +75,12 @@ export class DeeplinkService {
     return true;
   }
 
+  hasAccounts() {
+    return this.walletService.wallet.accounts.length > 0;
+  }
+
   handleSeed(seed) {
-    if (this.hasAccounts) {
+    if (this.hasAccounts()) {
       // Wallet already set up, sweeping...
       this.router.navigate(['sweeper'], { state: { seed: seed } });
     } else {
@@ -88,7 +90,7 @@ export class DeeplinkService {
   }
 
   handlePrivateKey(key) {
-    if (this.hasAccounts) {
+    if (this.hasAccounts()) {
       // Wallet already set up, sweeping...
       this.router.navigate(['sweeper'], { state: { seed: key } });
     } else {

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -15,3 +15,4 @@ export * from './wallet.service';
 export * from './websocket.service';
 export * from './work-pool.service';
 export * from './ninja.service';
+export * from './deeplink.service';


### PR DESCRIPTION
Per the title, Nault desktop opens and the send tab is autofilled with address/amount when clicking on deeplinks. Additionally, limited the Nault desktop app to only one instance so that clicking on a deeplink while Nault is already open doesn't open another instance.

I noticed that the QR scan component also has code to handle deeplinks, should this and the added deeplink-related code be moved into a deeplink service? If so, should all the protocols specified by the QR scan component also work on click? 