### PR TITLE
Fixed: natricon size too big on mobile devices

### DIFF
--- a/src/app/components/helpers/nano-identicon/nano-identicon.component.css
+++ b/src/app/components/helpers/nano-identicon/nano-identicon.component.css
@@ -1,5 +1,6 @@
 img.natricon {
 	transform: scale(1.5) translateY(4%);
+	max-height: 100%;
 }
 
 .natricon-placeholder > img {


### PR DESCRIPTION
This PR fixes #400.

The issue is caused by this uikit CSS rule:
```
canvas, img, video {
    max-width: 100%;
    height: auto;
}
```