### PR TITLE
Transaction list layout improvements and fixes

### DIFF
--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -223,15 +223,17 @@
           <td class="type-column">
             <span class="type uk-text-small" uk-icon="icon: plus-circle; ratio: 1.2;"></span>
           </td>
-          <td class="account-column uk-text-middle uk-visible-toggle uk-text-truncate">
+          <td class="account-column uk-visible-toggle uk-text-truncate">
             <div uk-grid class="uk-flex-nowrap">
               <div class="uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
-                <a [routerLink]="'/account/' + pending.account" class="account-container uk-link-text uk-text-truncate" title="View Account Details" uk-tooltip>
-                  <app-nano-identicon scale="6" [accountID]="pending.account" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
-                  <span class="account-label-placeholder"></span><span class="account-label" *ngIf="pending.addressBookName">{{ pending.addressBookName }}</span><br>
-                  <span class="nano-address-clickable nano-address-monospace uk-text-truncate">
+                <a [routerLink]="'/account/' + pending.account" class="account-container uk-text-truncate" title="View Account Details" uk-tooltip>
+                  <div class="identicon-name-row uk-text-truncate">
+                    <app-nano-identicon scale="6" [accountID]="pending.account" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
+                    <div class="account-label uk-text-truncate" *ngIf="pending.addressBookName">{{ pending.addressBookName }}</div>
+                  </div>
+                  <div class="nano-address-clickable nano-address-monospace uk-text-truncate">
                     <app-nano-account-id [accountID]="pending.account" middle="auto"></app-nano-account-id>
-                  </span>
+                  </div>
                 </a>
               </div>
               <div class="nano-address-actions uk-width-auto uk-flex uk-flex-bottom">
@@ -242,25 +244,35 @@
             </div>
             <a [routerLink]="'/transaction/' + pending.hash" class="uk-link-text uk-text-small uk-text-muted uk-text-truncate block-hash block-hash-monospace" title="View Block Details" uk-tooltip>{{ pending.hash }}</a>
           </td>
+          <ng-template #transactionActionsOrDate>
+            <ng-container *ngIf="(walletAccount || remoteVisible) else noActionsAvailable">
+              <div class="button-container" *ngIf="walletAccount">
+                <button *ngIf="!pending.loading" class="uk-button uk-button-primary uk-text-center uk-width-auto" type="button" (click)="receivePending(pending)">RECEIVE</button>
+                <button *ngIf="pending.loading" class="uk-button uk-button-secondary uk-disabled uk-button-small nlt-icon-button nlt-icon-button-inline"><span class="spinner" uk-spinner="ratio: 0.5;"></span> Receiving</button>
+              </div>
+              <div class="button-container" *ngIf="remoteVisible">
+                <button class="uk-button uk-button-primary uk-text-center uk-width-auto remote-sign" type="button" (click)="generateReceive(pending.hash)">SIGN BLOCK</button>
+              </div>
+            </ng-container>
+            <ng-template #noActionsAvailable>
+              <span class="transaction-date" [class.uk-text-muted]="!pending.local_timestamp" [class.date-unknown]="!pending.local_timestamp">
+                <span class="date">{{ pending.local_timestamp ? ( pending.local_timestamp * 1000 | date: 'MMM d, y' ) : 'N/A' }}</span>
+                <span class="time">{{ pending.local_timestamp ? ( pending.local_timestamp * 1000 | date: 'HH:mm:ss' ) : '' }}</span>
+              </span>
+            </ng-template>
+          </ng-template>
           <td class="amount-column uk-text-middle uk-text-muted" [title]="('Incoming Transaction') + ( (pending.amountRaw && (pending.amountRaw > 0) ) ? ( ', +' + ( pending.amountRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )">
             <span class="uk-text-small">Ready to receive</span><br>
             <span class="amount-integer">{{ pending.amount | rai: 'mnano,true' | amountsplit: 0 }}</span>
             <span class="amount-fractional">{{ pending.amount | rai: 'mnano,true' | amountsplit: 1 }}</span>
             <span class="currency-name">NANO</span>
-          </td>
-          <td class="date-column uk-text-middle uk-text-truncate uk-text-muted" *ngIf="(walletAccount || remoteVisible) else noActionsAvailable">
-            <div class="button-container" *ngIf="walletAccount">
-              <button *ngIf="!pending.loading" class="uk-button uk-button-primary uk-text-center uk-width-auto" type="button" (click)="receivePending(pending)">RECEIVE</button>
-              <button *ngIf="pending.loading" class="uk-button uk-button-secondary uk-disabled uk-button-small nlt-icon-button"><span class="spinner" uk-spinner="ratio: 0.5;"></span> Receiving</button>
-            </div>
-            <div class="button-container" *ngIf="remoteVisible">
-              <button class="uk-button uk-button-primary uk-text-center uk-width-auto remote-sign" type="button" (click)="generateReceive(pending.hash)">SIGN BLOCK</button>
+            <div class="compact-actions-date">
+              <ng-template [ngTemplateOutlet]="transactionActionsOrDate"></ng-template>
             </div>
           </td>
-          <ng-template #noActionsAvailable>
-            <td class="date-column uk-text-middle uk-text-truncate uk-text-muted" *ngIf="!pending.local_timestamp">N/A</td>
-            <td class="date-column uk-text-middle uk-text-truncate" *ngIf="pending.local_timestamp">{{ pending.local_timestamp * 1000 | date: 'MMM d, y HH:mm:ss' }}</td>
-          </ng-template>
+          <td class="date-column uk-text-middle uk-text-truncate">
+            <ng-template [ngTemplateOutlet]="transactionActionsOrDate"></ng-template>
+          </td>
         </tr>
 
         <!-- Don't show if "Loading transactions..." is already shown -->
@@ -277,12 +289,14 @@
           <td class="account-column uk-text-middle uk-visible-toggle uk-text-truncate">
             <div uk-grid class="uk-flex-nowrap">
               <div class="uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
-                <a [routerLink]="'/account/' + (history.link_as_account || history.account)" class="account-container uk-link-text uk-text-truncate" title="View Account Details" uk-tooltip>
-                  <app-nano-identicon scale="6" [accountID]="history.link_as_account || history.account" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
-                  <span class="account-label-placeholder"></span><span class="account-label" *ngIf="history.addressBookName">{{ history.addressBookName }}</span><br>
-                  <span class="nano-address-clickable nano-address-monospace uk-text-truncate">
+                <a [routerLink]="'/account/' + (history.link_as_account || history.account)" class="account-container uk-text-truncate" title="View Account Details" uk-tooltip>
+                  <div class="identicon-name-row uk-text-truncate">
+                    <app-nano-identicon scale="6" [accountID]="history.link_as_account || history.account" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
+                    <div class="account-label uk-text-truncate" *ngIf="history.addressBookName">{{ history.addressBookName }}</div>
+                  </div>
+                  <div class="nano-address-clickable nano-address-monospace uk-text-truncate">
                     <app-nano-account-id [accountID]="history.link_as_account || history.account" middle="auto"></app-nano-account-id>
-                  </span>
+                  </div>
                 </a>
               </div>
               <div class="nano-address-actions uk-width-auto uk-flex uk-flex-bottom" style="margin-bottom: 11px !important; flex-shrink: 0;">
@@ -293,6 +307,16 @@
             </div>
             <a [routerLink]="'/transaction/' + history.hash" class="uk-link-text uk-text-small uk-text-muted uk-text-truncate block-hash block-hash-monospace" title="View Block Details" uk-tooltip>{{ history.hash }}</a>
           </td>
+          <ng-template #transactionActionsOrDate>
+            <span class="transaction-date" [class.uk-text-muted]="!history.local_timestamp" [class.date-unknown]="!history.local_timestamp">
+              <span class="date">{{ history.local_timestamp ? ( history.local_timestamp * 1000 | date: 'MMM d, y' ) : 'N/A' }}</span>
+              <span class="time"> {{ history.local_timestamp ? ( history.local_timestamp * 1000 | date: 'HH:mm:ss' ) : '' }}</span>
+              <span class="unconfirmed-text" *ngIf="(history.confirmed === false)">
+                <br>
+                <div class="uk-text-small uk-text-muted">Awaiting confirmation</div>
+              </span>
+            </span>
+          </ng-template>
           <td [ngClass]="{
             'amount-column': true,
             'uk-text-middle': true,
@@ -335,14 +359,13 @@
               <span class="amount-integer">{{ history.amount | rai: 'mnano,true' | amountsplit: 0 }}</span>
               <span class="amount-fractional">{{ history.amount | rai: 'mnano,true' | amountsplit: 1 }}</span>
               <span class="currency-name">NANO</span>
+              <div class="compact-actions-date text-half-muted">
+                <ng-template [ngTemplateOutlet]="transactionActionsOrDate"></ng-template>
+              </div>
             </span>
           </td>
-          <td class="date-column uk-text-middle uk-text-truncate" [class.uk-text-muted]="!history.local_timestamp">
-            {{ history.local_timestamp ? ( history.local_timestamp * 1000 | date: 'MMM d, y HH:mm:ss' ) : 'N/A' }}
-            <ng-container *ngIf="(history.confirmed === false)">
-              <br>
-              <div class="uk-text-small uk-text-muted">Awaiting confirmation</div>
-            </ng-container>
+          <td class="date-column uk-text-middle uk-text-truncate">
+            <ng-template [ngTemplateOutlet]="transactionActionsOrDate"></ng-template>
           </td>
         </tr>
 

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -255,7 +255,11 @@
               </div>
             </ng-container>
             <ng-template #noActionsAvailable>
-              <span class="transaction-date" [class.uk-text-muted]="!pending.local_timestamp" [class.date-unknown]="!pending.local_timestamp">
+              <span
+                class="transaction-date"
+                [class.uk-text-muted]="!pending.local_timestamp"
+                [class.date-unknown]="!pending.local_timestamp"
+              >
                 <span class="date">{{ pending.local_timestamp ? ( pending.local_timestamp * 1000 | date: 'MMM d, y' ) : 'N/A' }}</span>
                 <span class="time">{{ pending.local_timestamp ? ( pending.local_timestamp * 1000 | date: 'HH:mm:ss' ) : '' }}</span>
               </span>
@@ -308,14 +312,17 @@
             <a [routerLink]="'/transaction/' + history.hash" class="uk-link-text uk-text-small uk-text-muted uk-text-truncate block-hash block-hash-monospace" title="View Block Details" uk-tooltip>{{ history.hash }}</a>
           </td>
           <ng-template #transactionActionsOrDate>
-            <span class="transaction-date" [class.uk-text-muted]="!history.local_timestamp" [class.date-unknown]="!history.local_timestamp">
+            <span
+              class="transaction-date"
+              [class.uk-text-muted]="!history.local_timestamp"
+              [class.date-unknown]="!history.local_timestamp"
+            >
               <span class="date">{{ history.local_timestamp ? ( history.local_timestamp * 1000 | date: 'MMM d, y' ) : 'N/A' }}</span>
               <span class="time"> {{ history.local_timestamp ? ( history.local_timestamp * 1000 | date: 'HH:mm:ss' ) : '' }}</span>
-              <span class="unconfirmed-text" *ngIf="(history.confirmed === false)">
-                <br>
-                <div class="uk-text-small uk-text-muted">Awaiting confirmation</div>
-              </span>
             </span>
+            <div class="label-unconfirmed" *ngIf="(history.confirmed === false)">
+              <div class="uk-text-small uk-text-muted">Awaiting confirmation</div>
+            </div>
           </ng-template>
           <td [ngClass]="{
             'amount-column': true,

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -94,15 +94,17 @@
             <td class="type-column">
               <span class="type uk-text-small" uk-icon="icon: plus-circle; ratio: 1.2;"></span>
             </td>
-            <td class="account-column uk-text-middle uk-visible-toggle uk-text-truncate">
+            <td class="account-column uk-visible-toggle uk-text-truncate">
               <div uk-grid class="uk-flex-nowrap">
                 <div class="uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
-                  <a [routerLink]="'/account/' + pending.source" class="account-container uk-link-text uk-text-truncate" title="View Account Details" uk-tooltip>
-                    <app-nano-identicon scale="6" [accountID]="pending.source" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
-                    <span class="account-label-placeholder"></span><span class="account-label" *ngIf="pending.sourceAddressBookName">{{ pending.sourceAddressBookName }}</span><br>
-                    <span class="nano-address-clickable nano-address-monospace uk-text-truncate">
+                  <a [routerLink]="'/account/' + pending.source" class="account-container uk-text-truncate" title="View Account Details" uk-tooltip>
+                    <div class="identicon-name-row uk-text-truncate">
+                      <app-nano-identicon scale="6" [accountID]="pending.source" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
+                      <div class="account-label uk-text-truncate" *ngIf="pending.sourceAddressBookName">{{ pending.sourceAddressBookName }}</div>
+                    </div>
+                    <div class="nano-address-clickable nano-address-monospace uk-text-truncate">
                       <app-nano-account-id [accountID]="pending.source" middle="auto"></app-nano-account-id>
-                    </span>
+                    </div>
                   </a>
                 </div>
                 <div class="nano-address-actions uk-width-auto uk-flex uk-flex-bottom">
@@ -118,12 +120,14 @@
                 </div>
                 <div uk-grid class="uk-flex-nowrap">
                   <div class="uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
-                    <a [routerLink]="'/account/' + pending.account" class="account-container uk-link-text uk-text-truncate" title="View Account Details" uk-tooltip>
-                      <app-nano-identicon scale="6" [accountID]="pending.account" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
-                      <span class="account-label-placeholder"></span><span class="account-label" *ngIf="pending.accountAddressBookName">{{ pending.accountAddressBookName }}</span><br>
-                      <span class="nano-address-clickable nano-address-monospace uk-text-truncate">
+                    <a [routerLink]="'/account/' + pending.account" class="account-container uk-text-truncate" title="View Account Details" uk-tooltip>
+                      <div class="identicon-name-row uk-text-truncate">
+                        <app-nano-identicon scale="6" [accountID]="pending.account" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
+                        <div class="account-label uk-text-truncate" *ngIf="pending.accountAddressBookName">{{ pending.accountAddressBookName }}</div>
+                      </div>
+                      <div class="nano-address-clickable nano-address-monospace uk-text-truncate">
                         <app-nano-account-id [accountID]="pending.account" middle="auto"></app-nano-account-id>
-                      </span>
+                      </div>
                     </a>
                   </div>
                   <div class="nano-address-actions uk-width-auto uk-flex uk-flex-bottom">
@@ -134,17 +138,23 @@
                 </div>
               </ng-container>
             </td>
+            <ng-template #transactionActions>
+              <div class="button-container">
+                <button *ngIf="!pending.loading" class="uk-button uk-button-primary uk-text-center uk-width-auto" type="button" (click)="receivePending(pending)">RECEIVE</button>
+                <button *ngIf="pending.loading" class="uk-button uk-button-secondary uk-disabled uk-button-small nlt-icon-button nlt-icon-button-inline"><span class="spinner" uk-spinner="ratio: 0.5;"></span> Receiving</button>
+              </div>
+            </ng-template>
             <td class="amount-column uk-text-middle uk-text-muted" [title]="('Incoming Transaction') + ( (pending.amountRaw && (pending.amountRaw > 0) ) ? ( ', +' + ( pending.amountRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )">
               <span class="uk-text-small">Ready to receive</span><br>
               <span class="amount-integer">{{ pending.amount | rai: 'mnano,true' | amountsplit: 0 }}</span>
               <span class="amount-fractional">{{ pending.amount | rai: 'mnano,true' | amountsplit: 1 }}</span>
               <span class="currency-name">NANO</span>
-            </td>
-            <td class="date-column uk-text-middle uk-text-truncate uk-text-muted">
-              <div class="button-container">
-                <button *ngIf="!pending.loading" class="uk-button uk-button-primary uk-text-center uk-width-auto" type="button" (click)="receivePending(pending)">RECEIVE</button>
-                <button *ngIf="pending.loading" class="uk-button uk-button-secondary uk-disabled uk-button-small nlt-icon-button"><span class="spinner" uk-spinner="ratio: 0.5;"></span> Receiving</button>
+              <div class="compact-actions-date">
+                <ng-template [ngTemplateOutlet]="transactionActions"></ng-template>
               </div>
+            </td>
+            <td class="date-column uk-text-middle uk-text-truncate">
+              <ng-template [ngTemplateOutlet]="transactionActions"></ng-template>
             </td>
           </tr>
           <tr *ngIf="!loadingIncomingTxList && !pendingBlocksForSelectedAccount.length">

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -228,9 +228,7 @@
         <div class="uk-text-right@s nlt-button-group">
           <button (click)="activePanel = 'send'" class="uk-button uk-button-danger uk-width-1-1@s uk-width-auto@m">Cancel</button>
           <button *ngIf="!confirmingTransaction" class="uk-button uk-button-primary uk-width-1-1@s uk-width-auto@m" (click)="confirmTransaction()">Confirm & Send</button>
-          <button *ngIf="confirmingTransaction" class="uk-button uk-button-secondary uk-disabled nlt-icon-button uk-width-1-1@s uk-width-auto@m"
-            style="display: inline-flex;"
-          ><span class="spinner" uk-spinner="ratio: 0.5;"></span> Sending</button>
+          <button *ngIf="confirmingTransaction" class="uk-button uk-button-secondary uk-disabled nlt-icon-button nlt-icon-button-inline uk-width-1-1@s uk-width-auto@m"><span class="spinner" uk-spinner="ratio: 0.5;"></span> Sending</button>
         </div>
       </div>
     </div>

--- a/src/less/components/nav.less
+++ b/src/less/components/nav.less
@@ -554,7 +554,7 @@
 
 	> .representative > .representative-name-row {
 		display: flex;
-		align-items: flex-end;
+		align-items: center;
 		margin-bottom: 8px;
 
 		> .name {

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -744,7 +744,7 @@ input[type=number] {
 				margin-top: 10px;
 			}
 
-			.unconfirmed-text {
+			.label-unconfirmed {
 				display: none;
 			}
 

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -23,8 +23,8 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
 }
 
 @media (max-width: 939px) {
-	button, .uk-button {
-		margin-bottom: @nlt-intro-margin / 2!important;
+	.nlt-button-group button {
+		margin-bottom: @nlt-intro-margin / 2 !important;
 	}
 
 	h2:not(.uk-card-title):not(.uk-modal-title) {
@@ -110,6 +110,10 @@ h1, h2, h3, h4, h5, .uk-text-lead, .uk-button, .uk-alert, .uk-description-list d
 	.spinner {
 		margin-right: 8px;
 		margin-top: -1px;
+	}
+
+	&.nlt-icon-button-inline {
+		display: inline-flex;
 	}
 }
 
@@ -652,28 +656,38 @@ input[type=number] {
 	}
 
 	.account-column {
-		.nano-identicon {
-			display: inline-block;
-			width: 27px;
-			height: 27px;
-			margin-right: 11px;
-			margin-left: 1px;
+		.account-container {
+			text-decoration: none;
 
-			.canvas-container canvas {
-				border-radius: 3px;
+			.identicon-name-row {
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+				height: 28px;
+				margin-bottom: 5px;
+
+				.nano-identicon {
+					display: inline-block;
+					width: 27px;
+					height: 27px;
+					margin-right: 12px;
+					margin-left: 1px;
+					flex-shrink: 0;
+
+					.canvas-container canvas {
+						border-radius: 3px;
+					}
+				}
+			}
+
+			.nano-address-clickable {
+				flex-shrink: 0;
+				margin-top: 3px;
 			}
 		}
 
-		.account-label-placeholder {
-			height: 33px;
-			width: 1px;
-			display: inline-block;
-			vertical-align: -14px;
-		}
-
-		.nano-address-clickable {
-			flex-shrink: 0;
-			margin-top: 3px;
+		.nano-address-actions {
+			margin-bottom: 11px !important;
 		}
 
 		.block-hash {
@@ -688,7 +702,7 @@ input[type=number] {
 		}
 
 		.arrow-down {
-			margin: 3px 0 15px -2px;
+			margin: 1px 0 16px -2px;
 		}
 	}
 
@@ -717,6 +731,27 @@ input[type=number] {
 		&.rep-change {
 			color: #A478E3;
 		}
+
+		.compact-actions-date {
+			margin-top: 20px;
+
+			button {
+				font-size: 12px;
+				padding: 8px 20px;
+			}
+
+			.button-container + .button-container {
+				margin-top: 10px;
+			}
+
+			.unconfirmed-text {
+				display: none;
+			}
+
+			.date-unknown {
+				display: none;
+			}
+		}
 	}
 
 	.date-column {
@@ -743,14 +778,18 @@ input[type=number] {
 	.account-column {
 		min-width: 155px;
 		width: 45%;
-
-		.nano-address-actions {
-			margin-bottom: 22px !important;
-		}
 	}
 
 	.amount-column {
 		width: 55%;
+
+		.compact-actions-date {
+			display: block;
+
+			.transaction-date {
+				font-size: 15px;
+			}
+		}
 	}
 
 	.date-column {
@@ -803,6 +842,16 @@ input[type=number] {
 				margin-left: 0;
 				display: block;
 			}
+
+			.compact-actions-date {
+				.transaction-date {
+					font-size: 14px;
+
+					.date, .time {
+						display: block;
+					}
+				}
+			}
 		}
 	}
 
@@ -810,16 +859,16 @@ input[type=number] {
 		.account-column {
 			width: 45%;
 			min-width: 210px;
-
-			.nano-address-actions {
-				margin-bottom: 11px !important;
-			}
 		}
 
 		.amount-column {
 			width: 35%;
 			text-align: left;
 			padding-left: 30px;
+
+			.compact-actions-date {
+				display: none;
+			}
 		}
 
 		.date-column {
@@ -832,15 +881,15 @@ input[type=number] {
 		.account-column {
 			width: 55%;
 			min-width: 210px;
-
-			.nano-address-actions {
-				margin-bottom: 11px !important;
-			}
 		}
 
 		.amount-column {
 			width: 25%;
 			text-align: left;
+
+			.compact-actions-date {
+				display: none;
+			}
 		}
 
 		.date-column {

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -664,7 +664,7 @@ input[type=number] {
 				flex-direction: row;
 				align-items: center;
 				height: 28px;
-				margin-bottom: 5px;
+				padding-bottom: 8px;
 
 				.nano-identicon {
 					display: inline-block;
@@ -682,7 +682,6 @@ input[type=number] {
 
 			.nano-address-clickable {
 				flex-shrink: 0;
-				margin-top: 3px;
 			}
 		}
 


### PR DESCRIPTION
Fixes #371, date and actions (receive / sign block) are now visible on compact layouts (when the date column is hidden). Affects `Account Details` and `Receive` pages.

![image](https://user-images.githubusercontent.com/29272208/116876951-cd5de580-ac0c-11eb-8f6b-483dcf25cb49.png)

![image](https://user-images.githubusercontent.com/29272208/116877390-67259280-ac0d-11eb-993b-56b72c4791a5.png)

![image](https://user-images.githubusercontent.com/29272208/116877456-7e648000-ac0d-11eb-8f0e-6eb93da2467e.png)


\-

Improves hover/press area and alignment of account identicon / label / address on the transaction list, example:

![image](https://user-images.githubusercontent.com/29272208/116876706-66d8c780-ac0c-11eb-958d-a7d552415b48.png)

\-

Fixes clipboard icon on the transaction list not being aligned under certain circumstances, example of the bug:

![image](https://user-images.githubusercontent.com/29272208/116876738-73f5b680-ac0c-11eb-9061-9d1512cb3ec7.png)

\-

Fixes representative weight label in the sidebar not being properly aligned on Firefox under certain circumstances, example of bug:

![image](https://user-images.githubusercontent.com/29272208/116877102-039b6500-ac0d-11eb-87b3-196f4c34cd56.png)
