### PR TITLE
Correct backup of a private-key-wallet

### DIFF
--- a/src/app/components/configure-wallet/configure-wallet.component.ts
+++ b/src/app/components/configure-wallet/configure-wallet.component.ts
@@ -376,7 +376,8 @@ export class ConfigureWalletComponent implements OnInit {
       const fileData = event.target['result'] as string;
       try {
         const importData = JSON.parse(fileData);
-        if (!importData.seed || (!importData.hasOwnProperty('accountsIndex') && !importData.hasOwnProperty('indexes'))) {
+        if ((!importData.seed && !importData.privateKey && !importData.expandedKey) ||
+        (!importData.hasOwnProperty('accountsIndex') && !importData.hasOwnProperty('indexes'))) {
           return this.notifications.sendError(`Bad import data `);
         }
 

--- a/src/app/components/manage-wallet/manage-wallet.component.html
+++ b/src/app/components/manage-wallet/manage-wallet.component.html
@@ -30,13 +30,20 @@
         <h3 class="uk-card-title">Backup Wallet</h3>
       </div>
       <div class="uk-card-body">
-        <p *ngIf="wallet.locked">
+        <p *ngIf="wallet.locked && wallet.type === 'seed'">
           <span uk-icon="icon: lock;"></span> Unlock wallet to access the seed/mnemonic.
         </p>
-        <p *ngIf="!wallet.locked">
-          To backup your wallet mnemonic phrase, <a title="Copy Mnemonic To Clipboard" ngxClipboard [cbContent]="seedMnemonic()" (cbOnSuccess)="notifications.sendSuccess('Wallet mnemonic copied to clipboard!')" uk-tooltip>click here</a> to copy it to your clipboard.<br>
-          <br>
+        <p *ngIf="wallet.locked && (wallet.type === 'privateKey' || wallet.type === 'expandedKey')">
+          <span uk-icon="icon: lock;"></span> Unlock wallet to access the private key.
+        </p>
+        <p *ngIf="!wallet.locked && wallet.type === 'seed'">
+          To backup your wallet mnemonic phrase, <a title="Copy Mnemonic To Clipboard" ngxClipboard [cbContent]="seedMnemonic()" (cbOnSuccess)="notifications.sendSuccess('Wallet mnemonic copied to clipboard!')" uk-tooltip>click here</a> to copy it to your clipboard.
+        </p>
+        <p *ngIf="!wallet.locked && wallet.type === 'seed'">
           To backup your wallet seed, <a title="Copy Seed To Clipboard" ngxClipboard [cbContent]="wallet.seed" (cbOnSuccess)="notifications.sendSuccess('Wallet seed copied to clipboard!')" uk-tooltip>click here</a> to copy it to your clipboard.<br>
+        </p>
+        <p *ngIf="!wallet.locked && (wallet.type === 'privateKey' || wallet.type === 'expandedKey')">
+          To backup your private key, <a title="Copy Private Key To Clipboard" ngxClipboard [cbContent]="wallet.seed" (cbOnSuccess)="notifications.sendSuccess('Private Key copied to clipboard!')" uk-tooltip>click here</a> to copy it to your clipboard.<br>
         </p>
       </div>
     </div>


### PR DESCRIPTION
**Problems before this update**
When importing a wallet as a private key or expanded private key
- Backup possible of an invalid mnemonic (based on inexisting seed)
- Bad name of backup (seed instead of private key)
- Exported wallet file is treated as a seed when imported again, resulting in wrong account. Nault can't know which wallet type.

**Fixes with this PR**
- Removes invalid mnemonic
- Correct naming of backup (private key)
- Added additional wallet types for backup file (privateKey/expandedKey)
- Handle import of new backup file format. If priv key or expanded key, treat it as such

**Notes**
- Previously exported backup files (with a seed wallet) are unaffected
- Previously exported backup files containing private key will continue to be imported as a seed and wrong account (because there is no way to differentiate them). If the user needs to recover this, they can do the import, then export the seed (which is a private key) and import that again as a private key. Now it will be treated correctly and they can save a new backup file.
- If the user has a mnemonic that was created from a private key, they can convert it using tools.nanos.cc to a seed and treat the seed as a private key to be imported into Nault
- Any backup file after this fix exported as a private key will be correctly imported

Fixes #305 

Before:
![image](https://user-images.githubusercontent.com/2406720/115771588-6fc8ce00-a3ae-11eb-8009-e0dcf38b7769.png)


After:
![image](https://user-images.githubusercontent.com/2406720/115771629-79eacc80-a3ae-11eb-8444-83b6253254ba.png)
