### PR TITLE
Support UTF-16 characters in address book export

### DIFF
--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -33,7 +33,7 @@
                   <div class="uk-inline uk-width-1-1">
                     <a class="uk-form-icon uk-form-icon-flip uk-text-success" (click)="saveAddressBook()" uk-icon="icon: check" uk-tooltip title="Save Changes"></a>
                     <a class="uk-form-icon uk-form-icon-flip uk-text-danger" style="margin-right: 26px;" (click)="showEditAddressBook = false" uk-tooltip title="Cancel Changes - To remove the label, leave the text field blank and save changes" uk-icon="icon: close"></a>
-                    <input class="uk-input" (keyup.enter)="saveAddressBook()" [(ngModel)]="addressBookModel" placeholder="Address Book Name (Leave blank to remove)" type="text" style="padding-right: 60px;">
+                    <input class="uk-input" (keyup.enter)="saveAddressBook()" [(ngModel)]="addressBookModel" placeholder="Address Book Name (Leave blank to remove)" type="text" style="padding-right: 60px;" maxlength="64">
                   </div>
                 </div>
               </div>

--- a/src/app/components/address-book/address-book.component.html
+++ b/src/app/components/address-book/address-book.component.html
@@ -154,7 +154,7 @@
               <div class="uk-margin">
                 <label class="uk-form-label" for="new-address-name">Name</label>
                 <div class="uk-form-controls">
-                  <input type="text" class="uk-input" id="new-address-name" [(ngModel)]="newAddressName" (keyup.enter)="saveNewAddress()" placeholder="Exchange Deposit Address, Main Trading Account, etc">
+                  <input type="text" class="uk-input" id="new-address-name" [(ngModel)]="newAddressName" (keyup.enter)="saveNewAddress()" placeholder="Exchange Deposit Address, Main Trading Account, etc" maxlength="64">
                 </div>
               </div>
 
@@ -215,18 +215,19 @@
           </div>
           <div class="uk-card-body">
             <p>Export all address book entries to a file or QR Code/URL.<br><br>Note: Exported address book will NOT be encrypted by your wallet password.</p>
-            <div *ngIf="addressBookShowQRExport" uk-grid>
+            <div *ngIf="addressBookShowFileExport" uk-grid>
               <div class="uk-width-1-1">
                 <hr class="uk-divider-icon">
               </div>
 
               <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
-                <img [src]="addressBookQRExportImg" alt="QR code" style="border-radius: 6px;">
+                <img *ngIf="addressBookShowQRExport" [src]="addressBookQRExportImg" alt="QR code" style="border-radius: 6px;">
+                <span *ngIf="!addressBookShowQRExport" class="uk-text-warning">Address book too large for a QR code.<br>If you need a QR,<br>use fewer entries or shorter aliases.<br></span>
               </div>
               <div class="uk-width-1-1@s uk-width-1-2@m uk-width-2-3@l">
-                Scan the QR code on any device to import your address book!<br>
-                <br>
-                You can also import your address book by using the URL below.
+                <span *ngIf="addressBookShowQRExport">Scan the QR code on any device to import your address book!<br><br></span>
+                <span *ngIf="addressBookShowQRExport">You can also import your address book by using the URL below or download it as a file.</span>
+                <span *ngIf="!addressBookShowQRExport">You can still import your address book by using the URL below or download it as a file.</span>
                 <br><br>
                 <input type="text" class="uk-input" style="max-width: 750px;" value="{{ addressBookQRExportUrl }}"><br>
                 <div class="nlt-button-group uk-margin-small-top">

--- a/src/app/components/import-address-book/import-address-book.component.html
+++ b/src/app/components/import-address-book/import-address-book.component.html
@@ -21,13 +21,13 @@
         </p>
         <p class="uk-text-center">
           <span class="import-warning" *ngIf="conflictingEntries">
-            {{ conflictingEntries }} Labels already exist and will have their name changed.
+            {{ conflictingEntries }} entries already exist but will have their name and/or tracking settings changed.
           </span>
           <span class="import-warning" *ngIf="newEntries">
-            {{ newEntries }} New labels will be added.
+            {{ newEntries }} New entries will be added.
           </span>
           <span class="import-warning" *ngIf="existingEntries">
-            {{ existingEntries }} Labels already exist and will not be modified.
+            {{ existingEntries }} entries already exist and will not be modified.
           </span>
         </p>
 
@@ -36,14 +36,14 @@
             <ul class="uk-list uk-list-striped" style="margin-bottom: 0;">
               <li class="uk-list-header">
                 <div uk-grid>
-                  <div class="uk-width-1-4">New Label</div>
-                  <div class="uk-width-1-4">Current Label</div>
-                  <div class="uk-width-1-2 uk-text-truncate" style="padding-left: 0;">Account</div>
+                  <div class="uk-width-1-4">New Name</div>
+                  <div class="uk-width-1-4">Current Name</div>
+                  <div class="uk-width-1-2 uk-text-truncate">Account</div>
                 </div>
               </li>
             </ul>
             <ul class="uk-list uk-list-striped" style="margin-top: 0;">
-              <li *ngFor="let entry of importData" [ngClass]="{ 'uk-text-success': !entry.originalName, 'uk-text-warning': entry.originalName && entry.originalName !== entry.name, 'uk-text-muted': entry.originalName == entry.name }">
+              <li *ngFor="let entry of importData" [ngClass]="{ 'uk-text-success': !entry.originalName, 'uk-text-warning': entry.originalName && (entry.originalName !== entry.name || entry.originalTrackBalance !== entry.trackBalance || entry.originalTrackTransactions !== entry.trackTransactions), 'uk-text-muted': entry.originalName === entry.name &&  entry.originalTrackBalance === entry.trackBalance && entry.originalTrackTransactions === entry.trackTransactions}">
                 <div uk-grid>
                   <div class="uk-width-1-4 uk-text-truncate">
                     {{ entry.name }}


### PR DESCRIPTION
Beyond ASCII by using 2-byte binary
* Backward compatible
* Improved address book importer (respect changes in tracking settings)
* Improved address book exporter (disable QR and enable file export for large address book)
* Limits account names to 64 characters
* New format is 2x larger which affects the QR limit but not much to do

**Normal:**
![image](https://user-images.githubusercontent.com/2406720/120707750-0531a480-c4bb-11eb-97db-cc318ca506fb.png)

**Large:**
![image](https://user-images.githubusercontent.com/2406720/120707788-0bc01c00-c4bb-11eb-8237-d0667ac6e9dd.png)

Fixes #393 