### PR TITLE
Transaction details page tweaks

### DIFF
--- a/src/app/components/transaction-details/transaction-details.component.html
+++ b/src/app/components/transaction-details/transaction-details.component.html
@@ -115,7 +115,7 @@
             </a>
           </div>
         </div>
-        <div class="uk-margin" *ngIf="transaction?.contents?.previous">
+        <div class="uk-margin" *ngIf="transaction?.contents?.previous && (blockType != 'open')">
           <label class="uk-form-label">Previous:</label>
           <div class="uk-form-controls uk-text-truncate">
             <a [routerLink]="'/transaction/' + transaction?.contents?.previous" class="uk-link-text" uk-tooltip title="View Block Details">{{ transaction?.contents?.previous }}</a>

--- a/src/app/components/transaction-details/transaction-details.component.html
+++ b/src/app/components/transaction-details/transaction-details.component.html
@@ -38,7 +38,7 @@
         <span *ngIf="amountRaw.gt(0)" style="display:block; font-size: 12px;">+{{ amountRaw.toString(10) }} raw</span>
       </div>
       <div class="uk-card uk-card-default uk-width-1-1 uk-text-center" *ngIf="(blockType == 'change')">
-        <span style="display:block; font-size: 32px;">Change Representative</span>
+        <span style="display:block; font-size: 32px;">Representative Change</span>
       </div>
       <br>
       <div uk-grid>

--- a/src/app/components/transaction-details/transaction-details.component.html
+++ b/src/app/components/transaction-details/transaction-details.component.html
@@ -28,7 +28,7 @@
     </div>
 
     <div class="uk-width-1-1" *ngIf="transaction">
-      <div class="uk-card uk-card-default uk-width-1-1 uk-text-center" *ngIf="blockType !== 'change'">
+      <div class="uk-card uk-card-default uk-width-1-1 uk-text-center" *ngIf="(blockType !== 'change') && (blockType !== '')">
         <span style="display: block; padding-top: 8px;">
           <span *ngIf="blockType == 'send'">Send</span>
           <span *ngIf="blockType == 'open'">Receive</span>
@@ -37,7 +37,7 @@
         <span style="display:block; font-size: 32px;" *ngIf="transaction?.amount">{{ transaction?.amount | rai: 'mnano,true' | amountsplit: 0 }}{{ transaction?.amount | rai: 'mnano,true' | amountsplit: 1 }} NANO</span>
         <span *ngIf="amountRaw.gt(0)" style="display:block; font-size: 12px;">+{{ amountRaw.toString(10) }} raw</span>
       </div>
-      <div class="uk-card uk-card-default uk-width-1-1 uk-text-center" *ngIf="blockType == 'change'">
+      <div class="uk-card uk-card-default uk-width-1-1 uk-text-center" *ngIf="(blockType == 'change')">
         <span style="display:block; font-size: 32px;">Change Representative</span>
       </div>
       <br>

--- a/src/app/components/transaction-details/transaction-details.component.html
+++ b/src/app/components/transaction-details/transaction-details.component.html
@@ -127,7 +127,7 @@
             <a [routerLink]="'/transaction/' + transaction?.contents?.source" class="uk-link-text" uk-tooltip title="View Block Details">{{ transaction?.contents?.source }}</a>
           </div>
         </div>
-        <div class="uk-margin" *ngIf="transaction?.contents?.link && blockType == 'receive'">
+        <div class="uk-margin" *ngIf="transaction?.contents?.link && (blockType == 'open' || blockType == 'receive')">
           <label class="uk-form-label">Link (Source):</label>
           <div class="uk-form-controls uk-text-truncate">
             <a [routerLink]="'/transaction/' + transaction?.contents?.link" class="uk-link-text" uk-tooltip title="View Block Details">{{ transaction?.contents?.link }}</a>

--- a/src/app/components/transaction-details/transaction-details.component.ts
+++ b/src/app/components/transaction-details/transaction-details.component.ts
@@ -16,7 +16,7 @@ export class TransactionDetailsComponent implements OnInit {
   routerSub = null;
   transaction: any = {};
   hashID = '';
-  blockType = 'send';
+  blockType = '';
   isStateBlock = true;
   isUnconfirmedBlock = false;
   blockHeight = -1;
@@ -59,6 +59,7 @@ export class TransactionDetailsComponent implements OnInit {
     this.blockHeight = -1;
     this.showBlockData = false;
     let legacyFromAccount = '';
+    this.blockType = '';
     this.amountRaw = new BigNumber(0);
     const hash = this.route.snapshot.params.transaction;
     this.hashID = hash;
@@ -76,9 +77,10 @@ export class TransactionDetailsComponent implements OnInit {
     this.isUnconfirmedBlock = (hashData.confirmed === 'false') ? true : false;
     this.blockHeight = hashData.height;
 
-    this.blockType = hashData.contents.type;
-    if (this.blockType === 'state') {
+    const blockType = hashData.contents.type;
+    if (blockType === 'state') {
       const isOpen = hashData.contents.previous === '0000000000000000000000000000000000000000000000000000000000000000';
+
       if (isOpen) {
         this.blockType = 'open';
       } else {
@@ -103,6 +105,7 @@ export class TransactionDetailsComponent implements OnInit {
         }
       }
     } else {
+      this.blockType = blockType;
       this.isStateBlock = false;
     }
     if (hashData.amount) {


### PR DESCRIPTION
"Open" blocks now include a sending block hash as Source (Link), similarly to "Receive" blocks

"Open" blocks no longer link to the invalid previous block (0000000000000000000000000000000000000000000000000000000000000000)

Misleading label "Change Representative" was replaced with "Representative Change"

Block type is now reset while the information is loading