### PR TITLE
Allow remote signing to show even when no internet

### DIFF
--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -298,7 +298,7 @@
     <div uk-grid *ngIf="activePanel == 'error'" class="uk-animation-slide-left">
       <div class="uk-width-1-1">
         <div class="uk-card uk-card-default uk-width-1-1 uk-text-center">
-          <span style="display: block; padding-top: 8px;">The provided block info is not valid.<br/>Please refer to any error message below.<br/></span>
+          <span style="display: block; padding-top: 8px;">The provided block info is not valid or Nault got connection issues.<br/> Try set Nault in Offline Mode from the app settings if you want to be offline.<br/></span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
When remote signing an OPEN or RECEIVE block. Before this fix the app needed to be explicitly set to offline mode.
- Before it just said the block was invalid and did not load the signing page
- Now it will simply skip fetching the "from account" info (which is just user information), just as it was in offline mode

The underlying cause is if Nault does not detect Internet is gone and retries forever. Not seen on Windows but reported on Ubuntu.
Could potentially also be fixed by setting a timeout on the RPC service but much more complicated.