### PR TITLE
Add loading indication to the account details page

### DIFF
--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -206,6 +206,13 @@
     margin-top: -1px;
 }
 
+.more-results > a {
+    display: block;
+}
+.more-results > a > .chevron {
+    margin: 0 40px -4px 40px;
+}
+
 .form-input-destination {
     max-width: 800px;
 }

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -60,15 +60,6 @@
     bottom: 3px;
 }
 
-.icon-transactions-refresh.spinner {
-    margin-left: 3px;
-    margin-right: 2px;
-}
-
-.icon-transactions-refresh.disabled {
-    cursor: default;
-}
-
 .incoming-label {
     display: inline-block;
     background: #4a90e2;

--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -60,8 +60,13 @@
     bottom: 3px;
 }
 
-.refresh-disabled {
-    color: #bbb;
+.icon-transactions-refresh.spinner {
+    margin-left: 3px;
+    margin-right: 2px;
+}
+
+.icon-transactions-refresh.disabled {
+    cursor: default;
 }
 
 .incoming-label {

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -355,7 +355,10 @@
           </tr>
           <tr *ngIf="accountHistory.length + 1 >= pageSize && pageSize <= maxPageSize">
             <td colspan="4" class="more-results">
-              <a (click)="loadMore()" class="uk-link-text">Load More Results</a>
+              <a (click)="loadMore()" class="uk-link-text">
+                Show More<br>
+                <div class="chevron chevron-down"></div>
+              </a>
             </td>
           </tr>
         </ng-template>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -185,12 +185,28 @@
     <div class="uk-width-1-1 uk-flex uk-flex-center uk-flex-middle uk-margin-small-bottom">
       <h3 class="uk-margin-remove-bottom">Transactions</h3>
       <ul class="uk-width-auto uk-iconnav uk-margin-remove-left" style="margin-top: -1px;">
-        <li><a [class]="{ 'refresh-disabled': !statsRefreshEnabled }" uk-icon="icon: refresh;" (click)="loadAccountDetails(true)" uk-tooltip title="Reload the transaction history from the network."></a></li>
+        <li>
+          <div
+            uk-spinner="ratio: 0.5;"
+            class="icon-transactions-refresh spinner"
+            *ngIf="(loadingIncomingTxList || loadingTxList || loadingAccountDetails) else notUpdatingTxList"
+          ></div>
+          <ng-template #notUpdatingTxList>
+            <a
+              class="icon-transactions-refresh"
+              [class.disabled]="!statsRefreshEnabled"
+              [class.uk-text-muted]="!statsRefreshEnabled"
+              uk-icon="icon: refresh;"
+              title="Reload transaction history from the network"
+              uk-tooltip
+              (click)="loadAccountDetails(true)"
+            ></a>
+          </ng-template>
+        </li>
       </ul>
     </div>
 
     <div class="uk-overflow-hidden">
-
 
       <table class="transactions-list uk-table uk-table-striped uk-table-small" style="margin-top: 0;">
         <thead>
@@ -202,6 +218,7 @@
         </tr>
         </thead>
         <tbody>
+
         <tr *ngFor="let pending of pendingBlocks" [class]="{ 'uk-text-muted': true, 'uk-hidden': pending.received }">
           <td class="type-column">
             <span class="type uk-text-small" uk-icon="icon: plus-circle; ratio: 1.2;"></span>
@@ -244,6 +261,11 @@
             <td class="date-column uk-text-middle uk-text-truncate uk-text-muted" *ngIf="!pending.local_timestamp">N/A</td>
             <td class="date-column uk-text-middle uk-text-truncate" *ngIf="pending.local_timestamp">{{ pending.local_timestamp * 1000 | date: 'MMM d, y HH:mm:ss' }}</td>
           </ng-template>
+        </tr>
+
+        <!-- Don't show if "Loading transactions..." is already shown -->
+        <tr *ngIf="(loadingIncomingTxList && !loadingTxList && !loadingAccountDetails)">
+          <td colspan="4" style="text-align: center;"><span class="uk-margin-right" uk-spinner></span> Loading incoming transactions...</td>
         </tr>
 
         <tr *ngFor="let history of accountHistory">
@@ -323,14 +345,20 @@
             </ng-container>
           </td>
         </tr>
-        <tr *ngIf="!accountHistory.length && !pendingBlocks.length">
-          <td colspan="4" style="text-align: center;">No account history</td>
+
+        <tr *ngIf="(loadingIncomingTxList || loadingTxList || loadingAccountDetails) else notLoadingTransactions">
+          <td colspan="4" style="text-align: center;"><span class="uk-margin-right" uk-spinner></span> Loading transactions...</td>
         </tr>
-        <tr *ngIf="accountHistory.length + 1 >= pageSize && pageSize <= maxPageSize">
-          <td colspan="4" class="more-results">
-            <a (click)="loadMore()" class="uk-link-text">Load More Results</a>
-          </td>
-        </tr>
+        <ng-template #notLoadingTransactions>
+          <tr *ngIf="!accountHistory.length && !pendingBlocks.length">
+            <td colspan="4" style="text-align: center;">No transactions</td>
+          </tr>
+          <tr *ngIf="accountHistory.length + 1 >= pageSize && pageSize <= maxPageSize">
+            <td colspan="4" class="more-results">
+              <a (click)="loadMore()" class="uk-link-text">Load More Results</a>
+            </td>
+          </tr>
+        </ng-template>
         </tbody>
       </table>
     </div>

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -279,7 +279,6 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
       let pendingBalance = '0';
       let pending;
 
-
       this.pendingBlocks = [];
       this.loadingIncomingTxList = true;
       if (this.settings.settings.minimumReceive) {

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -65,7 +65,16 @@
     <div class="uk-width-1-1 uk-flex uk-flex-center uk-flex-middle uk-margin-small-bottom">
       <h3 class="uk-margin-remove-bottom">Incoming Transactions</h3>
       <ul class="uk-width-auto uk-iconnav uk-margin-remove-left" style="margin-top: -1px;">
-        <li><a uk-icon="icon: refresh;" (click)="getPending()" uk-tooltip title="Reload incoming transactions from the network"></a></li>
+        <li>
+          <div
+            uk-spinner="ratio: 0.5;"
+            class="icon-transactions-refresh spinner"
+            *ngIf="loadingIncomingTxList else notUpdatingTxList"
+          ></div>
+          <ng-template #notUpdatingTxList>
+            <a uk-icon="icon: refresh;" class="icon-transactions-refresh" (click)="getPending()" uk-tooltip title="Reload incoming transactions from the network"></a>
+          </ng-template>
+        </li>
       </ul>
     </div>
 

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -65,7 +65,7 @@
     <div class="uk-width-1-1 uk-flex uk-flex-center uk-flex-middle uk-margin-small-bottom">
       <h3 class="uk-margin-remove-bottom">Incoming Transactions</h3>
       <ul class="uk-width-auto uk-iconnav uk-margin-remove-left" style="margin-top: -1px;">
-        <li><a uk-icon="icon: refresh;" (click)="getPending()" uk-tooltip title="Reload incoming transactions from the network."></a></li>
+        <li><a uk-icon="icon: refresh;" (click)="getPending()" uk-tooltip title="Reload incoming transactions from the network"></a></li>
       </ul>
     </div>
 

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -506,6 +506,17 @@ input[type=number] {
 }
 
 // Transactions list
+.icon-transactions-refresh {
+	&.spinner {
+		margin-left: 3px;
+		margin-right: 2px;
+	}
+
+	&.disabled {
+		cursor: default;
+	}
+}
+
 .transactions-list {
 	.type-column {
 		min-width: 25px;


### PR DESCRIPTION
(transactions are loading)

old:

![image](https://user-images.githubusercontent.com/29272208/112996477-b9314f00-915b-11eb-97e9-b6e112d65c36.png)

new:

![image](https://user-images.githubusercontent.com/29272208/112996367-a454bb80-915b-11eb-8d47-8e2a4fbf6c44.png)

fixes #320

\-

Improve style of the "show more" button and increase its interaction area

old:

![image](https://user-images.githubusercontent.com/29272208/113000598-81c4a180-915f-11eb-9021-f1bf161bd035.png)

new:

![image](https://user-images.githubusercontent.com/29272208/113000645-89844600-915f-11eb-9c34-6fa25dc6a55a.png)


\-

Fix existing timeout allowing tx list refresh not being removed
In night mode, fix manual refresh button not becoming muted when disabled
Fix pointer hand cursor when hovering on a disabled manual refresh button
Hide rep and balance while fetching data from a manual refresh
Add loading spinner to the manual refresh button on Receive page