### PR TITLE
Add "Copy address" button to Receive page for mobile devices

### DIFF
--- a/src/app/components/receive/receive.component.css
+++ b/src/app/components/receive/receive.component.css
@@ -42,6 +42,9 @@
     display: flex;
     flex-direction: column;
 }
+.qr-column {
+    margin-top: 15px;
+}
 @media (min-width: 640px) {
     .receive-columns {
         flex-direction: row-reverse;
@@ -50,6 +53,7 @@
         width: 0;
         max-width: 360px;
         margin-right: 20px;
+        margin-top: 0;
     }
 }
 
@@ -65,7 +69,10 @@
 }
 .qr-address {
     max-width: 280px;
-    margin: 0 auto;
+    margin: 25px auto 0 auto;
+}
+.copy-address-button {
+    margin-top: 25px;
 }
 @media (max-width: 959px) {
     .qr-code {
@@ -112,7 +119,7 @@
     animation: slideup 1.2s;
 }
 .qr-confirmation.out {
-    animation: fadeout 5s;
+    animation: fadeout 1s;
 }
 
 @keyframes slidedown {

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -35,27 +35,43 @@
             </div>
           </div>
 
-          <div class="uk-flex-1 uk-margin qr-column">
+          <div class="uk-flex-1 qr-column">
             <div *ngIf="qrCodeImage; else placeholder">
               <div class="qr-code">
+                <img class="uk-position-absolute" [src]="qrCodeImage" alt="QR code">
                 <div class="qr-confirmation" [class]="qrSuccessClass">
                   <div uk-icon="icon: check; ratio: 5"></div>
                   <span class="uk-text-large uk-text-center">Nano Received</span>
                 </div>
-                <img [src]="qrCodeImage" alt="QR code">
-              </div>
-              <br>
-              <div class="uk-flex uk-flex-center uk-flex-middle uk-text-center qr-address">
-                <app-nano-account-id [accountID]="pendingAccountModel" middle="break" class="nano-address-monospace uk-width-auto" style="max-width: 90%;"></app-nano-account-id>
-                <a class="span-icon" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
+                <div style="padding-top: 100%"></div>
               </div>
             </div>
             <ng-template #placeholder>
               <div class="qr-code qr-placeholder">
-                <div class="uk-position-absolute text-half-muted">Select an account<br/>to view QR code</div>
+                <div class="uk-position-absolute text-half-muted" *ngIf="(pendingAccountModel === '0')">Select an account<br/>to view QR code</div>
+                <div class="uk-position-absolute text-half-muted" *ngIf="(pendingAccountModel !== '0')"><div uk-spinner="ratio: 3;"></div></div>
                 <div style="padding-top: 100%"></div>
               </div>
             </ng-template>
+            <div *ngIf="(pendingAccountModel !== '0')">
+              <div class="uk-flex uk-flex-center uk-flex-middle uk-text-center qr-address">
+                <app-nano-account-id [accountID]="pendingAccountModel" middle="break" class="nano-address-monospace uk-width-auto" style="max-width: 90%;"></app-nano-account-id>
+                <a class="span-icon hide-on-small-viewports" ngxClipboard [cbContent]="pendingAccountModel" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a>
+              </div>
+              <div class="only-on-small-viewports uk-text-center">
+                <button
+                  class="copy-address-button uk-width-1-1 uk-width-4-5@s uk-button uk-button-primary uk-text-center"
+                  [class.nlt-button-success]="recentlyCopiedAccountAddress"
+                  [class.uk-disabled]="recentlyCopiedAccountAddress"
+                  type="button"
+                  ngxClipboard
+                  [cbContent]="pendingAccountModel"
+                  (cbOnSuccess)="copiedAccountAddress()"
+                >
+                  {{ recentlyCopiedAccountAddress ? 'Copied!' : 'Copy address' }}
+                </button>
+              </div>
+            </div>
           </div>
                   
         </div>

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -25,12 +25,14 @@ export class ReceiveComponent implements OnInit {
   nano = 1000000000000000000000000;
   accounts = this.walletService.wallet.accounts;
 
+  timeoutIdClearingRecentlyCopiedState: any = null;
   pendingAccountModel = '0';
   pendingBlocks = [];
   pendingBlocksForSelectedAccount = [];
   qrCodeImage = null;
   qrAccount = '';
   qrAmount: BigNumber = null;
+  recentlyCopiedAccountAddress = false;
   walletAccount: WalletAccount = null;
   selAccountInit = false;
   loadingIncomingTxList = false;
@@ -208,6 +210,7 @@ export class ReceiveComponent implements OnInit {
     let qrCode = null;
     if (account.length > 1) {
       this.qrAccount = account;
+      this.qrCodeImage = null;
       qrCode = await QRCode.toDataURL(`nano:${account}${this.qrAmount ? `?amount=${this.qrAmount.toString(10)}` : ''}`, {scale: 7});
     }
     this.qrCodeImage = qrCode;
@@ -222,6 +225,7 @@ export class ReceiveComponent implements OnInit {
       }
     }
     if (this.qrAccount.length > 1) {
+      this.qrCodeImage = null;
       qrCode = await QRCode.toDataURL(`nano:${this.qrAccount}${this.qrAmount ? `?amount=${this.qrAmount.toString(10)}` : ''}`, {scale: 7});
       this.qrCodeImage = qrCode;
     }
@@ -274,6 +278,19 @@ export class ReceiveComponent implements OnInit {
   copied() {
     this.notificationService.removeNotification('success-copied');
     this.notificationService.sendSuccess(`Successfully copied to clipboard!`, { identifier: 'success-copied' });
+  }
+
+  copiedAccountAddress() {
+    if (this.timeoutIdClearingRecentlyCopiedState != null) {
+      clearTimeout(this.timeoutIdClearingRecentlyCopiedState);
+    }
+    this.recentlyCopiedAccountAddress = true;
+    this.timeoutIdClearingRecentlyCopiedState = setTimeout(
+      () => {
+        this.recentlyCopiedAccountAddress = false;
+      },
+      2000
+    );
   }
 
   toBigNumber(value) {

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -1490,6 +1490,10 @@ input[type=number] {
 	}
 }
 
+.nlt-button-success {
+	background-color: #16A670 !important;
+}
+
 .nlt-page-intro {
 	margin-bottom: @nlt-intro-margin;
 }


### PR DESCRIPTION
Fixes #438

![image](https://user-images.githubusercontent.com/29272208/126691430-7d592f01-d650-4bb3-a58d-5010b2660212.png)

Fix "Select an account" placeholder being shown while qr image is generated even if an account is selected, now displaying a spinner icon instead
Fix address not being shown while qr image is being generated
Fix layout jumping when qr image isn't taking up any space during qr load
Reset existing qr code when generating a new one
Reduce confirmation overlay fade out duration from 5 to 1 second
Remove unnecessary margins