### PR TITLE
Label own wallet accounts across the application

### DIFF
--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -297,7 +297,10 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
             amount: pending.blocks[block].amount,
             amountRaw: new BigNumber( pending.blocks[block].amount || 0 ).mod(this.nano),
             local_timestamp: pending.blocks[block].local_timestamp,
-            addressBookName: this.addressBook.getAccountName(pending.blocks[block].source) || null,
+            addressBookName: (
+                this.addressBook.getAccountName( pending.blocks[block].source )
+              || this.getAccountLabel( pending.blocks[block].source, null )
+            ),
             hash: block,
             loading: false,
             received: false,
@@ -327,6 +330,16 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     await this.getAccountHistory(this.accountID);
 
     this.loadingAccountDetails = false;
+  }
+
+  getAccountLabel(accountID, defaultLabel) {
+    const walletAccount = this.wallet.wallet.accounts.find(a => a.id === accountID);
+
+    if (walletAccount == null) {
+      return defaultLabel;
+    }
+
+    return ('Account #' + walletAccount.index);
   }
 
   ngOnDestroy() {
@@ -368,13 +381,22 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
             additionalBlocksInfo.push({ hash: h.hash, link: h.link });
           } else if (h.subtype === 'change') {
             h.link_as_account = h.representative;
-            h.addressBookName = this.addressBook.getAccountName(h.link_as_account) || null;
+            h.addressBookName = (
+                this.addressBook.getAccountName(h.link_as_account)
+              || this.getAccountLabel(h.link_as_account, null)
+            );
           } else {
             h.link_as_account = this.util.account.getPublicAccountID(this.util.hex.toUint8(h.link));
-            h.addressBookName = this.addressBook.getAccountName(h.link_as_account) || null;
+            h.addressBookName = (
+                this.addressBook.getAccountName(h.link_as_account)
+              || this.getAccountLabel(h.link_as_account, null)
+            );
           }
         } else {
-          h.addressBookName = this.addressBook.getAccountName(h.account) || null;
+          h.addressBookName = (
+              this.addressBook.getAccountName(h.account)
+            || this.getAccountLabel(h.account, null)
+          );
         }
 
         if (
@@ -404,7 +426,10 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
           const blockData = blocksInfo.blocks[block];
 
           accountHistoryBlock.link_as_account = blockData.block_account;
-          accountHistoryBlock.addressBookName = this.addressBook.getAccountName(blockData.block_account) || null;
+          accountHistoryBlock.addressBookName = (
+              this.addressBook.getAccountName(blockData.block_account)
+            || this.getAccountLabel(blockData.block_account, null)
+          );
         }
       }
 
@@ -560,7 +585,10 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     // Remove spaces from the account id
     this.toAccountID = this.toAccountID.replace(/ /g, '');
 
-    this.addressBookMatch = this.addressBook.getAccountName(this.toAccountID);
+    this.addressBookMatch = (
+        this.addressBook.getAccountName(this.toAccountID)
+      || this.getAccountLabel(this.toAccountID, null)
+    );
 
     // const accountInfo = await this.walletService.walletApi.accountInfo(this.toAccountID);
     this.toAccountStatus = null;

--- a/src/app/components/address-book/address-book.component.ts
+++ b/src/app/components/address-book/address-book.component.ts
@@ -72,7 +72,13 @@ export class AddressBookComponent implements OnInit, AfterViewInit {
   }
 
   async saveNewAddress() {
-    if (!this.newAddressAccount || !this.newAddressName) return this.notificationService.sendError(`Account and name are required`);
+    if (!this.newAddressAccount || !this.newAddressName) {
+      return this.notificationService.sendError(`Account and name are required`);
+    }
+
+    if ( /^Account #\d+$/g.test(this.newAddressName) === true ) {
+      return this.notificationService.sendError(`This name is reserved for wallet accounts without a label`);
+    }
 
     this.newAddressAccount = this.newAddressAccount.replace(/ /g, ''); // Remove spaces
 

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -228,7 +228,9 @@
         <div class="uk-text-right@s nlt-button-group">
           <button (click)="activePanel = 'send'" class="uk-button uk-button-danger uk-width-1-1@s uk-width-auto@m">Cancel</button>
           <button *ngIf="!confirmingTransaction" class="uk-button uk-button-primary uk-width-1-1@s uk-width-auto@m" (click)="confirmTransaction()">Confirm & Send</button>
-          <button *ngIf="confirmingTransaction" class="uk-button uk-button-secondary uk-disabled nlt-icon-button uk-width-1-1@s uk-width-auto@m"><span class="spinner" uk-spinner="ratio: 0.5;"></span> Sending</button>
+          <button *ngIf="confirmingTransaction" class="uk-button uk-button-secondary uk-disabled nlt-icon-button uk-width-1-1@s uk-width-auto@m"
+            style="display: inline-flex;"
+          ><span class="spinner" uk-spinner="ratio: 0.5;"></span> Sending</button>
         </div>
       </div>
     </div>

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -202,7 +202,11 @@ export class SendComponent implements OnInit {
     // Remove spaces from the account id
     this.toAccountID = this.toAccountID.replace(/ /g, '');
 
-    this.addressBookMatch = this.addressBookService.getAccountName(this.toAccountID);
+    this.addressBookMatch = (
+        this.addressBookService.getAccountName(this.toAccountID)
+      || this.getAccountLabel(this.toAccountID, null)
+    );
+
     if (!this.addressBookMatch && this.toAccountID === environment.donationAddress) {
       this.addressBookMatch = 'Nault Donations';
     }
@@ -222,6 +226,16 @@ export class SendComponent implements OnInit {
     } else {
       this.toAccountStatus = 0;
     }
+  }
+
+  getAccountLabel(accountID, defaultLabel) {
+    const walletAccount = this.walletService.wallet.accounts.find(a => a.id === accountID);
+
+    if (walletAccount == null) {
+      return defaultLabel;
+    }
+
+    return ('Account #' + walletAccount.index);
   }
 
   validateAmount() {
@@ -303,9 +317,17 @@ export class SendComponent implements OnInit {
     // Determine fiat value of the amount
     this.amountFiat = this.util.nano.rawToMnano(rawAmount).times(this.price.price.lastPrice).toNumber();
 
+    this.fromAddressBook = (
+        this.addressBookService.getAccountName(this.fromAccountID)
+      || this.getAccountLabel(this.fromAccountID, 'Account')
+    );
+
+    this.toAddressBook = (
+        this.addressBookService.getAccountName(destinationID)
+      || this.getAccountLabel(destinationID, null)
+    );
+
     // Start precomputing the work...
-    this.fromAddressBook = this.addressBookService.getAccountName(this.fromAccountID);
-    this.toAddressBook = this.addressBookService.getAccountName(destinationID);
     this.workPool.addWorkToCache(this.fromAccount.frontier, 1);
 
     this.activePanel = 'confirm';

--- a/src/app/components/transaction-details/transaction-details.component.ts
+++ b/src/app/components/transaction-details/transaction-details.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import {ActivatedRoute, ChildActivationEnd, Router} from '@angular/router';
+import {WalletService} from '../../services/wallet.service';
 import {ApiService} from '../../services/api.service';
 import {NotificationService} from '../../services/notification.service';
 import {AppSettingsService} from '../../services/app-settings.service';
@@ -34,6 +35,7 @@ export class TransactionDetailsComponent implements OnInit {
   amountRaw = new BigNumber(0);
 
   constructor(
+    private walletService: WalletService,
     private route: ActivatedRoute,
     private router: Router,
     private addressBook: AddressBookService,
@@ -149,10 +151,27 @@ export class TransactionDetailsComponent implements OnInit {
     this.toAccountID = toAccount;
     this.fromAccountID = fromAccount;
 
-    this.fromAddressBook = this.addressBook.getAccountName(fromAccount);
-    this.toAddressBook = this.addressBook.getAccountName(toAccount);
+    this.fromAddressBook = (
+        this.addressBook.getAccountName(fromAccount)
+      || this.getAccountLabel(fromAccount, null)
+    );
+
+    this.toAddressBook = (
+        this.addressBook.getAccountName(toAccount)
+      || this.getAccountLabel(toAccount, null)
+    );
 
     this.loadingBlock = false;
+  }
+
+  getAccountLabel(accountID, defaultLabel) {
+    const walletAccount = this.walletService.wallet.accounts.find(a => a.id === accountID);
+
+    if (walletAccount == null) {
+      return defaultLabel;
+    }
+
+    return ('Account #' + walletAccount.index);
   }
 
   getBalanceFromHex(balance) {

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -652,10 +652,6 @@ input[type=number] {
 	}
 
 	.account-column {
-		.account-label {
-			margin-bottom: 6px;
-		}
-
 		.nano-identicon {
 			display: inline-block;
 			width: 27px;
@@ -669,7 +665,7 @@ input[type=number] {
 		}
 
 		.account-label-placeholder {
-			height: 32px;
+			height: 33px;
 			width: 1px;
 			display: inline-block;
 			vertical-align: -14px;
@@ -677,7 +673,7 @@ input[type=number] {
 
 		.nano-address-clickable {
 			flex-shrink: 0;
-			margin-top: 2px;
+			margin-top: 3px;
 		}
 
 		.block-hash {


### PR DESCRIPTION
own wallet accounts are now labeled across practically all pages as "Account #\<Number\>", which fixes #319

tx list:

![image](https://user-images.githubusercontent.com/29272208/113209267-5bd3f580-9262-11eb-848d-c1655e0a85d3.png)

block details:

![image](https://user-images.githubusercontent.com/29272208/113209390-8a51d080-9262-11eb-8884-4bee1a20e363.png)

send form:

![image](https://user-images.githubusercontent.com/29272208/113209348-7ad28780-9262-11eb-91a7-f3af7979b962.png)

send confirmation:

![image](https://user-images.githubusercontent.com/29272208/113209318-6e4e2f00-9262-11eb-8a78-59eebe866624.png)


it is no longer possible to add an address book entry with the format "Account #\<Number\>" or change an existing entry to that format

this PR includes a minor fix for account label spacing and a fix for "Sending" button not staying inline after my last PR