### PR TITLE
Implemented watch-only accounts

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -79,6 +79,12 @@ export class AppComponent implements OnInit {
     this.workPool.loadWorkCache();
 
     await this.walletService.loadStoredWallet();
+    // Subscribe to any transaction tracking
+    for (const entry of this.addressBook.addressBook) {
+      if (entry.trackTransactions) {
+        this.walletService.trackAddress(entry.account);
+      }
+    }
 
     // Navigate to accounts page if there is wallet, but only if coming from home. On desktop app the path ends with index.html
     if (this.walletService.isConfigured() && (window.location.pathname === '/' || window.location.pathname.endsWith('index.html'))) {

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -121,7 +121,7 @@
                 <div class="account-amounts-primary">
                   <div
                     class="account-amounts-primary-confirmed"
-                    [title]="( (account && account.balanceRaw && account.balanceRaw.gt(0) ) ? ( '+' + ( account.balanceRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )"
+                    [title]="( (account && account.balanceRaw && account.balanceRaw.gt(0) ) ? ( '+' + ( account.balanceRaw.toString(10)  ) + ' raw' ) : '' )"
                   >
                     <span class="amount-integer">{{ !account ? 0 : (account.balance || 0 | rai: 'mnano,true') | amountsplit: 0 }}</span>
                     <span class="amount-fractional">{{ !account ? 0 : (account.balance || 0 | rai: 'mnano,true') | amountsplit: 1 }}</span>
@@ -130,7 +130,7 @@
                   <div
                     *ngIf="account && account.pending && (account.pending > 0)"
                     class="incoming-label"
-                    [title]="( (account && account.pendingRaw && account.pendingRaw.gt(0) ) ? ( '+' + ( account.pendingRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )"
+                    [title]="( (account && account.pendingRaw && account.pendingRaw.gt(0) ) ? ( '+' + ( account.pendingRaw.toString(10) ) + ' raw' ) : '' )"
                   >
                     <div class="text-snippet">New</div>
                     <div class="text-full">
@@ -277,7 +277,7 @@
               </span>
             </ng-template>
           </ng-template>
-          <td class="amount-column uk-text-middle uk-text-muted" [title]="('Incoming Transaction') + ( (pending.amountRaw && (pending.amountRaw > 0) ) ? ( ', +' + ( pending.amountRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )">
+          <td class="amount-column uk-text-middle uk-text-muted" [title]="('Incoming Transaction') + ( (pending.amountRaw && (pending.amountRaw > 0) ) ? ( ', +' + ( pending.amountRaw.toString(10) ) + ' raw' ) : '' )">
             <span class="uk-text-small">Ready to receive</span><br>
             <span class="amount-integer">{{ pending.amount | rai: 'mnano,true' | amountsplit: 0 }}</span>
             <span class="amount-fractional">{{ pending.amount | rai: 'mnano,true' | amountsplit: 1 }}</span>

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -509,7 +509,9 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
     }
 
     try {
-      await this.addressBook.saveAddress(this.accountID, this.addressBookModel);
+      const currentBalanceTracking = this.addressBook.getBalanceTrackingById(this.accountID);
+      const currentTransactionTracking = this.addressBook.getTransactionTrackingById(this.accountID);
+      await this.addressBook.saveAddress(this.accountID, this.addressBookModel, currentBalanceTracking, currentTransactionTracking);
     } catch (err) {
       this.notifications.sendError(`Unable to save entry: ${err.message}`);
       return;

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -80,7 +80,7 @@
                   <div class="text-snippet">New</div>
                   <div class="text-full">+{{ account.pending | rai: 'mnano,true' | amountsplit: 0 }}{{ account.pending | rai: 'mnano,true' | amountsplit: 1 }} NANO</div>
                 </div>
-                <span [title]="( account.balanceRaw.gt(0) ? ( '+' + ( account.balanceRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )">
+                <span [title]="( account.balanceRaw.gt(0) ? ( '+' + ( account.balanceRaw.toString(10) ) + ' raw' ) : '' )">
                   <span class="amount-integer">{{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}</span>
                   <span class="amount-fractional">{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }}</span>
                   <span class="currency-name">NANO</span>

--- a/src/app/components/address-book/address-book.component.css
+++ b/src/app/components/address-book/address-book.component.css
@@ -9,3 +9,105 @@
 .uk-sortable-handle {
 	margin-top: 4px;
 }
+
+.checkbox-aligned {
+	vertical-align: bottom;
+}
+
+.amount-container {
+	flex: none;
+  margin-top: 10px;
+}
+
+.account-amounts-primary {
+	margin-bottom: 3px;
+}
+
+.account-amounts-primary .amount-integer {
+	font-weight: 700;
+}
+
+.account-amounts-primary .amount-fractional {
+	font-weight: 500;
+}
+
+.account-amounts-primary .currency-name {
+	font-weight: 400;
+	margin-left: 5px;
+}
+
+.incoming-label {
+	display: inline-block;
+	background: #4a90e2;
+	border-radius: 20px;
+	font-size: 13px;
+	padding: 2px 10px;
+	margin-left: 9px;
+	vertical-align: 1px;
+	padding-bottom: 1px;
+	text-transform: uppercase;
+	color: #FFF;
+}
+
+.incoming-label > .text-full {
+	display: none;
+}
+
+.incoming-label > .text-snippet {
+	display: inline-block;
+}
+
+.total-balance {
+	text-decoration: underline;
+}
+
+@media (min-width: 1500px) {
+	.incoming-label > .text-full {
+		display: inline-block;
+	}
+
+	.incoming-label > .text-snippet {
+		display: none;
+	}
+}
+
+.advanced-options-link {
+	display: inline-flex;
+	align-items: center;
+	cursor: pointer;
+}
+
+.advanced-options-link .chevron {
+	margin-left: 8px;
+}
+
+.chevron {
+	background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2214%22%20height%3D%2214%22%20viewBox%3D%220%200%2014%2014%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%20%20%3Cpolyline%20fill%3D%22none%22%20stroke%3D%22%23676686%22%20stroke-width%3D%221.1%22%20points%3D%221%204%207%2010%2013%204%22%20%2F%3E%0A%3C%2Fsvg%3E");
+	width: 14px;
+	height: 14px;
+	display: inline-block;
+	margin-left: 4px;
+}
+
+.chevron-up {
+	transform: scaleY(-1);
+}
+
+.advanced-options {
+	margin-top: 20px;
+}
+
+.advanced-option {
+	display: flex;
+	align-items: center;
+	margin-bottom: 4px;
+}
+
+.advanced-option + .advanced-option {
+	margin-top: 16px;
+}
+
+.advanced-option .uk-checkbox {
+	margin-left: 12px;
+	margin-top: -1px;
+}

--- a/src/app/components/address-book/address-book.component.html
+++ b/src/app/components/address-book/address-book.component.html
@@ -176,7 +176,7 @@
               </div>
 
               <div class="uk-margin">
-                <label class="uk-form-label" for="new-track-transactions">Track Transactions <span uk-icon="icon: info;" uk-tooltip title="Notifications will be shown for any SEND, RECEIVE or CHANGE transactions on this address."></span></label>
+                <label class="uk-form-label" for="new-track-transactions">Track Transactions <span uk-icon="icon: info;" uk-tooltip title="A notification will be shown whenever the address has a new incoming transaction, sends or receives funds, or changes its representative."></span></label>
                 <div class="uk-form-controls">
                   <input class="uk-checkbox checkbox-aligned" type="checkbox" id="new-track-transactions" value="1" [(ngModel)]="newTrackTransactions">
                 </div>

--- a/src/app/components/address-book/address-book.component.html
+++ b/src/app/components/address-book/address-book.component.html
@@ -9,14 +9,36 @@
         </h2>
       </div>
       <div class="uk-width-auto@s uk-width-1-1 uk-text-right">
-        <button class="uk-button uk-button-secondary uk-align-right uk-width-auto@s" (click)="addEntry()" *ngIf="activePanel === 0">Add New Contact</button>
+        <button class="uk-button uk-button-secondary uk-align-right uk-width-auto@s" (click)="addEntry()" *ngIf="activePanel === 0">Add New Entry</button>
       </div>
     </div>
 
     <div class="uk-width-1-1 nlt-page-intro" *ngIf="activePanel === 0">
       <p>
-        You can use the address book to store a label for your own accounts and others you frequently transact with, which are visible throughout the application.
+        You can use the address book to store a label for your own accounts or for easy access to other addresses throughout the application.<br>
+        It's also possible to track the balance and/or transactions of any address, known as "watch-only".<br>
       </p>
+      <div class="account-amounts-primary uk-width-1-1">
+        <div class="details-header advanced-options-link" (click)="showAdvancedOptions = !showAdvancedOptions">
+          Show Total Tracked Balance
+          <div [class]="['chevron', ( showAdvancedOptions ? 'chevron-up' : 'chevron-down' )]"></div>
+        </div>
+
+        <div class="advanced-options" *ngIf="showAdvancedOptions">
+          <span [title]="( totalTrackedBalanceRaw.gt(0) ? ( '+' + ( totalTrackedBalanceRaw.toString(10) ) + ' raw' ) : '' )">
+            <span class="amount-integer">{{ totalTrackedBalance | rai: 'mnano,true' | amountsplit: 0 }}</span>
+            <span class="amount-fractional">{{ totalTrackedBalance | rai: 'mnano,true' | amountsplit: 1 }}</span>
+            <span class="currency-name">NANO</span>
+          </span>
+          <div *ngIf="totalTrackedPending.gt(0)" class="incoming-label">
+            <div class="text-snippet">New</div>
+            <div class="text-full">+{{ totalTrackedPending | rai: 'mnano,true' | amountsplit: 0 }}{{ totalTrackedPending | rai: 'mnano,true' | amountsplit: 1 }} NANO</div>
+          </div>
+          <div class="account-amounts-converted uk-width-1-1 text-half-muted">
+            {{ totalTrackedBalanceFiat | fiat: appSettings.settings.displayCurrency }}
+          </div>
+        </div>
+      </div>
     </div>
 
     <div class="uk-animation-slide-left-small" *ngIf="activePanel === 0" uk-grid>
@@ -27,7 +49,31 @@
             <li class="uk-list-header">
               <div uk-grid>
                 <div class="uk-width-2-5">Name</div>
-                <div class="uk-width-expand">Account ID</div>
+                <div class="uk-width-expand">Address
+                  <div *ngIf="numberOfTrackedBalance > 0" style="display: flex;">
+                    RELOAD BALANCES
+                    <ul class="uk-width-auto uk-iconnav uk-margin-remove-left" style="margin-top: -1px;">
+                      <li>
+                        <div
+                          uk-spinner="ratio: 0.5;"
+                          class="icon-transactions-refresh spinner"
+                          *ngIf="(loadingBalances || walletService.wallet.updatingBalance === true) else notUpdatingTxList"
+                        ></div>
+                        <ng-template #notUpdatingTxList>
+                          <a
+                            class="icon-transactions-refresh"
+                            [class.disabled]="!statsRefreshEnabled"
+                            [class.uk-text-muted]="!statsRefreshEnabled"
+                            uk-icon="icon: refresh;"
+                            title="Reload tracked balances (for addresses not in your Nault wallet)"
+                            uk-tooltip
+                            (click)="updateTrackedBalances(true)"
+                          ></a>
+                        </ng-template>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
                 <div class="uk-width-1-6 uk-text-center" style="padding-left: 0;">Options</div>
               </div>
             </li>
@@ -42,7 +88,7 @@
                       {{ addressBook.name }}
                     </div>
                     <ul class="uk-iconnav uk-width-auto">
-                      <li><a (click)="editEntry(addressBook)" title="Edit Account Label" uk-tooltip uk-icon="icon: pencil;" class="edit-name-icon"></a></li>
+                      <li><a (click)="editEntry(addressBook)" title="Edit Label" uk-tooltip uk-icon="icon: pencil;" class="edit-name-icon"></a></li>
                       <li><a class="uk-sortable-handle uk-margin-small-right" uk-icon="icon: table"></a></li>
                     </ul>
                   </div>
@@ -50,18 +96,40 @@
                 <div class="uk-width-expand uk-text-truncate uk-visible-toggle">
                   <div uk-grid>
                     <div class="uk-width-expand uk-text-truncate">
-                      <a [routerLink]="'/account/' + addressBook.account" class="nano-address-clickable nano-address-monospace uk-display-block" title="View Account Details" uk-tooltip>
+                      <a [routerLink]="'/account/' + addressBook.account" class="nano-address-clickable nano-address-monospace uk-display-block" title="View on Network Explorer" uk-tooltip>
                         <app-nano-account-id [accountID]="addressBook.account"></app-nano-account-id>
                       </a>
                     </div>
                     <ul class="nano-address-actions uk-iconnav">
-                      <li><a ngxClipboard [cbContent]="addressBook.account" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
+                      <li><a ngxClipboard [cbContent]="addressBook.account" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Address" uk-tooltip></a></li>
                     </ul>
+                    <div class="uk-width-expand amount-container" *ngIf="addressBook.trackBalance">
+                      <ng-container *ngIf="(walletService.wallet.updatingBalance === false) else balanceLoading">
+                        <div class="account-amounts-primary uk-width-1-1">
+                          <span [title]="( accounts[addressBook.account]?.balanceRaw.gt(0) ? ( '+' + ( accounts[addressBook.account]?.balanceRaw.toString(10) ) + ' raw' ) : '' )">
+                            <span class="amount-integer">{{ accounts[addressBook.account]?.balance | rai: 'mnano,true' | amountsplit: 0 }}</span>
+                            <span class="amount-fractional">{{ accounts[addressBook.account]?.balance | rai: 'mnano,true' | amountsplit: 1 }}</span>
+                            <span class="currency-name">NANO</span>
+                          </span>
+                          <div *ngIf="accounts[addressBook.account]?.pending.gt(0)" class="incoming-label">
+                            <div class="text-snippet">New</div>
+                            <div class="text-full">+{{ accounts[addressBook.account]?.pending | rai: 'mnano,true' | amountsplit: 0 }}{{ accounts[addressBook.account]?.pending | rai: 'mnano,true' | amountsplit: 1 }} NANO</div>
+                          </div>
+                        </div>
+                        <div class="account-amounts-converted uk-width-1-1 text-half-muted">
+                          {{ accounts[addressBook.account]?.balanceFiat | fiat: appSettings.settings.displayCurrency }}
+                        </div>
+                      </ng-container>
+                      <ng-template #balanceLoading>
+                        <div class="account-amounts-primary uk-width-1-1">
+                          <div uk-spinner="ratio: 0.5;"></div>
+                        </div>
+                      </ng-template>
+                    </div>
                   </div>
-
                 </div>
                 <div class="uk-width-1-6 uk-text-center" style="padding-left: 0;">
-                  <a (click)="deleteAddress(addressBook.account)" class="uk-text-danger" title="Delete From Address Book" uk-tooltip><span uk-icon="icon: trash;"></span></a>
+                  <a (click)="deleteAddress(addressBook.account)" class="uk-text-danger" title="Remove From Address Book" uk-tooltip><span uk-icon="icon: trash;"></span></a>
                 </div>
               </div>
 
@@ -79,12 +147,19 @@
       <div class="uk-width-1-1">
         <div class="uk-card uk-card-default">
           <div class="uk-card-header">
-            <h2 class="uk-card-title">{{ creatingNewEntry ? 'Add New Contact' : 'Edit Contact' }}</h2>
+            <h2 class="uk-card-title">{{ creatingNewEntry ? 'Add New Entry' : 'Edit Entry' }}</h2>
           </div>
           <div class="uk-card-body">
             <div class="uk-form-horizontal">
               <div class="uk-margin">
-                <label class="uk-form-label" for="new-address-account">Account ID</label>
+                <label class="uk-form-label" for="new-address-name">Name</label>
+                <div class="uk-form-controls">
+                  <input type="text" class="uk-input" id="new-address-name" [(ngModel)]="newAddressName" (keyup.enter)="saveNewAddress()" placeholder="Exchange Deposit Address, Main Trading Account, etc">
+                </div>
+              </div>
+
+              <div class="uk-margin">
+                <label class="uk-form-label" for="new-address-account">Address</label>
                 <div class="uk-form-controls">
                   <div class="uk-inline uk-width-1-1">
                     <a class="uk-form-icon uk-form-icon-flip" uk-icon="icon: camera" (click)="openQR('account1','account')" uk-tooltip title="Scan from QR code" *ngIf="creatingNewEntry"></a>
@@ -94,9 +169,16 @@
               </div>
 
               <div class="uk-margin">
-                <label class="uk-form-label" for="new-address-name">Name</label>
+                <label class="uk-form-label" for="new-track-balance">Track Balance <span uk-icon="icon: info;" uk-tooltip title="The balance will be displayed in the address book."></span></label>
                 <div class="uk-form-controls">
-                  <input type="text" class="uk-input" id="new-address-name" [(ngModel)]="newAddressName" (keyup.enter)="saveNewAddress()" placeholder="Exchange Deposit Address, Main Trading Account, etc">
+                  <input class="uk-checkbox checkbox-aligned" type="checkbox" id="new-track-balance" value="1" [(ngModel)]="newTrackBalance">
+                </div>
+              </div>
+
+              <div class="uk-margin">
+                <label class="uk-form-label" for="new-track-transactions">Track Transactions <span uk-icon="icon: info;" uk-tooltip title="Notifications will be shown for any SEND, RECEIVE or CHANGE transactions on this address."></span></label>
+                <div class="uk-form-controls">
+                  <input class="uk-checkbox checkbox-aligned" type="checkbox" id="new-track-transactions" value="1" [(ngModel)]="newTrackTransactions">
                 </div>
               </div>
             </div>

--- a/src/app/components/address-book/address-book.component.ts
+++ b/src/app/components/address-book/address-book.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, OnInit} from '@angular/core';
+import {AfterViewInit, Component, OnInit, OnDestroy} from '@angular/core';
 import {AddressBookService} from '../../services/address-book.service';
 import {WalletService} from '../../services/wallet.service';
 import {NotificationService} from '../../services/notification.service';
@@ -7,14 +7,27 @@ import {UtilService} from '../../services/util.service';
 import { QrModalService } from '../../services/qr-modal.service';
 import {Router} from '@angular/router';
 import * as QRCode from 'qrcode';
+import {BigNumber} from 'bignumber.js';
+import {ApiService} from '../../services/api.service';
+import {PriceService} from '../../services/price.service';
+import {AppSettingsService} from '../../services/app-settings.service';
+
+export interface BalanceAccount {
+  balance: BigNumber;
+  balanceRaw: BigNumber;
+  pending: BigNumber;
+  balanceFiat: number;
+}
 
 @Component({
   selector: 'app-address-book',
   templateUrl: './address-book.component.html',
   styleUrls: ['./address-book.component.css']
 })
-export class AddressBookComponent implements OnInit, AfterViewInit {
 
+export class AddressBookComponent implements OnInit, AfterViewInit, OnDestroy {
+
+  nano = 1000000000000000000000000;
   activePanel = 0;
   creatingNewEntry = false;
 
@@ -26,6 +39,20 @@ export class AddressBookComponent implements OnInit, AfterViewInit {
   addressBookQRExportUrl = '';
   addressBookQRExportImg = '';
   importExport = false;
+  newTrackBalance = false;
+  newTrackTransactions = false;
+  accounts: BalanceAccount[] = [];
+  totalTrackedBalance = new BigNumber(0);
+  totalTrackedBalanceRaw = new BigNumber(0);
+  totalTrackedBalanceFiat = 0;
+  totalTrackedPending = new BigNumber(0);
+  fiatPrice = 0;
+  priceSub = null;
+  refreshSub = null;
+  statsRefreshEnabled = true;
+  timeoutIdAllowingRefresh: any = null;
+  loadingBalances = false;
+  numberOfTrackedBalance = 0;
 
   constructor(
     private addressBookService: AddressBookService,
@@ -34,10 +61,59 @@ export class AddressBookComponent implements OnInit, AfterViewInit {
     public modal: ModalService,
     private util: UtilService,
     private qrModalService: QrModalService,
-    private router: Router) { }
+    private router: Router,
+    private api: ApiService,
+    private price: PriceService,
+    public appSettings: AppSettingsService) { }
 
   async ngOnInit() {
     this.addressBookService.loadAddressBook();
+    // Keep price up to date with the service
+    this.priceSub = this.price.lastPrice$.subscribe(event => {
+      this.fiatPrice = this.price.price.lastPrice;
+    });
+
+    // Detect if local wallet balance is refreshed
+    this.refreshSub = this.walletService.wallet.refresh$.subscribe(shouldRefresh => {
+      if (shouldRefresh) {
+        this.loadingBalances = true;
+        // Check if we have a local wallet account tracked and update the balances
+        for (const entry of this.addressBookService.addressBook) {
+          if (!entry.trackBalance || !this.accounts[entry.account]) continue;
+          // If the account exist in the wallet, take the info from there to save on RPC calls
+          const walletAccount = this.walletService.wallet.accounts.find(a => a.id.toLowerCase() === entry.account.toLowerCase());
+          if (walletAccount) {
+            // Subtract first so we can add back any updated amounts
+            this.totalTrackedBalance = this.totalTrackedBalance.minus(this.accounts[entry.account].balance);
+            this.totalTrackedBalanceRaw = this.totalTrackedBalanceRaw.minus(this.accounts[entry.account].balanceRaw);
+            this.totalTrackedBalanceFiat = this.totalTrackedBalanceFiat - this.accounts[entry.account].balanceFiat;
+            this.totalTrackedPending = this.totalTrackedPending.minus(this.accounts[entry.account].pending);
+
+            this.accounts[entry.account].balance = walletAccount.balance;
+            this.accounts[entry.account].pending = walletAccount.pending;
+            this.accounts[entry.account].balanceFiat = walletAccount.balanceFiat;
+            this.accounts[entry.account].balanceRaw = walletAccount.balanceRaw;
+
+            this.totalTrackedBalance = this.totalTrackedBalance.plus(walletAccount.balance);
+            this.totalTrackedBalanceRaw = this.totalTrackedBalanceRaw.plus(walletAccount.balanceRaw);
+            this.totalTrackedBalanceFiat = this.totalTrackedBalanceFiat + walletAccount.balanceFiat;
+            this.totalTrackedPending = this.totalTrackedPending.plus(this.accounts[entry.account].pending);
+          }
+        }
+        this.loadingBalances = false;
+      }
+    });
+
+    this.updateTrackedBalances();
+  }
+
+  ngOnDestroy() {
+    if (this.priceSub) {
+      this.priceSub.unsubscribe();
+    }
+    if (this.refreshSub) {
+      this.refreshSub.unsubscribe();
+    }
   }
 
   ngAfterViewInit() {
@@ -54,8 +130,120 @@ export class AddressBookComponent implements OnInit, AfterViewInit {
     });
   }
 
+  sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  async updateTrackedBalances(refresh= false) {
+    if (refresh && !this.statsRefreshEnabled) return;
+    this.statsRefreshEnabled = false;
+    if (this.timeoutIdAllowingRefresh != null) {
+      clearTimeout(this.timeoutIdAllowingRefresh);
+    }
+    this.timeoutIdAllowingRefresh = setTimeout(() => this.statsRefreshEnabled = true, 5000);
+    this.loadingBalances = true;
+
+     // Inform html that at least one entry is tracked
+    this.numberOfTrackedBalance = 0;
+    for (const entry of this.addressBookService.addressBook) {
+      if (entry.trackBalance) {
+        this.numberOfTrackedBalance++;
+      }
+    }
+    // No need to process if there is nothing to track
+    if (this.numberOfTrackedBalance === 0) return;
+
+    this.totalTrackedBalance = new BigNumber(0);
+    this.totalTrackedBalanceRaw = new BigNumber(0);
+    this.totalTrackedBalanceFiat = 0;
+    this.totalTrackedPending = new BigNumber(0);
+
+    // Get account balances for all account in address book not in wallet (which has tracking active)
+    const accountIDsWallet = this.walletService.wallet.accounts.map(a => a.id);
+    const accountIDs = this.addressBookService.addressBook.filter(a => !accountIDsWallet.includes(a.account) &&
+      a.trackBalance).map(a => a.account);
+    const apiAccounts = await this.api.accountsBalances(accountIDs);
+
+    // Fetch pending of all tracked accounts
+    let pending;
+    if (this.appSettings.settings.minimumReceive) {
+      const minAmount = this.util.nano.mnanoToRaw(this.appSettings.settings.minimumReceive);
+      pending = await this.api.accountsPendingLimitSorted(accountIDs, minAmount.toString(10));
+    } else {
+      pending = await this.api.accountsPendingSorted(accountIDs);
+    }
+
+    // Save balances
+    for (const entry of this.addressBookService.addressBook) {
+      if (!entry.trackBalance) continue;
+
+      const balanceAccount: BalanceAccount = {
+        balance: new BigNumber(0),
+        balanceRaw: new BigNumber(0),
+        pending: new BigNumber(0),
+        balanceFiat: 0
+      };
+      // If the account exist in the wallet, take the info from there to save on RPC calls
+      const walletAccount = this.walletService.wallet.accounts.find(a => a.id.toLowerCase() === entry.account.toLowerCase());
+      if (walletAccount) {
+        balanceAccount.balance = walletAccount.balance;
+        balanceAccount.pending = walletAccount.pending;
+        balanceAccount.balanceFiat = walletAccount.balanceFiat;
+        balanceAccount.balanceRaw = walletAccount.balanceRaw;
+      // Add balances from RPC data
+      } else {
+        balanceAccount.balance = new BigNumber(apiAccounts.balances[entry.account].balance);
+        balanceAccount.balanceFiat = this.util.nano.rawToMnano(balanceAccount.balance).times(this.fiatPrice).toNumber();
+        balanceAccount.balanceRaw = new BigNumber(balanceAccount.balance).mod(this.nano);
+      }
+      this.totalTrackedBalance = this.totalTrackedBalance.plus(balanceAccount.balance);
+      this.totalTrackedBalanceRaw = this.totalTrackedBalanceRaw.plus(balanceAccount.balanceRaw);
+      this.totalTrackedBalanceFiat = this.totalTrackedBalanceFiat + balanceAccount.balanceFiat;
+      this.accounts[entry.account] = balanceAccount;
+    }
+
+    // Add pending from RPC data
+    if (pending && pending.blocks) {
+      for (const block in pending.blocks) {
+        if (!pending.blocks.hasOwnProperty(block)) {
+          continue;
+        }
+
+        const targetAccount = this.accounts[block];
+
+        if (pending.blocks[block]) {
+          let accountPending = new BigNumber(0);
+
+          for (const hash in pending.blocks[block]) {
+            if (!pending.blocks[block].hasOwnProperty(hash)) {
+              continue;
+            }
+              accountPending = accountPending.plus(pending.blocks[block][hash].amount);
+          }
+          if (targetAccount) {
+            targetAccount.pending = accountPending;
+            this.totalTrackedPending = this.totalTrackedPending.plus(targetAccount.pending);
+          }
+        }
+      }
+    }
+
+    // If not already updating balances, update to get latest values from internal wallet
+    if (this.walletService.wallet.updatingBalance) {
+      while (this.walletService.wallet.updatingBalance) {
+        await this.sleep(100); // Wait until update is finished
+      }
+    } else {
+      await this.walletService.reloadBalances();
+    }
+
+    this.loadingBalances = false;
+  }
+
   addEntry() {
     this.previousAddressName = '';
+    this.newTrackBalance = false;
+    this.newTrackTransactions = false;
     this.creatingNewEntry = true;
     this.activePanel = 1;
   }
@@ -64,6 +252,8 @@ export class AddressBookComponent implements OnInit, AfterViewInit {
     this.newAddressAccount = addressBook.account;
     this.previousAddressName = addressBook.name;
     this.newAddressName = addressBook.name;
+    this.newTrackBalance = addressBook.trackBalance;
+    this.newTrackTransactions = addressBook.trackTransactions;
     this.creatingNewEntry = false;
     this.activePanel = 1;
     setTimeout(() => {
@@ -76,6 +266,10 @@ export class AddressBookComponent implements OnInit, AfterViewInit {
       return this.notificationService.sendError(`Account and name are required`);
     }
 
+    if (this.newTrackBalance && this.numberOfTrackedBalance >= 20) {
+      return this.notificationService.sendError(`You can only track the balance of maximum 20 addresses`);
+    }
+
     // Trim and remove duplicate spaces
     this.newAddressName = this.newAddressName.trim().replace(/ +/g, ' ');
 
@@ -83,7 +277,8 @@ export class AddressBookComponent implements OnInit, AfterViewInit {
       return this.notificationService.sendError(`This name is reserved for wallet accounts without a label`);
     }
 
-    this.newAddressAccount = this.newAddressAccount.replace(/ /g, ''); // Remove spaces
+    // Remove spaces and convert to nano prefix
+    this.newAddressAccount = this.newAddressAccount.replace(/ /g, '').replace('xrb_', 'nano_');
 
     // If the name has been changed, make sure no other entries are using that name
     if ( (this.newAddressName !== this.previousAddressName) && this.addressBookService.nameExists(this.newAddressName) ) {
@@ -94,14 +289,28 @@ export class AddressBookComponent implements OnInit, AfterViewInit {
     const valid = this.util.account.isValidAccount(this.newAddressAccount);
     if (!valid) return this.notificationService.sendWarning(`Account ID is not a valid account`);
 
+    // Store old setting
+    const wasTransactionTracked = this.addressBookService.getTransactionTrackingById(this.newAddressAccount);
+
     try {
-      await this.addressBookService.saveAddress(this.newAddressAccount, this.newAddressName);
+      await this.addressBookService.saveAddress(this.newAddressAccount,
+        this.newAddressName, this.newTrackBalance, this.newTrackTransactions);
       this.notificationService.sendSuccess(`Address book entry saved successfully!`);
-      // IF this is one of our accounts, set its name, and hope things update?
+      // If this is one of our accounts, set its name and let it propagate through the app
       const walletAccount = this.walletService.wallet.accounts.find(a => a.id.toLowerCase() === this.newAddressAccount.toLowerCase());
       if (walletAccount) {
         walletAccount.addressBookName = this.newAddressName;
       }
+
+      // track account transaction (if unchanged)
+      if (this.newTrackTransactions && !wasTransactionTracked) {
+        this.walletService.trackAddress(this.newAddressAccount);
+
+      } else if (!this.newTrackTransactions && wasTransactionTracked) {
+        this.walletService.untrackAddress(this.newAddressAccount);
+      }
+
+      this.updateTrackedBalances();
       this.cancelNewAddress();
     } catch (err) {
       this.notificationService.sendError(`Unable to save entry: ${err.message}`);
@@ -123,6 +332,8 @@ export class AddressBookComponent implements OnInit, AfterViewInit {
     try {
       this.addressBookService.deleteAddress(account);
       this.notificationService.sendSuccess(`Successfully deleted address book entry`);
+      this.walletService.untrackAddress(account);
+      this.updateTrackedBalances();
     } catch (err) {
       this.notificationService.sendError(`Unable to delete entry: ${err.message}`);
     }

--- a/src/app/components/address-book/address-book.component.ts
+++ b/src/app/components/address-book/address-book.component.ts
@@ -81,7 +81,7 @@ export class AddressBookComponent implements OnInit, AfterViewInit, OnDestroy {
         for (const entry of this.addressBookService.addressBook) {
           if (!entry.trackBalance || !this.accounts[entry.account]) continue;
           // If the account exist in the wallet, take the info from there to save on RPC calls
-          const walletAccount = this.walletService.wallet.accounts.find(a => a.id.toLowerCase() === entry.account.toLowerCase());
+          const walletAccount = this.walletService.wallet.accounts.find(a => a.id === entry.account);
           if (walletAccount) {
             // Subtract first so we can add back any updated amounts
             this.totalTrackedBalance = this.totalTrackedBalance.minus(this.accounts[entry.account].balance);
@@ -184,7 +184,7 @@ export class AddressBookComponent implements OnInit, AfterViewInit, OnDestroy {
         balanceFiat: 0
       };
       // If the account exist in the wallet, take the info from there to save on RPC calls
-      const walletAccount = this.walletService.wallet.accounts.find(a => a.id.toLowerCase() === entry.account.toLowerCase());
+      const walletAccount = this.walletService.wallet.accounts.find(a => a.id === entry.account);
       if (walletAccount) {
         balanceAccount.balance = walletAccount.balance;
         balanceAccount.pending = walletAccount.pending;
@@ -218,7 +218,7 @@ export class AddressBookComponent implements OnInit, AfterViewInit, OnDestroy {
             if (!pending.blocks[block].hasOwnProperty(hash)) {
               continue;
             }
-              accountPending = accountPending.plus(pending.blocks[block][hash].amount);
+            accountPending = accountPending.plus(pending.blocks[block][hash].amount);
           }
           if (targetAccount) {
             targetAccount.pending = accountPending;
@@ -297,7 +297,7 @@ export class AddressBookComponent implements OnInit, AfterViewInit, OnDestroy {
         this.newAddressName, this.newTrackBalance, this.newTrackTransactions);
       this.notificationService.sendSuccess(`Address book entry saved successfully!`);
       // If this is one of our accounts, set its name and let it propagate through the app
-      const walletAccount = this.walletService.wallet.accounts.find(a => a.id.toLowerCase() === this.newAddressAccount.toLowerCase());
+      const walletAccount = this.walletService.wallet.accounts.find(a => a.id === this.newAddressAccount);
       if (walletAccount) {
         walletAccount.addressBookName = this.newAddressName;
       }

--- a/src/app/components/import-address-book/import-address-book.component.ts
+++ b/src/app/components/import-address-book/import-address-book.component.ts
@@ -70,10 +70,12 @@ export class ImportAddressBookComponent implements OnInit {
     let importedCount = 0;
     for (const entry of this.importData) {
       if (!entry.originalName) {
-        await this.addressBook.saveAddress(entry.account, entry.name);
+        await this.addressBook.saveAddress(entry.account, entry.name,
+          entry.trackBalance ? entry.trackBalance : false, entry.trackTransactions ? entry.trackTransactions : false);
         importedCount++;
       } else if (entry.originalName && entry.originalName !== entry.name) {
-        await this.addressBook.saveAddress(entry.account, entry.name);
+        await this.addressBook.saveAddress(entry.account, entry.name,
+          entry.trackBalance ? entry.trackBalance : false, entry.trackTransactions ? entry.trackTransactions : false);
         importedCount++;
       }
     }

--- a/src/app/components/manage-representatives/manage-representatives.component.html
+++ b/src/app/components/manage-representatives/manage-representatives.component.html
@@ -9,7 +9,7 @@
         </h2>
       </div>
       <div class="uk-width-auto@s uk-width-1-1 uk-text-right" *ngIf="activePanel == 0">
-        <button class="uk-button uk-button-secondary uk-align-right uk-width-auto@s" (click)="addEntry()">Add Representative</button>
+        <button class="uk-button uk-button-secondary uk-align-right uk-width-auto@s" (click)="addEntry()">Add New Entry</button>
       </div>
     </div>
 
@@ -27,7 +27,7 @@
             <li class="uk-list-header">
               <div uk-grid>
                 <div class="uk-width-2-5">Name</div>
-                <div class="uk-width-expand">Account ID</div>
+                <div class="uk-width-expand">Address</div>
                 <div class="uk-width-1-6 uk-text-center" style="padding-left: 0;">Actions</div>
               </div>
             </li>
@@ -85,16 +85,16 @@
           <div class="uk-card-body">
             <div class="uk-form-horizontal">
               <div class="uk-margin">
-                <label class="uk-form-label" for="new-address-account">Account ID</label>
+                <label class="uk-form-label" for="new-address-name">Name</label>
                 <div class="uk-form-controls">
-                  <input type="text" class="uk-input" id="new-address-account" [(ngModel)]="newRepAccount" [disabled]="!creatingNewEntry" placeholder="nano_abc123">
+                  <input type="text" class="uk-input" id="new-address-name" [(ngModel)]="newRepName" (keyup.enter)="saveNewRepresentative()" placeholder="Representative Name">
                 </div>
               </div>
 
               <div class="uk-margin">
-                <label class="uk-form-label" for="new-address-name">Name</label>
+                <label class="uk-form-label" for="new-address-account">Address</label>
                 <div class="uk-form-controls">
-                  <input type="text" class="uk-input" id="new-address-name" [(ngModel)]="newRepName" (keyup.enter)="saveNewRepresentative()" placeholder="Representative Name">
+                  <input type="text" class="uk-input" id="new-address-account" [(ngModel)]="newRepAccount" [disabled]="!creatingNewEntry" placeholder="nano_abc123">
                 </div>
               </div>
 

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -144,7 +144,7 @@
                 <button *ngIf="pending.loading" class="uk-button uk-button-secondary uk-disabled uk-button-small nlt-icon-button nlt-icon-button-inline"><span class="spinner" uk-spinner="ratio: 0.5;"></span> Receiving</button>
               </div>
             </ng-template>
-            <td class="amount-column uk-text-middle uk-text-muted" [title]="('Incoming Transaction') + ( (pending.amountRaw && (pending.amountRaw > 0) ) ? ( ', +' + ( pending.amountRaw.toString(10) | squeeze:'5,5' ) + ' raw' ) : '' )">
+            <td class="amount-column uk-text-middle uk-text-muted" [title]="('Incoming Transaction') + ( (pending.amountRaw && (pending.amountRaw > 0) ) ? ( ', +' + ( pending.amountRaw.toString(10) ) + ' raw' ) : '' )">
               <span class="uk-text-small">Ready to receive</span><br>
               <span class="amount-integer">{{ pending.amount | rai: 'mnano,true' | amountsplit: 0 }}</span>
               <span class="amount-fractional">{{ pending.amount | rai: 'mnano,true' | amountsplit: 1 }}</span>

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -164,10 +164,11 @@ export class WalletService {
       && walletAccountIDs.indexOf(transaction.block.account) !== -1) {
         shouldNotify = true;
         await this.processStateBlock(transaction);
+      }
 
-        // Find if the source or destination is a tracked address in the address book
-        // This is a send transaction (to tracked account or from tracked account)
-      } if (walletAccountIDs.indexOf(transaction.block.link_as_account) === -1 && transaction.block.type === 'state' &&
+      // Find if the source or destination is a tracked address in the address book
+      // This is a send transaction (to tracked account or from tracked account)
+      if (walletAccountIDs.indexOf(transaction.block.link_as_account) === -1 && transaction.block.type === 'state' &&
       (transaction.block.subtype === 'send' || transaction.block.subtype === 'receive') || transaction.block.subtype === 'change' &&
       (this.addressBook.getTransactionTrackingById(transaction.block.link_as_account) ||
       this.addressBook.getTransactionTrackingById(transaction.block.account))) {

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -60,6 +60,7 @@ export interface FullWallet {
   pendingBlocks: Block[];
   pendingBlocksUpdate$: BehaviorSubject<boolean|false>;
   newWallet$: BehaviorSubject<boolean|false>;
+  refresh$: BehaviorSubject<boolean|false>;
 }
 
 export interface BaseApiAccount {
@@ -107,10 +108,12 @@ export class WalletService {
     pendingBlocks: [],
     pendingBlocksUpdate$: new BehaviorSubject(false),
     newWallet$: new BehaviorSubject(false),
+    refresh$: new BehaviorSubject(false),
   };
 
   processingPending = false;
   successfulBlocks = [];
+  trackedHashes = [];
 
   constructor(
     private util: UtilService,
@@ -127,21 +130,20 @@ export class WalletService {
       if (!transaction) return; // Not really a new transaction
       console.log('New Transaction', transaction);
       let shouldNotify = false;
-
-      // Find out if this is a send, with our account as a destination or not
-      const walletAccountIDs = this.wallet.accounts.map(a => a.id);
-      // If we have a minimum receive,  once we know the account... add the amount to wallet pending? set pending to true
-
-      if (transaction.block.type === 'state' && transaction.block.subtype === 'send'
-      && walletAccountIDs.indexOf(transaction.block.link_as_account) !== -1) {
-        if (this.appSettings.settings.minimumReceive) {
-          const minAmount = this.util.nano.mnanoToRaw(this.appSettings.settings.minimumReceive);
-          if ((new BigNumber(transaction.amount)).gte(minAmount)) {
-            shouldNotify = true;
-          }
-        } else {
+      if (this.appSettings.settings.minimumReceive) {
+        const minAmount = this.util.nano.mnanoToRaw(this.appSettings.settings.minimumReceive);
+        if ((new BigNumber(transaction.amount)).gte(minAmount)) {
           shouldNotify = true;
         }
+      } else {
+        shouldNotify = true;
+      }
+
+      const walletAccountIDs = this.wallet.accounts.map(a => a.id);
+
+      // If an incoming pending
+      if (transaction.block.type === 'state' && transaction.block.subtype === 'send'
+      && walletAccountIDs.indexOf(transaction.block.link_as_account) !== -1) {
         if (shouldNotify) {
           if (this.wallet.locked && this.appSettings.settings.pendingOption !== 'manual') {
             this.notifications.sendWarning(`New incoming transaction - Unlock the wallet to receive`, { length: 10000, identifier: 'pending-locked' });
@@ -150,21 +152,71 @@ export class WalletService {
           }
         } else {
           console.log(
-            `Found new pending block that was below minimum receive amount: `,
+            `Found new incoming block that was below minimum receive amount: `,
             transaction.amount,
             this.appSettings.settings.minimumReceive
           );
         }
         await this.processStateBlock(transaction);
-      } else if (transaction.block.type === 'state') {
+
+        // If a confirmed outgoing transaction
+      } else if (transaction.block.type === 'state' && transaction.block.subtype === 'send'
+      && walletAccountIDs.indexOf(transaction.block.account) !== -1) {
         shouldNotify = true;
         await this.processStateBlock(transaction);
+
+        // Find if the source or destination is a tracked address in the address book
+        // This is a send transaction (to tracked account or from tracked account)
+      } if (walletAccountIDs.indexOf(transaction.block.link_as_account) === -1 && transaction.block.type === 'state' &&
+      (transaction.block.subtype === 'send' || transaction.block.subtype === 'receive') || transaction.block.subtype === 'change' &&
+      (this.addressBook.getTransactionTrackingById(transaction.block.link_as_account) ||
+      this.addressBook.getTransactionTrackingById(transaction.block.account))) {
+        if (shouldNotify || transaction.block.subtype === 'change') {
+          const trackedAmount = this.util.nano.rawToMnano(transaction.amount);
+          // Save hash so we can ignore duplicate messages if subscribing to both send and receive
+          if (this.trackedHashes.indexOf(transaction.hash) !== -1) return; // Already notified this block
+          this.trackedHashes.push(transaction.hash);
+          const addressLink = transaction.block.link_as_account;
+          const address = transaction.block.account;
+          const rep = transaction.block.representative;
+          const accountHrefLink = `<a href="/account/${addressLink}">${this.addressBook.getAccountName(addressLink)}</a>`;
+          const accountHref = `<a href="/account/${address}">${this.addressBook.getAccountName(address)}</a>`;
+
+          if (transaction.block.subtype === 'send') {
+            // Incoming transaction
+            if (this.addressBook.getTransactionTrackingById(addressLink)) {
+              this.notifications.sendInfo(`Tracked address ${accountHrefLink} can now receive ${trackedAmount} NANO`, { length: 10000 });
+              console.log(`Tracked incoming block to: ${address} - ${trackedAmount} Nano`);
+            }
+            // Outgoing transaction
+            if (this.addressBook.getTransactionTrackingById(address)) {
+              this.notifications.sendInfo(`Tracked address ${accountHref} sent ${trackedAmount} NANO`, { length: 10000 });
+              console.log(`Tracked send block from: ${address} - ${trackedAmount} Nano`);
+            }
+          } else if (transaction.block.subtype === 'receive' && this.addressBook.getTransactionTrackingById(address)) {
+            // Receive transaction
+            this.notifications.sendInfo(`Tracked address ${accountHref} received incoming ${trackedAmount} NANO`, { length: 10000 });
+            console.log(`Tracked receive block to: ${address} - ${trackedAmount} Nano`);
+          } else if (transaction.block.subtype === 'change' && this.addressBook.getTransactionTrackingById(address)) {
+            // Change transaction
+            this.notifications.sendInfo(`Tracked address ${accountHref} changed its representative to ${rep}`, { length: 10000 });
+            console.log(`Tracked change block of: ${address} - Rep: ${rep}`);
+          }
+        } else {
+          console.log(
+            `Found new transaction on watch-only account that was below minimum receive amount: `,
+            transaction.amount,
+            this.appSettings.settings.minimumReceive
+          );
+        }
       }
 
       // TODO: We don't really need to call to update balances, we should be able to balance on our own from here
       // I'm not sure about that because what happens if the websocket is disconnected and misses a transaction?
       // won't the balance be incorrect if relying only on the websocket? / Json
-      if (shouldNotify) {
+
+      // Only reload balance if the incoming is to an internal wallet (to avoid RPC spam)
+      if (shouldNotify && walletAccountIDs.indexOf(transaction.block.link_as_account) !== -1) {
         await this.reloadBalances();
       }
     });
@@ -798,6 +850,7 @@ export class WalletService {
     if (this.wallet.pendingBlocks.length) {
       await this.processPendingBlocks();
     }
+    this.informBalanceRefresh();
   }
 
   async loadWalletAccount(accountIndex, accountID) {
@@ -879,6 +932,16 @@ export class WalletService {
     this.saveWalletExport();
 
     return true;
+  }
+
+  async trackAddress(address: string) {
+    this.websocket.subscribeAccounts([address]);
+    console.log('Tracking transactions on ' + address);
+  }
+
+  async untrackAddress(address: string) {
+    this.websocket.unsubscribeAccounts([address]);
+    console.log('Stopped tracking transactions on ' + address);
   }
 
   addPendingBlock(accountID, blockHash, amount, source) {
@@ -1019,5 +1082,11 @@ export class WalletService {
   informNewWallet() {
     this.wallet.newWallet$.next(true);
     this.wallet.newWallet$.next(false);
+  }
+
+  // Subscribable event when balances has been refreshed
+  informBalanceRefresh() {
+    this.wallet.refresh$.next(true);
+    this.wallet.refresh$.next(false);
   }
 }

--- a/src/app/services/websocket.service.ts
+++ b/src/app/services/websocket.service.ts
@@ -81,7 +81,7 @@ export class WebsocketService {
         const newEvent = JSON.parse(event.data);
         console.log('WS', newEvent);
 
-        if (newEvent.topic === 'confirmation' && newEvent.message.block.subtype === 'send') {
+        if (newEvent.topic === 'confirmation') {
           this.newTransactions$.next(newEvent.message);
         }
       } catch (err) {
@@ -115,7 +115,8 @@ export class WebsocketService {
       action: 'subscribe',
       topic: 'confirmation',
       options: {
-        accounts: accountIDs
+        accounts: accountIDs,
+        confirmation_type: 'active_quorum'
       }
     };
 

--- a/src/app/services/websocket.service.ts
+++ b/src/app/services/websocket.service.ts
@@ -115,8 +115,7 @@ export class WebsocketService {
       action: 'subscribe',
       topic: 'confirmation',
       options: {
-        accounts: accountIDs,
-        confirmation_type: 'active_quorum'
+        accounts: accountIDs
       }
     };
 


### PR DESCRIPTION
Allows the user to add any address on the Nano network to track the balance and / or any transaction that occur. Works with or without a wallet set up and does not mix with the real accounts to avoid confusion.

* Utilizes the address book to separate from normal accounts
* Subscribing to websocket to know when confirmed blocks
* Allow optional balance and/or transaction tracking
* Show individual balance or total
* Display notifications for SEND, RECEIVE and CHANGE
* Balances refreshes automatically for internal accounts
* Manual refresh for external addresses (don't want spam RPC)
* Settings stored when exporting/importing address book
* Total tracked balance is hidden by default
* Removed squeezing of additional raw amounts

Fixes #374 

![address](https://user-images.githubusercontent.com/2406720/119628046-099bf480-be0d-11eb-8a2e-ab4830b8c119.png)
![add](https://user-images.githubusercontent.com/2406720/119628071-0f91d580-be0d-11eb-99a3-1185d859198f.png)
![note3](https://user-images.githubusercontent.com/2406720/119628124-191b3d80-be0d-11eb-84c1-c464bb72cc90.png)
![image](https://user-images.githubusercontent.com/2406720/119629745-96937d80-be0e-11eb-97a1-f8808406f74d.png)
![image](https://user-images.githubusercontent.com/2406720/119629851-b4f97900-be0e-11eb-817c-a338b9fda050.png)
