### PR TITLE
Export account transaction history as csv files

### DIFF
--- a/src/app/components/manage-wallet/manage-wallet.component.css
+++ b/src/app/components/manage-wallet/manage-wallet.component.css
@@ -1,0 +1,3 @@
+.narrow-div {
+  margin-top: 0px;
+}

--- a/src/app/components/manage-wallet/manage-wallet.component.html
+++ b/src/app/components/manage-wallet/manage-wallet.component.html
@@ -170,12 +170,12 @@
               </div>
             </div>
           </div>
-
-          <div class="uk-width-1-1 narrow-div">
-            <button *ngIf="!exportingCsv" class="uk-button uk-button-primary uk-width-1-1" type="button" [disabled]="!settings.settings.serverAPI" (click)="exportToCsv()">{{settings.settings.serverAPI ? 'EXPORT HISTORY':'NOT AVAILABLE IN OFFLINE MODE'}}</button>
-            <button *ngIf="exportingCsv" class="uk-button uk-button-primary uk-disabled uk-width-1-1" type="button"><span class="uk-margin-right" uk-spinner></span> FETCHING HISTORY...</button>
-          </div>
         </div>
+      </div>
+
+      <div class="uk-card-footer uk-text-right@s uk-text-center nlt-button-group">
+        <button *ngIf="!exportingCsv" class="uk-button uk-button-primary uk-width-1-1@s uk-width-auto@m uk-float-right" type="button" [disabled]="!settings.settings.serverAPI" (click)="exportToCsv()">{{settings.settings.serverAPI ? 'EXPORT HISTORY':'NOT AVAILABLE IN OFFLINE MODE'}}</button>
+        <button *ngIf="exportingCsv" class="uk-button uk-button-secondary uk-disabled uk-width-1-1@s uk-width-auto@m uk-float-right nlt-icon-button nlt-icon-button-inline" type="button"><span class="uk-margin-right" uk-spinner="ratio: 0.5;"></span> FETCHING HISTORY...</button>
       </div>
     </div>
 

--- a/src/app/components/manage-wallet/manage-wallet.component.html
+++ b/src/app/components/manage-wallet/manage-wallet.component.html
@@ -127,7 +127,7 @@
           <div class="uk-width-1-1 narrow-div">
             <div class="uk-form-horizontal">
               <div class="uk-margin">
-                <label class="uk-form-label" for="account">Account <span uk-icon="icon: info;" uk-tooltip title="Select a local account to export transaction history for."></span></label>
+                <label class="uk-form-label" for="account">Account</label>
                 <div class="uk-form-controls">
                   <select class="uk-select" id="account" [(ngModel)]="csvAccount">
                     <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO)</option>
@@ -140,7 +140,7 @@
           <div class="uk-width-1-1 narrow-div">
             <div class="uk-form-horizontal">
               <div class="uk-margin">
-                <label class="uk-form-label" for="tx-count">Limit <span uk-icon="icon: info;" uk-tooltip title="Maximum number of transactions to export. Blank or 0 equals unlimited but only effective if using a custom server."></span></label>
+                <label class="uk-form-label" for="tx-count">Transaction Limit <span uk-icon="icon: info;" uk-tooltip title="Maximum number of transactions to export. Blank or 0 equals unlimited but only effective if using a custom server."></span></label>
                 <div class="uk-form-controls">
                   <div class="uk-inline uk-width-1-1">
                     <input [(ngModel)]="csvCount" class="uk-input uk-margin-small-bottom {{invalidCsvCount ? 'uk-form-danger':''}}" id="tx-count" type="text" (ngModelChange)="csvCountChange(csvCount)" placeholder="" autocomplete="off">
@@ -153,7 +153,7 @@
           <div class="uk-width-1-1 narrow-div">
             <div class="uk-form-horizontal">
               <div class="uk-margin">
-                <label class="uk-form-label" for="tx-order">Order <span uk-icon="icon: info;" uk-tooltip title="The order to export transactions. Newest transaction means highest block height."></span></label>
+                <label class="uk-form-label" for="tx-order">Transaction Order</label>
                 <div class="uk-form-controls">
                   <div class="uk-inline uk-width-1-1">
                     <select class="uk-select" [(ngModel)]="selectedOrder" id="tx-order">

--- a/src/app/components/manage-wallet/manage-wallet.component.html
+++ b/src/app/components/manage-wallet/manage-wallet.component.html
@@ -109,5 +109,90 @@
       </ng-template>
     </div>
 
+    <div class="uk-card uk-card-default uk-margin" *ngIf="!walletService.isLedgerWallet()">
+      <div class="uk-card-header">
+        <h3 class="uk-card-title">Export Transaction History</h3>
+      </div>
+      <div class="uk-card-body">
+        <p>
+          Each account in the wallet can be exported individually to a csv file.<br>
+          Due to limitations in Nault backend servers, you can only request 500 transactions per export.<br>
+          However, you can use an offset of 500 to continue exporting 501 to 1000 and so on. Another way is connecting Nault to your own Nano node for unlimited history.<br>
+        </p>
+        <div uk-grid>
+          <div class="uk-width-1-1 narrow-div">
+            <div class="uk-form-horizontal">
+              <div class="uk-margin">
+                <label class="uk-form-label" for="account">Account <span uk-icon="icon: info;" uk-tooltip title="Only local accounts are available for export."></span></label>
+                <div class="uk-form-controls">
+                  <select class="uk-select" id="account" [(ngModel)]="csvAccount">
+                    <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO)</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="uk-width-1-1 narrow-div">
+            <div class="uk-form-horizontal">
+              <div class="uk-margin">
+                <label class="uk-form-label" for="tx-count">Limit <span uk-icon="icon: info;" uk-tooltip title="Maximum number of transactions to export. Leave blank for unlimited but only available if using a custom Nault backend."></span></label>
+                <div class="uk-form-controls">
+                  <div class="uk-inline uk-width-1-1">
+                    <input [(ngModel)]="csvCount" class="uk-input uk-margin-small-bottom" id="tx-count" type="text" placeholder="500" autocomplete="off">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="uk-width-1-1 narrow-div">
+            <div class="uk-form-horizontal">
+              <div class="uk-margin">
+                <label class="uk-form-label" for="tx-offset">Offset (optional) <span uk-icon="icon: info;" uk-tooltip title="Start the export after this index. 500 means starting at transaction 501. Leaving blank equals 0."></span></label>
+                <div class="uk-form-controls">
+                  <div class="uk-inline uk-width-1-1">
+                    <input [(ngModel)]="csvOffset" class="uk-input uk-margin-small-bottom" id="tx-offset" type="text" placeholder="" autocomplete="off">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="uk-width-1-1 narrow-div">
+            <div class="uk-form-horizontal">
+              <div class="uk-margin">
+                <label class="uk-form-label" for="filter">Account Filter (optional) <span uk-icon="icon: info;" uk-tooltip title="Comma separated list of accounts to match against (SEND or RECEIVE). Other transactions will be excluded from the export. Available if using a custom Nault backend."></span></label>
+                <div class="uk-form-controls">
+                  <div class="uk-width-1-1">
+                    <div class="uk-inline uk-width-1-1">
+                      <input [(ngModel)]="csvFilter" class="uk-input uk-margin-small-bottom {{invalidFilter ? 'uk-form-danger':''}}" id="filter" type="text" (ngModelChange)="csvFilterChange(sourceWallet)" placeholder="nano_1abc,nano_1def" autocomplete="off">
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="uk-width-1-1 narrow-div">
+            <div class="uk-form-horizontal">
+              <div class="uk-margin">
+                <label class="uk-form-label" for="tx-reverse">Reversed (optional) <span uk-icon="icon: info;" uk-tooltip title="The default (unchecked) order is starting with the latest transaction and searching back in time."></span></label>
+                <div class="uk-form-controls">
+                  <div class="uk-inline uk-width-1-1">
+                    <input class="uk-checkbox" type="checkbox" id="tx-reverse" name="tx-reverse" value="1" [(ngModel)]="csvReversed">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="uk-width-1-1 narrow-div">
+            <button class="uk-button uk-button-primary uk-width-1-1" type="button"> Export to File</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
 </div>

--- a/src/app/components/manage-wallet/manage-wallet.component.html
+++ b/src/app/components/manage-wallet/manage-wallet.component.html
@@ -111,7 +111,7 @@
 
     <div class="uk-card uk-card-default uk-margin" *ngIf="!walletService.isLedgerWallet()">
       <div class="uk-card-header">
-        <h3 class="uk-card-title">Export Transaction History (csv files)</h3>
+        <h3 class="uk-card-title">Export Transaction History (CSV file)</h3>
       </div>
       <div class="uk-card-body">
         <p>
@@ -172,7 +172,7 @@
           </div>
 
           <div class="uk-width-1-1 narrow-div">
-            <button *ngIf="!exportingCsv" class="uk-button uk-button-primary uk-width-1-1" type="button" [disabled]="!settings.settings.serverAPI" (click)="exportToCsv()">{{settings.settings.serverAPI ? 'EXPORT TO FILE':'NOT AVAILABLE IN OFFLINE MODE'}}</button>
+            <button *ngIf="!exportingCsv" class="uk-button uk-button-primary uk-width-1-1" type="button" [disabled]="!settings.settings.serverAPI" (click)="exportToCsv()">{{settings.settings.serverAPI ? 'EXPORT HISTORY':'NOT AVAILABLE IN OFFLINE MODE'}}</button>
             <button *ngIf="exportingCsv" class="uk-button uk-button-primary uk-disabled uk-width-1-1" type="button"><span class="uk-margin-right" uk-spinner></span> FETCHING HISTORY...</button>
           </div>
         </div>

--- a/src/app/components/manage-wallet/manage-wallet.component.html
+++ b/src/app/components/manage-wallet/manage-wallet.component.html
@@ -48,7 +48,7 @@
       </div>
     </div>
 
-    <div class="uk-card uk-card-default uk-margin">
+    <div class="uk-card uk-card-default uk-margin" *ngIf="!walletService.isLedgerWallet()">
       <div class="uk-card-header">
         <h3 class="uk-card-title">Export Nault Wallet</h3>
       </div>
@@ -109,7 +109,7 @@
       </ng-template>
     </div>
 
-    <div class="uk-card uk-card-default uk-margin" *ngIf="!walletService.isLedgerWallet()">
+    <div class="uk-card uk-card-default uk-margin">
       <div class="uk-card-header">
         <h3 class="uk-card-title">Export Transaction History</h3>
       </div>

--- a/src/app/components/manage-wallet/manage-wallet.component.html
+++ b/src/app/components/manage-wallet/manage-wallet.component.html
@@ -111,9 +111,14 @@
 
     <div class="uk-card uk-card-default uk-margin" *ngIf="!walletService.isLedgerWallet()">
       <div class="uk-card-header">
-        <h3 class="uk-card-title">Export Transaction History (CSV file)</h3>
+        <h3 class="uk-card-title">Export Transaction History</h3>
       </div>
-      <div class="uk-card-body">
+      <div *ngIf="!csvExportStarted" class="uk-card-body">
+        <p>
+          Use this tool to export the transaction history of a specific account as a CSV file.
+        </p>
+      </div>
+      <div *ngIf="csvExportStarted" class="uk-card-body">
         <p>
           Due to limitations in backend servers, you can only request {{transactionHistoryLimit}} transactions per export.<br>
           However, you can use an offset of X to continue exporting from (X + 1). Another way is connecting Nault to a <a routerLink="/configure-app" routerLinkActive="active">custom server</a> for unlimited history.<br>
@@ -148,10 +153,12 @@
           <div class="uk-width-1-1 narrow-div">
             <div class="uk-form-horizontal">
               <div class="uk-margin">
-                <label class="uk-form-label" for="tx-offset">Offset (optional) <span uk-icon="icon: info;" uk-tooltip title="Start the export after this index. 10 means starting at transaction 11. Blank or 0 equals no offset."></span></label>
+                <label class="uk-form-label" for="tx-order">Order <span uk-icon="icon: info;" uk-tooltip title="The order to export transactions. Newest transaction means highest block height."></span></label>
                 <div class="uk-form-controls">
                   <div class="uk-inline uk-width-1-1">
-                    <input [(ngModel)]="csvOffset" class="uk-input uk-margin-small-bottom {{invalidCsvOffset ? 'uk-form-danger':''}}" id="tx-offset" type="text" (ngModelChange)="csvOffsetChange(csvOffset)" placeholder="" autocomplete="off">
+                    <select class="uk-select" [(ngModel)]="selectedOrder" id="tx-order">
+                      <option *ngFor="let option of orderOptions" [ngValue]="option.value">{{ option.name }}</option>
+                    </select>
                   </div>
                 </div>
               </div>
@@ -161,10 +168,10 @@
           <div class="uk-width-1-1 narrow-div">
             <div class="uk-form-horizontal">
               <div class="uk-margin">
-                <label class="uk-form-label" for="tx-reverse">Reversed (optional) <span uk-icon="icon: info;" uk-tooltip title="Checking this will start the export from the oldest transaction first (block height 1) and forward."></span></label>
+                <label class="uk-form-label" for="tx-offset">Offset (optional) <span uk-icon="icon: info;" uk-tooltip title="Start the export after this index. 10 means starting at transaction 11. Blank or 0 equals no offset."></span></label>
                 <div class="uk-form-controls">
                   <div class="uk-inline uk-width-1-1">
-                    <input class="uk-checkbox" type="checkbox" id="tx-reverse" name="tx-reverse" value="1" [(ngModel)]="csvReversed">
+                    <input [(ngModel)]="csvOffset" class="uk-input uk-margin-small-bottom {{invalidCsvOffset ? 'uk-form-danger':''}}" id="tx-offset" type="text" (ngModelChange)="csvOffsetChange(csvOffset)" placeholder="" autocomplete="off">
                   </div>
                 </div>
               </div>
@@ -174,8 +181,9 @@
       </div>
 
       <div class="uk-card-footer uk-text-right@s uk-text-center nlt-button-group">
-        <button *ngIf="!exportingCsv" class="uk-button uk-button-primary uk-width-1-1@s uk-width-auto@m uk-float-right" type="button" [disabled]="!settings.settings.serverAPI" (click)="exportToCsv()">{{settings.settings.serverAPI ? 'EXPORT HISTORY':'NOT AVAILABLE IN OFFLINE MODE'}}</button>
-        <button *ngIf="exportingCsv" class="uk-button uk-button-secondary uk-disabled uk-width-1-1@s uk-width-auto@m uk-float-right nlt-icon-button nlt-icon-button-inline" type="button"><span class="uk-margin-right" uk-spinner="ratio: 0.5;"></span> FETCHING HISTORY...</button>
+        <button *ngIf="!csvExportStarted" class="uk-button uk-button-primary uk-width-1-1@s uk-width-auto@m uk-float-right" type="button" [disabled]="!settings.settings.serverAPI" (click)="csvInit()">{{settings.settings.serverAPI ? 'GET STARTED':'NOT AVAILABLE IN OFFLINE MODE'}}</button>
+        <button *ngIf="csvExportStarted && !exportingCsv" class="uk-button uk-button-primary uk-width-1-1@s uk-width-auto@m uk-float-right" type="button" [disabled]="!exportEnabled" (click)="exportToCsv()">{{exportEnabled ? 'EXPORT HISTORY':'COOLDOWN'}}</button>
+        <button *ngIf="csvExportStarted && exportingCsv" class="uk-button uk-button-secondary uk-disabled uk-width-1-1@s uk-width-auto@m uk-float-right nlt-icon-button nlt-icon-button-inline" type="button"><span class="uk-margin-right" uk-spinner="ratio: 0.5;"></span> FETCHING HISTORY...</button>
       </div>
     </div>
 

--- a/src/app/components/manage-wallet/manage-wallet.component.html
+++ b/src/app/components/manage-wallet/manage-wallet.component.html
@@ -48,7 +48,7 @@
       </div>
     </div>
 
-    <div class="uk-card uk-card-default uk-margin" *ngIf="!walletService.isLedgerWallet()">
+    <div class="uk-card uk-card-default uk-margin">
       <div class="uk-card-header">
         <h3 class="uk-card-title">Export Nault Wallet</h3>
       </div>

--- a/src/app/components/manage-wallet/manage-wallet.component.html
+++ b/src/app/components/manage-wallet/manage-wallet.component.html
@@ -111,19 +111,18 @@
 
     <div class="uk-card uk-card-default uk-margin" *ngIf="!walletService.isLedgerWallet()">
       <div class="uk-card-header">
-        <h3 class="uk-card-title">Export Transaction History</h3>
+        <h3 class="uk-card-title">Export Transaction History (csv files)</h3>
       </div>
       <div class="uk-card-body">
         <p>
-          Each account in the wallet can be exported individually to a csv file.<br>
-          Due to limitations in Nault backend servers, you can only request 500 transactions per export.<br>
-          However, you can use an offset of 500 to continue exporting 501 to 1000 and so on. Another way is connecting Nault to your own Nano node for unlimited history.<br>
+          Due to limitations in backend servers, you can only request {{transactionHistoryLimit}} transactions per export.<br>
+          However, you can use an offset of X to continue exporting from (X + 1). Another way is connecting Nault to a <a routerLink="/configure-app" routerLinkActive="active">custom server</a> for unlimited history.<br>
         </p>
         <div uk-grid>
           <div class="uk-width-1-1 narrow-div">
             <div class="uk-form-horizontal">
               <div class="uk-margin">
-                <label class="uk-form-label" for="account">Account <span uk-icon="icon: info;" uk-tooltip title="Only local accounts are available for export."></span></label>
+                <label class="uk-form-label" for="account">Account <span uk-icon="icon: info;" uk-tooltip title="Select a local account to export transaction history for."></span></label>
                 <div class="uk-form-controls">
                   <select class="uk-select" id="account" [(ngModel)]="csvAccount">
                     <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'mnano,true' | amountsplit: 0 }}{{ account.balance | rai: 'mnano,true' | amountsplit: 1 }} NANO)</option>
@@ -136,10 +135,10 @@
           <div class="uk-width-1-1 narrow-div">
             <div class="uk-form-horizontal">
               <div class="uk-margin">
-                <label class="uk-form-label" for="tx-count">Limit <span uk-icon="icon: info;" uk-tooltip title="Maximum number of transactions to export. Leave blank for unlimited but only available if using a custom Nault backend."></span></label>
+                <label class="uk-form-label" for="tx-count">Limit <span uk-icon="icon: info;" uk-tooltip title="Maximum number of transactions to export. Blank or 0 equals unlimited but only effective if using a custom server."></span></label>
                 <div class="uk-form-controls">
                   <div class="uk-inline uk-width-1-1">
-                    <input [(ngModel)]="csvCount" class="uk-input uk-margin-small-bottom" id="tx-count" type="text" placeholder="500" autocomplete="off">
+                    <input [(ngModel)]="csvCount" class="uk-input uk-margin-small-bottom {{invalidCsvCount ? 'uk-form-danger':''}}" id="tx-count" type="text" (ngModelChange)="csvCountChange(csvCount)" placeholder="" autocomplete="off">
                   </div>
                 </div>
               </div>
@@ -149,10 +148,10 @@
           <div class="uk-width-1-1 narrow-div">
             <div class="uk-form-horizontal">
               <div class="uk-margin">
-                <label class="uk-form-label" for="tx-offset">Offset (optional) <span uk-icon="icon: info;" uk-tooltip title="Start the export after this index. 500 means starting at transaction 501. Leaving blank equals 0."></span></label>
+                <label class="uk-form-label" for="tx-offset">Offset (optional) <span uk-icon="icon: info;" uk-tooltip title="Start the export after this index. 10 means starting at transaction 11. Blank or 0 equals no offset."></span></label>
                 <div class="uk-form-controls">
                   <div class="uk-inline uk-width-1-1">
-                    <input [(ngModel)]="csvOffset" class="uk-input uk-margin-small-bottom" id="tx-offset" type="text" placeholder="" autocomplete="off">
+                    <input [(ngModel)]="csvOffset" class="uk-input uk-margin-small-bottom {{invalidCsvOffset ? 'uk-form-danger':''}}" id="tx-offset" type="text" (ngModelChange)="csvOffsetChange(csvOffset)" placeholder="" autocomplete="off">
                   </div>
                 </div>
               </div>
@@ -162,22 +161,7 @@
           <div class="uk-width-1-1 narrow-div">
             <div class="uk-form-horizontal">
               <div class="uk-margin">
-                <label class="uk-form-label" for="filter">Account Filter (optional) <span uk-icon="icon: info;" uk-tooltip title="Comma separated list of accounts to match against (SEND or RECEIVE). Other transactions will be excluded from the export. Available if using a custom Nault backend."></span></label>
-                <div class="uk-form-controls">
-                  <div class="uk-width-1-1">
-                    <div class="uk-inline uk-width-1-1">
-                      <input [(ngModel)]="csvFilter" class="uk-input uk-margin-small-bottom {{invalidFilter ? 'uk-form-danger':''}}" id="filter" type="text" (ngModelChange)="csvFilterChange(sourceWallet)" placeholder="nano_1abc,nano_1def" autocomplete="off">
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div class="uk-width-1-1 narrow-div">
-            <div class="uk-form-horizontal">
-              <div class="uk-margin">
-                <label class="uk-form-label" for="tx-reverse">Reversed (optional) <span uk-icon="icon: info;" uk-tooltip title="The default (unchecked) order is starting with the latest transaction and searching back in time."></span></label>
+                <label class="uk-form-label" for="tx-reverse">Reversed (optional) <span uk-icon="icon: info;" uk-tooltip title="Checking this will start the export from the oldest transaction first (block height 1) and forward."></span></label>
                 <div class="uk-form-controls">
                   <div class="uk-inline uk-width-1-1">
                     <input class="uk-checkbox" type="checkbox" id="tx-reverse" name="tx-reverse" value="1" [(ngModel)]="csvReversed">
@@ -188,7 +172,8 @@
           </div>
 
           <div class="uk-width-1-1 narrow-div">
-            <button class="uk-button uk-button-primary uk-width-1-1" type="button"> Export to File</button>
+            <button *ngIf="!exportingCsv" class="uk-button uk-button-primary uk-width-1-1" type="button" [disabled]="!settings.settings.serverAPI" (click)="exportToCsv()">{{settings.settings.serverAPI ? 'EXPORT TO FILE':'NOT AVAILABLE IN OFFLINE MODE'}}</button>
+            <button *ngIf="exportingCsv" class="uk-button uk-button-primary uk-disabled uk-width-1-1" type="button"><span class="uk-margin-right" uk-spinner></span> FETCHING HISTORY...</button>
           </div>
         </div>
       </div>

--- a/src/app/components/manage-wallet/manage-wallet.component.ts
+++ b/src/app/components/manage-wallet/manage-wallet.component.ts
@@ -12,6 +12,7 @@ import * as bip from 'bip39';
 export class ManageWalletComponent implements OnInit {
 
   wallet = this.walletService.wallet;
+  accounts = this.walletService.wallet.accounts;
 
   newPassword = '';
   confirmPassword = '';
@@ -20,12 +21,33 @@ export class ManageWalletComponent implements OnInit {
   QRExportUrl = '';
   QRExportImg = '';
 
+  selAccountInit = false;
+  invalidFilter = false;
+  csvAccount = this.accounts.length > 0 ? this.accounts[0].id : '0';
+  csvCount = '500';
+  csvOffset = '';
+  csvFilter = '';
+  csvReversed = false;
+
   constructor(
     public walletService: WalletService,
     public notifications: NotificationService) { }
 
   async ngOnInit() {
     this.wallet = this.walletService.wallet;
+
+    // Update selected account if changed in the sidebar
+    this.walletService.wallet.selectedAccount$.subscribe(async acc => {
+      if (this.selAccountInit) {
+        this.csvAccount = acc ? acc.id : (this.accounts.length > 0 ? this.accounts[0].id : '0');
+      }
+      this.selAccountInit = true;
+    });
+
+    // Set the account selected in the sidebar as default
+    if (this.walletService.wallet.selectedAccount !== null) {
+      this.csvAccount = this.walletService.wallet.selectedAccount.id;
+    }
   }
 
   async changePassword() {

--- a/src/app/components/manage-wallet/manage-wallet.component.ts
+++ b/src/app/components/manage-wallet/manage-wallet.component.ts
@@ -189,7 +189,9 @@ export class ManageWalletComponent implements OnInit {
         this.beyondCsvLimit = true;
       } else {
         this.invalidCsvCount = false;
-      } } else {
+        this.beyondCsvLimit = false;
+      }
+    } else {
       this.invalidCsvCount = true;
     }
   }

--- a/src/app/components/manage-wallet/manage-wallet.component.ts
+++ b/src/app/components/manage-wallet/manage-wallet.component.ts
@@ -207,7 +207,6 @@ export class ManageWalletComponent implements OnInit {
   async exportToCsv() {
     if (this.invalidCsvCount) {
       if (this.beyondCsvLimit) {
-        this.beyondCsvLimit = false;
         return this.notifications.sendWarning(`To export transactions above the limit, please use a custom Nault server`);
       } else {
         return this.notifications.sendWarning(`Invalid limit`);

--- a/src/app/components/manage-wallet/manage-wallet.component.ts
+++ b/src/app/components/manage-wallet/manage-wallet.component.ts
@@ -224,11 +224,15 @@ export class ManageWalletComponent implements OnInit {
 
     // contruct the export data
     const csvData = [];
-    if (history && history.history.length > 0) {
+    if (history && history.history && history.history.length > 0) {
       history.history.forEach(a => {
         csvData.push({'account': a.account, 'type': a.type, 'amount': this.util.nano.rawToMnano(a.amount).toString(10),
         'hash': a.hash, 'height': a.height, 'time': formatDate(a.local_timestamp * 1000, 'y-MM-d HH:mm:ss', 'en-US')});
       });
+    }
+
+    if (csvData.length === 0) {
+      return this.notifications.sendWarning(`No transaction history found or bad server response!`);
     }
 
     // download file

--- a/src/app/components/manage-wallet/manage-wallet.component.ts
+++ b/src/app/components/manage-wallet/manage-wallet.component.ts
@@ -1,8 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import {WalletService} from '../../services/wallet.service';
 import {NotificationService} from '../../services/notification.service';
+import {ApiService} from '../../services/api.service';
+import {UtilService} from '../../services/util.service';
+import {AppSettingsService} from '../../services/app-settings.service';
 import * as QRCode from 'qrcode';
 import * as bip from 'bip39';
+import {formatDate} from '@angular/common';
 
 @Component({
   selector: 'app-manage-wallet',
@@ -21,17 +25,23 @@ export class ManageWalletComponent implements OnInit {
   QRExportUrl = '';
   QRExportImg = '';
 
+  transactionHistoryLimit = 500; // if the backend server limit changes, change this too
   selAccountInit = false;
-  invalidFilter = false;
+  invalidCsvCount = false;
+  invalidCsvOffset = false;
   csvAccount = this.accounts.length > 0 ? this.accounts[0].id : '0';
-  csvCount = '500';
+  csvCount = this.transactionHistoryLimit.toString();
   csvOffset = '';
-  csvFilter = '';
+  beyondCsvLimit = false;
   csvReversed = false;
+  exportingCsv = false;
 
   constructor(
     public walletService: WalletService,
-    public notifications: NotificationService) { }
+    public notifications: NotificationService,
+    private api: ApiService,
+    private util: UtilService,
+    public settings: AppSettingsService) { }
 
   async ngOnInit() {
     this.wallet = this.walletService.wallet;
@@ -93,8 +103,40 @@ export class ManageWalletComponent implements OnInit {
     }
   }
 
-  triggerFileDownload(fileName, exportData) {
-    const blob = new Blob([JSON.stringify(exportData)], { type: 'application/json' });
+  triggerFileDownload(fileName, exportData, type) {
+    let blob;
+    // first line, include columns for spreadsheet
+    let csvFile = 'account,type,amount,hash,height,time\n';
+
+    switch (type) {
+      case 'json':
+        blob = new Blob([JSON.stringify(exportData)], { type: 'application/json' });
+        break;
+      case 'csv':
+        // comma-separated attributes for each row
+        const processRow = function (row) {
+          let finalVal = '';
+          let j = 0;
+          for (const [key, value] of Object.entries(row)) {
+            const innerValue = value === null ? '' : value.toString();
+            let result = innerValue.replace(/"/g, '""');
+            if (result.search(/("|,| |\n)/g) >= 0) {
+              result = '"' + result + '"';
+            }
+            if (j > 0) {
+              finalVal += ',';
+            }
+            j++;
+            finalVal += result;
+          }
+          return finalVal + '\n';
+        };
+        for (let i = 0; i < exportData.length; i++) {
+          csvFile += processRow(exportData[i]);
+        }
+        blob = new Blob([csvFile], { type: 'text/csv;charset=utf-8;' });
+        break;
+    }
 
     // Check for iOS, which is weird with saving files
     const iOS = !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform);
@@ -105,7 +147,14 @@ export class ManageWalletComponent implements OnInit {
       const elem = window.document.createElement('a');
       const objUrl = window.URL.createObjectURL(blob);
       if (iOS) {
-        elem.href = `data:attachment/file,${JSON.stringify(exportData)}`;
+        switch (type) {
+          case 'json':
+            elem.href = `data:attachment/file,${JSON.stringify(exportData)}`;
+            break;
+          case 'csv':
+            elem.href = `data:attachment/file,${csvFile}`;
+            break;
+        }
       } else {
         elem.href = objUrl;
       }
@@ -126,9 +175,64 @@ export class ManageWalletComponent implements OnInit {
 
     const fileName = `Nault-Wallet.json`;
     const exportData = this.walletService.generateExportData();
-    this.triggerFileDownload(fileName, exportData);
+    this.triggerFileDownload(fileName, exportData, 'json');
 
     this.notifications.sendSuccess(`Wallet export downloaded!`);
   }
 
+  csvCountChange(count) {
+    if (this.util.string.isNumeric(count) && count % 1 === 0 || count === '') {
+      // only allow beyond limit if using a custom server
+      if (this.settings.settings.serverName !== 'custom' &&
+      (parseInt(count, 10) > this.transactionHistoryLimit || count === '' || count === '0')) {
+        this.invalidCsvCount = true;
+        this.beyondCsvLimit = true;
+      } else {
+        this.invalidCsvCount = false;
+      } } else {
+      this.invalidCsvCount = true;
+    }
+  }
+
+  csvOffsetChange(offset) {
+    if (this.util.string.isNumeric(offset) && offset % 1 === 0 || offset === '') {
+      this.invalidCsvOffset = false;
+    } else {
+      this.invalidCsvOffset = true;
+    }
+  }
+
+  async exportToCsv() {
+    if (this.invalidCsvCount) {
+      if (this.beyondCsvLimit) {
+        this.beyondCsvLimit = false;
+        return this.notifications.sendWarning(`To export transactions above the limit, please use a custom Nault server`);
+      } else {
+        return this.notifications.sendWarning(`Invalid limit`);
+      }
+    }
+    if (this.invalidCsvOffset) {
+      return this.notifications.sendWarning(`Invalid offset`);
+    }
+
+    this.exportingCsv = true;
+    const transactionCount = this.csvCount === '' ? 0 : parseInt(this.csvCount, 10);
+    const transactionOffset = this.csvOffset === '' ? 0 : parseInt(this.csvOffset, 10);
+    const history = await this.api.accountHistory(this.csvAccount, transactionCount, false, transactionOffset, this.csvReversed);
+    this.exportingCsv = false; // reset it here in case the file download fails (don't want spinning button forever)
+
+    // contruct the export data
+    const csvData = [];
+    if (history && history.history.length > 0) {
+      history.history.forEach(a => {
+        csvData.push({'account': a.account, 'type': a.type, 'amount': this.util.nano.rawToMnano(a.amount).toString(10),
+        'hash': a.hash, 'height': a.height, 'time': formatDate(a.local_timestamp * 1000, 'y-MM-d HH:mm:ss', 'en-US')});
+      });
+    }
+
+    // download file
+    const fileName = `${this.csvAccount}_offset=${this.csvOffset === '' ? 0 : this.csvOffset}${this.csvReversed ? '_reversed' : ''}.csv`;
+    this.triggerFileDownload(fileName, csvData, 'csv');
+    this.notifications.sendSuccess(`Transaction history downloaded!`);
+  }
 }

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -99,8 +99,13 @@ export class ApiService {
   async process(block, subtype: TxType): Promise<{ hash: string, error?: string }> {
     return await this.request('process', { block: JSON.stringify(block), watch_work: 'false', subtype: TxType[subtype] }, false);
   }
-  async accountHistory(account, count = 25, raw = false): Promise<{history: any }> {
-    return await this.request('account_history', { account, count, raw }, false);
+  async accountHistory(account, count = 25, raw = false, offset = 0, reverse = false): Promise<{history: any }> {
+    // use unlimited count if 0
+    if (count === 0) {
+      return await this.request('account_history', { account, raw, offset, reverse}, false);
+    } else {
+      return await this.request('account_history', { account, count, raw, offset, reverse}, false);
+    }
   }
   async accountInfo(account): Promise<any> {
     return await this.request('account_info', { account, pending: true, representative: true, weight: true }, false);


### PR DESCRIPTION
Allows exporting the transaction history of any internal wallet account as csv files.

* Limit by transaction count: The default limit for Nault backend servers is 500 and going beyond that will require a custom server to be selected first. For example by using your own node, unlimited history should be no problem. It's a heavy RPC call, that's why.
* Optional offset if doing manual export of more than the limit. 501-1000, 1001-1500 and so on.
* Optional reverse order if exporting from block height 1 and forward in time. Default is starting with the latest transaction like the account detail page


![image](https://user-images.githubusercontent.com/2406720/127197384-5b78e8e4-78d7-4bbf-a51a-117381832544.png)

Csv can be opened directly in for example MS excel
![image](https://user-images.githubusercontent.com/2406720/126870228-d49538de-0282-47d7-862e-3fc559854c60.png)
