### PR TITLE
Upscale nanoidenticons when devicePixelRatio is higher than 1

### DIFF
--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -62,7 +62,7 @@
 
           <app-nano-identicon scale="12" [accountID]="accountID" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
 
-          <div class="uk-width-expand">
+          <div class="uk-width-1-1 uk-width-expand@s">
 
             <div
               *ngIf="walletAccount && (addressBookEntry || showEditAddressBook)"

--- a/src/app/components/helpers/nano-identicon/nano-identicon.component.ts
+++ b/src/app/components/helpers/nano-identicon/nano-identicon.component.ts
@@ -38,9 +38,15 @@ export class NanoIdenticonComponent implements OnChanges, AfterViewInit {
 
     this.renderedIdenticon = this.accountID;
 
+    const scale =
+      Math.max(
+        Math.ceil(this.scale * window.devicePixelRatio),
+        this.scale
+      );
+
     const canvas = createIcon({
       seed: this.accountID,
-      scale: this.scale,
+      scale,
     });
 
     const canvasContainerNative = this.canvasContainer.nativeElement;

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -935,12 +935,6 @@ input[type=number] {
 			border-radius: 6px;
 		}
 	}
-
-	@media (max-width: 599px) {
-		.nano-identicon {
-			flex-basis: 100%;
-		}
-	}
 }
 
 .transactions-list-header {


### PR DESCRIPTION
Fixes #423

to test this:

1. open a nault page with nanoidenticons (e.g. transactions list)
2. zoom in to ~170%
3. observe that the identicons are blurry

![image](https://user-images.githubusercontent.com/29272208/126772211-fde14260-87e5-4ff1-a879-248be41ccead.png)

4. refresh, causing new identicons to generate
5. observe that the identicons are crisp

![image](https://user-images.githubusercontent.com/29272208/126772274-46aa47af-766d-4dce-9362-b74f9805c4b9.png)


