### PR TITLE
Various UI/UX fixes

### DIFF
--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -217,7 +217,7 @@
           <td class="date-column uk-text-middle uk-text-truncate uk-text-muted" *ngIf="(walletAccount || remoteVisible) else noActionsAvailable">
             <div class="button-container" *ngIf="walletAccount">
               <button *ngIf="!pending.loading" class="uk-button uk-button-primary uk-text-center uk-width-auto" type="button" (click)="receivePending(pending)">RECEIVE</button>
-              <button *ngIf="pending.loading" class="uk-button uk-button-secondary uk-disabled uk-button-small"><span uk-spinner="ratio: 0.5;"></span> Receiving</button>
+              <button *ngIf="pending.loading" class="uk-button uk-button-secondary uk-disabled uk-button-small nlt-icon-button"><span class="spinner" uk-spinner="ratio: 0.5;"></span> Receiving</button>
             </div>
             <div class="button-container" *ngIf="remoteVisible">
               <button class="uk-button uk-button-primary uk-text-center uk-width-auto remote-sign" type="button" (click)="generateReceive(pending.hash)">REMOTE SIGN</button>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -212,7 +212,10 @@
             <a [routerLink]="'/transaction/' + pending.hash" class="uk-link-text uk-text-small uk-text-muted uk-text-truncate block-hash" title="View Block Details" uk-tooltip>{{ pending.hash }}</a>
           </td>
           <td class="amount-column uk-text-middle uk-text-muted" [title]="('Incoming Transaction') + ( (pending.amountRaw && (pending.amountRaw > 0) ) ? ( ', +' + ( pending.amountRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )">
-            <span class="uk-text-small">Ready to receive</span><br><span class="amount-nano">{{ pending.amount | rai: 'mnano,true' | amountsplit: 0 }}{{ pending.amount | rai: 'mnano,true' | amountsplit: 1 }}</span><span class="currency-name">NANO</span>
+            <span class="uk-text-small">Ready to receive</span><br>
+            <span class="amount-integer">{{ pending.amount | rai: 'mnano,true' | amountsplit: 0 }}</span>
+            <span class="amount-fractional">{{ pending.amount | rai: 'mnano,true' | amountsplit: 1 }}</span>
+            <span class="currency-name">NANO</span>
           </td>
           <td class="date-column uk-text-middle uk-text-truncate uk-text-muted" *ngIf="(walletAccount || remoteVisible) else noActionsAvailable">
             <div class="button-container" *ngIf="walletAccount">
@@ -270,7 +273,8 @@
               <ng-container *ngIf="(history.type == 'send' || history.subtype == 'send')">
                 <span class="uk-text-small">Sent</span><br>
               </ng-container>
-              <span class="amount-nano">{{ history.amount | rai: 'mnano,true' | amountsplit: 0 }}{{ history.amount | rai: 'mnano,true' | amountsplit: 1 }}</span>
+              <span class="amount-integer">{{ history.amount | rai: 'mnano,true' | amountsplit: 0 }}</span>
+              <span class="amount-fractional">{{ history.amount | rai: 'mnano,true' | amountsplit: 1 }}</span>
               <span class="currency-name">NANO</span>
             </span>
           </td>

--- a/src/app/components/accounts/accounts.component.css
+++ b/src/app/components/accounts/accounts.component.css
@@ -46,14 +46,22 @@ th.hidden-column, td.hidden-column {
 	margin-bottom: 3px;
 }
 
-.account-amounts-column .account-amounts-primary .amount-nano {
+.account-amounts-column .account-amounts-primary .amount-integer,
+.account-amounts-column .account-amounts-primary .amount-fractional,
+.account-amounts-column .account-amounts-primary .currency-name {
 	font-family: 'Montserrat', Arial, Helvetica, sans-serif;
-	font-weight: 700;
 	font-size: 16px;
 }
 
+.account-amounts-column .account-amounts-primary .amount-integer {
+	font-weight: 700;
+}
+
+.account-amounts-column .account-amounts-primary .amount-fractional {
+	font-weight: 500;
+}
+
 .account-amounts-column .account-amounts-primary .currency-name {
-	font-family: 'Montserrat', Arial, Helvetica, sans-serif;
 	font-weight: 400;
 	margin-left: 5px;
 }
@@ -62,9 +70,9 @@ th.hidden-column, td.hidden-column {
 	display: inline-block;
 	background: #4a90e2;
 	border-radius: 20px;
-	font-size: 12px;
+	font-size: 13px;
 	padding: 2px 10px;
-	margin-right: 7px;
+	margin-right: 9px;
 	vertical-align: 1px;
 	padding-bottom: 1px;
 	text-transform: uppercase;

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -75,7 +75,8 @@
                 <div class="text-full">+{{ account.pending | rai: 'mnano,true' | amountsplit: 0 }}{{ account.pending | rai: 'mnano,true' | amountsplit: 1 }} NANO</div>
               </div>
               <span [title]="( account.balanceRaw.gt(0) ? ( '+' + ( account.balanceRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )">
-                <span class="amount-nano">{{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }}</span>
+                <span class="amount-integer">{{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}</span>
+                <span class="amount-fractional">{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }}</span>
                 <span class="currency-name">NANO</span>
               </span>
             </div>

--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -1,6 +1,12 @@
 .label-block {
     margin-left: 10px;
     margin-bottom: 10px;
+    width: unset;
+}
+
+.label-block > .label-optional {
+    margin-left: 6px;
+    font-size: 12px;
 }
 
 .nano-address-actions {
@@ -12,7 +18,8 @@
 }
 
 .span-icon {
-    margin-left: 5px;
+    margin-left: 10px;
+    flex-shrink: 0;
 }
 
 .form-account {
@@ -56,10 +63,17 @@
     margin: 0 auto;
     box-sizing: border-box;
 }
+.qr-address {
+    max-width: 280px;
+    margin: 0 auto;
+}
 @media (max-width: 959px) {
     .qr-code {
         max-width: 250px;
         max-height: 250px;
+    }
+    .qr-address {
+        max-width: 280px;
     }
 }
 .qr-placeholder {

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -19,16 +19,16 @@
             </div>
   
             <div class="uk-margin">
-              <label for="form-horizontal-amount" class="uk-form-label label-block">Amount <span class="uk-text-muted">(optional)</span></label>
+              <label for="form-horizontal-amount" class="uk-form-label label-block">Requested Amount <span class="uk-text-muted label-optional">optional</span></label>
               <div class="form-amount">
                 <div class="uk-width-1-1 uk-inline">
                   <label class="uk-form-icon uk-link-reset uk-link-muted icon-nano-logo" for="form-horizontal-amount"></label>
-                  <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" [attr.disabled]="pendingAccountModel == '0' || null" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" style="padding-left: 52px !important;" type="number" step="any" placeholder="Amount of NANO to receive" maxlength="40">
+                  <input [(ngModel)]="amountNano" [ngClass]="{ 'uk-form-danger': !validNano }" [attr.disabled]="pendingAccountModel == '0' || null" autocomplete="off" class="uk-input" id="form-horizontal-amount" (keyup)="nanoAmountChange()" (change)="nanoAmountChange()" style="padding-left: 52px !important;" type="number" step="any" placeholder="Amount of NANO" maxlength="40">
                 </div>
                 <div style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
                   <div class="uk-width-1-1 uk-inline">
                     <a class="uk-form-icon uk-link-reset uk-link-muted fiat-currency-ticker" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
-                    <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" [attr.disabled]="pendingAccountModel == '0' || null" autocomplete="off" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" step="any" placeholder="Amount of {{ settings.settings.displayCurrency }} to receive">
+                    <input [(ngModel)]="amountFiat" [ngClass]="{ 'uk-form-danger': !validFiat }" [attr.disabled]="pendingAccountModel == '0' || null" autocomplete="off" (keyup)="fiatAmountChange()" (change)="fiatAmountChange()" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" step="any" placeholder="Amount of {{ settings.settings.displayCurrency }}">
                   </div>
                 </div>
               </div>
@@ -45,7 +45,7 @@
                 <img [src]="qrCodeImage" alt="QR code">
               </div>
               <br>
-              <div class="uk-flex uk-flex-center uk-flex-middle uk-text-center">
+              <div class="uk-flex uk-flex-center uk-flex-middle uk-text-center qr-address">
                 <app-nano-account-id [accountID]="pendingAccountModel" middle="break" class="nano-address-monospace uk-width-auto" style="max-width: 90%;"></app-nano-account-id>
                 <a class="span-icon" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
               </div>

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -233,7 +233,7 @@
           </div>
           <div class="uk-card-footer">
             <button class="uk-button uk-button-primary uk-width-1-1" type="button" (click)="changeRepresentatives()" *ngIf="!changingRepresentatives">Update Representatives</button>
-            <button class="uk-button uk-button-primary uk-width-1-1 uk-disabled" type="button" *ngIf="changingRepresentatives"><span uk-spinner></span> Updating Representatives...</button>
+            <button class="uk-button uk-button-secondary uk-width-1-1 uk-disabled nlt-icon-button" type="button" *ngIf="changingRepresentatives"><span class="spinner" uk-spinner="ratio: 0.5;"></span> Updating Representatives</button>
           </div>
       </div>
     </div>

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -74,7 +74,7 @@
                         <div class="uk-inline uk-width-1-1">
                           <a class="uk-form-icon uk-form-icon-flip form-icon-btn" (click)="setMaxAmount()" style="padding-right: 7px;" uk-tooltip title="Set Maximum Amount">Max</a>
                           <label class="uk-form-icon uk-link-reset uk-link-muted icon-nano-logo" for="form-horizontal-amount"></label>
-                          <input [(ngModel)]="amount" [ngClass]="{ 'uk-form-danger': amountStatus === 0 }" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="number" step="any" placeholder="Amount of {{ selectedAmount.name }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}" maxlength="40">
+                          <input [(ngModel)]="amount" [ngClass]="{ 'uk-form-danger': amountStatus === 0 }" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text" (keyup)="syncFiatPrice()" (change)="syncFiatPrice()" type="number" step="any" placeholder="Amount of {{ selectedAmount.name }}" maxlength="40">
                         </div>
 
                       </div>
@@ -86,7 +86,7 @@
                       <div class="uk-width-1-1" style="margin-top: 10px;" *ngIf="settings.settings.displayCurrency">
                         <div class="uk-width-1-1 uk-inline">
                           <a class="uk-form-icon uk-link-reset uk-link-muted fiat-currency-ticker" uk-tooltip title="Last Price: {{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO">{{ settings.settings.displayCurrency | currencySymbol }}</a>
-                          <input [(ngModel)]="amountFiat" (keyup)="syncNanoPrice()" (change)="syncNanoPrice()" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" step="any" placeholder="Amount of {{ settings.settings.displayCurrency }} to {{ (sendDestinationType === 'own-address') ? 'transfer' : 'send' }}">
+                          <input [(ngModel)]="amountFiat" (keyup)="syncNanoPrice()" (change)="syncNanoPrice()" style="padding-left: 52px !important;" class="uk-input" id="form-horizontal-text-fiat" type="number" step="any" placeholder="Amount of {{ settings.settings.displayCurrency }}">
                         </div>
                       </div>
 
@@ -99,7 +99,13 @@
             </div>
           </div>
           <div class="uk-card-footer">
-            <button class="uk-button uk-button-primary uk-width-1-1@s uk-width-auto@m uk-float-right" type="button" (click)="sendTransaction()">{{ (sendDestinationType === 'own-address') ? 'Transfer Nano' : 'Send Nano' }}</button>
+            <button class="uk-button uk-button-primary uk-width-1-1@s uk-width-auto@m uk-float-right nlt-icon-button" type="button" (click)="sendTransaction()" *ngIf="!preparingTransaction">
+              {{ (sendDestinationType === 'own-address') ? 'Transfer Nano' : 'Send Nano' }}
+            </button>
+            <button class="uk-button uk-button-secondary uk-disabled uk-width-1-1@s uk-width-auto@m uk-float-right nlt-icon-button" type="button" *ngIf="preparingTransaction">
+              <span class="spinner" uk-spinner="ratio: 0.5;"></span>
+              Preparing transaction
+            </button>
           </div>
         </div>
       </div>
@@ -186,7 +192,7 @@
           </div>
           <div class="uk-width-1-2@s">
             <button *ngIf="!confirmingTransaction" class="uk-button uk-button-primary uk-width-1-1" (click)="confirmTransaction()">Confirm & Send</button>
-            <button *ngIf="confirmingTransaction" class="uk-button uk-button-primary uk-disabled uk-width-1-1"><span class="uk-margin-right" uk-spinner></span> Loading</button>
+            <button *ngIf="confirmingTransaction" class="uk-button uk-button-secondary uk-disabled uk-width-1-1 nlt-icon-button"><span class="spinner" uk-spinner="ratio: 0.5;"></span> Sending</button>
           </div>
         </div>
       </div>

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -52,6 +52,7 @@ export class SendComponent implements OnInit {
   toAddressBook = '';
   toAccountStatus = null;
   amountStatus = null;
+  preparingTransaction = false;
   confirmingTransaction = false;
   selAccountInit = false;
 
@@ -262,8 +263,13 @@ export class SendComponent implements OnInit {
       return this.notificationService.sendWarning(`Invalid NANO Amount`);
     }
 
+    this.preparingTransaction = true;
+
     const from = await this.nodeApi.accountInfo(this.fromAccountID);
     const to = await this.nodeApi.accountInfo(destinationID);
+
+    this.preparingTransaction = false;
+
     if (!from) {
       return this.notificationService.sendError(`From account not found`);
     }

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -102,6 +102,17 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
 	border-bottom: 1px solid #dce9f9;
 }
 
+.nlt-icon-button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	.spinner {
+		margin-right: 8px;
+		margin-top: -1px;
+	}
+}
+
 .text-half-muted {
 	color: #81809f;
 }
@@ -466,11 +477,6 @@ input[type=number] {
 
 		button {
 			white-space: nowrap;
-
-			.uk-spinner {
-				margin-right: 5px;
-				vertical-align: 2px;
-			}
 		}
 
 		.button-container + .button-container {

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -455,14 +455,20 @@ input[type=number] {
 		white-space: nowrap;
 		text-align: right;
 
-		.amount-nano {
+		.amount-integer, .amount-fractional, .currency-name {
 			font-family: 'Montserrat', Arial, Helvetica, sans-serif;
-			font-weight: 700;
 			font-size: 16px;
 		}
 
+		.amount-integer {
+			font-weight: 700;
+		}
+
+		.amount-fractional {
+			font-weight: 500;
+		}
+
 		.currency-name {
-			font-family: 'Montserrat', Arial, Helvetica, sans-serif;
 			font-weight: 400;
 			margin-left: 5px;
 		}
@@ -546,10 +552,9 @@ input[type=number] {
 		td.amount-column {
 			font-size: 12px;
 
-			.amount-nano {
+			.amount-integer, .amount-fractional {
 				font-size: 13px;
 				margin: 5px 0 -3px 0;
-				display: block;
 			}
 
 			.currency-name {


### PR DESCRIPTION
new button state on the send button, fixes UX issue with nothing happening while balances are being fetched

![image](https://user-images.githubusercontent.com/29272208/110240670-f9c6ef80-7f44-11eb-9e38-f831595f0034.png)

These spinners sometimes made the button bigger than it used to be, or kept the button colored blue. Should be fixed in this commit for "confirm send" and "change rep" buttons

\-

![image](https://user-images.githubusercontent.com/29272208/110240742-427ea880-7f45-11eb-9782-f82537a9a3f9.png)

these fields no longer say "to send"/"to transfer" at the end, didn't fit on some mobile devices and was a little redundant anyway

similarly on receive page, with a few other tweaks such as fix to address visually exceeding its column:

![2021-03-07_13-04-32](https://user-images.githubusercontent.com/29272208/110240845-bde05a00-7f45-11eb-80f0-e48cf7e2a325.gif)

\-

less bold text on the fractional part to easier tell it apart from integers:

![2021-03-07_12-57-41](https://user-images.githubusercontent.com/29272208/110240615-b8364480-7f44-11eb-9d0e-b6201264305a.gif)

![2021-03-07_12-58-29](https://user-images.githubusercontent.com/29272208/110240635-d2702280-7f44-11eb-8ee7-6349c99a3c45.gif)
