### PR TITLE
Auto-remove pending while receiving

### DIFF
--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -90,7 +90,7 @@
           </tr>
           </thead>
           <tbody>
-          <tr *ngFor="let pending of pendingBlocksForSelectedAccount" [class]="{ 'uk-text-muted': true, 'uk-hidden': pending.received }">
+          <tr *ngFor="let pending of pendingBlocksForSelectedAccount" [class]="{ 'uk-text-muted': true }">
             <td class="type-column">
               <span class="type uk-text-small" uk-icon="icon: plus-circle; ratio: 1.2;"></span>
             </td>

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -255,11 +255,11 @@ export class ReceiveComponent implements OnInit {
     const newBlock = await this.nanoBlock.generateReceive(walletAccount, sourceBlock, this.walletService.isLedgerWallet());
 
     if (newBlock) {
-      pendingBlock.received = true;
       this.notificationService.removeNotification('success-receive');
       this.notificationService.sendSuccess(`Successfully received Nano!`, { identifier: 'success-receive' });
-      // clear the list of pending blocks. Updated again with reloadBalances()
-      this.walletService.clearPendingBlocks();
+      // pending has been processed, can be removed from the list
+      // list also updated with reloadBalances but not if called too fast
+      this.walletService.removeLastPending();
     } else {
       if (!this.walletService.isLedgerWallet()) {
         this.notificationService.sendError(`There was a problem receiving the transaction, try manually!`, {length: 10000});
@@ -269,6 +269,7 @@ export class ReceiveComponent implements OnInit {
     pendingBlock.loading = false;
 
     await this.walletService.reloadBalances();
+    this.updatePendingBlocks(); // update the list
   }
 
   copied() {

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -252,14 +252,14 @@ export class ReceiveComponent implements OnInit {
     }
     pendingBlock.loading = true;
 
-    const newBlock = await this.nanoBlock.generateReceive(walletAccount, sourceBlock, this.walletService.isLedgerWallet());
+    const newHash = await this.nanoBlock.generateReceive(walletAccount, sourceBlock, this.walletService.isLedgerWallet());
 
-    if (newBlock) {
+    if (newHash) {
       this.notificationService.removeNotification('success-receive');
       this.notificationService.sendSuccess(`Successfully received Nano!`, { identifier: 'success-receive' });
       // pending has been processed, can be removed from the list
       // list also updated with reloadBalances but not if called too fast
-      this.walletService.removeLastPending();
+      this.walletService.removePendingBlock(pendingBlock.hash);
     } else {
       if (!this.walletService.isLedgerWallet()) {
         this.notificationService.sendError(`There was a problem receiving the transaction, try manually!`, {length: 10000});
@@ -267,7 +267,6 @@ export class ReceiveComponent implements OnInit {
     }
 
     pendingBlock.loading = false;
-
     await this.walletService.reloadBalances();
     this.updatePendingBlocks(); // update the list
   }

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -969,11 +969,6 @@ export class WalletService {
     this.wallet.pendingBlocks.splice(0, this.wallet.pendingBlocks.length);
   }
 
-  // Remove the last pending from the list
-  removeLastPending() {
-    this.wallet.pendingBlocks.shift();
-  }
-
   sortByAmount(a, b) {
     const x = new BigNumber(a.amount);
     const y = new BigNumber(b.amount);
@@ -1011,7 +1006,7 @@ export class WalletService {
 
       // remove after processing
       // list also updated with reloadBalances but not if called too fast
-      this.wallet.pendingBlocks.shift();
+      this.removePendingBlock(nextBlock.hash);
       await this.reloadBalances();
       this.wallet.pendingBlocksUpdate$.next(true);
       this.wallet.pendingBlocksUpdate$.next(false);

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -962,11 +962,15 @@ export class WalletService {
   async removePendingBlock(blockHash) {
     const index = this.wallet.pendingBlocks.findIndex(b => b.hash === blockHash);
     this.wallet.pendingBlocks.splice(index, 1);
+    this.wallet.pendingBlocksUpdate$.next(true);
+    this.wallet.pendingBlocksUpdate$.next(false);
   }
 
   // Clear the list of pending blocks
   async clearPendingBlocks() {
     this.wallet.pendingBlocks.splice(0, this.wallet.pendingBlocks.length);
+    this.wallet.pendingBlocksUpdate$.next(true);
+    this.wallet.pendingBlocksUpdate$.next(false);
   }
 
   sortByAmount(a, b) {


### PR DESCRIPTION
This removes pending from the list while auto receiving them. This is done by calling the subscription function for pending blocks from the reloadBalances function (via clearPendingBlocks). It's not a perfect solution since the reload function first clears the pending list and then adds back any pending that exist. This means the list will flash for some milliseconds before the pending are added back in. Would be better if each item was more nicely removed but it's complicated. The advantage of doing it this way is it will also work if some other wallet is receiving at the same time. The pending will always be correct.

removePendingBlock() is not used anywhere in the wallet but added it there as well in case it will be used in the future.

Fixes #402 