### PR TITLE
UX improvements and bug fixes for changing address book labels

### DIFF
--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -1,3 +1,7 @@
+.account-type-label.editing-name {
+    margin-bottom: 6px;
+}
+
 .nano-address-actions {
     margin-top: 2px;
 }

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -12,16 +12,28 @@
 
           <div class="uk-width-expand">
 
-            <div *ngIf="walletAccount && addressBookEntry">{{ 'Account #' + walletAccount.index }}</div>
-            <div *ngIf="!walletAccount">External address</div>
+            <div
+              *ngIf="walletAccount && (addressBookEntry || showEditAddressBook)"
+              class="account-type-label"
+              [class.editing-name]="showEditAddressBook"
+            >
+              {{ 'Account #' + walletAccount.index }}
+            </div>
+            <div
+              *ngIf="!walletAccount"
+              class="account-type-label"
+              [class.editing-name]="showEditAddressBook"
+            >
+              External address
+            </div>
 
             <div uk-grid>
               <div class="uk-width-1-1" *ngIf="showEditAddressBook">
                 <div class="uk-margin">
                   <div class="uk-inline uk-width-1-1">
                     <a class="uk-form-icon uk-form-icon-flip uk-text-success" (click)="saveAddressBook()" uk-icon="icon: check" uk-tooltip title="Save Changes"></a>
-                    <a class="uk-form-icon uk-form-icon-flip uk-text-danger" style="margin-right: 26px;" (click)="showEditAddressBook = false" uk-tooltip title="Cancel Changes - Set the label to blank to delete" uk-icon="icon: close"></a>
-                    <input class="uk-input" (keyup.enter)="saveAddressBook()" [(ngModel)]="addressBookModel" placeholder="Account Label (Set to blank to delete)" type="text" style="padding-right: 60px;">
+                    <a class="uk-form-icon uk-form-icon-flip uk-text-danger" style="margin-right: 26px;" (click)="showEditAddressBook = false" uk-tooltip title="Cancel Changes - To remove the label, leave the text field blank and save changes" uk-icon="icon: close"></a>
+                    <input class="uk-input" (keyup.enter)="saveAddressBook()" [(ngModel)]="addressBookModel" placeholder="Address Book Name (Leave blank to remove)" type="text" style="padding-right: 60px;">
                   </div>
                 </div>
               </div>

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -184,6 +184,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     this.accountID = '';
     this.addressBookEntry = null;
     this.addressBookModel = '';
+    this.showEditAddressBook = false;
     this.walletAccount = null;
     this.account = {};
     this.qrCodeImage = null;

--- a/src/app/components/address-book/address-book.component.ts
+++ b/src/app/components/address-book/address-book.component.ts
@@ -76,6 +76,9 @@ export class AddressBookComponent implements OnInit, AfterViewInit {
       return this.notificationService.sendError(`Account and name are required`);
     }
 
+    // Trim and remove duplicate spaces
+    this.newAddressName = this.newAddressName.trim().replace(/ +/g, ' ');
+
     if ( /^Account #\d+$/g.test(this.newAddressName) === true ) {
       return this.notificationService.sendError(`This name is reserved for wallet accounts without a label`);
     }

--- a/src/app/services/address-book.service.ts
+++ b/src/app/services/address-book.service.ts
@@ -102,6 +102,12 @@ export class AddressBookService {
     return match && match.name || null;
   }
 
+  getAccountIdByName(name: string): string|null {
+    if (!name || !name.length) return null;
+    const match = this.addressBook.find(a => a.name.toLowerCase() === name.toLowerCase());
+    return match ? match.account : null;
+  }
+
   nameExists(name: string): boolean {
     return this.addressBook.findIndex(a => a.name.toLowerCase() === name.toLowerCase()) !== -1;
   }


### PR DESCRIPTION
prevent renaming to "Account #X" from the Account Details page

prevent naming account the same name as an existing address book entry from the Account Details page

trim and remove duplicate spaces to prevent names `" like   this "` which allowed to circumvent "Account #X" check

show account # when renaming account with no label

cancel renaming when navigating to another account 

minor improvement to wording