### PR TITLE
Use the new style for confirming remote signing

### DIFF
--- a/src/app/components/sign/sign.component.css
+++ b/src/app/components/sign/sign.component.css
@@ -101,3 +101,49 @@
 .add-button span {
   vertical-align: text-bottom;
 }
+
+.block-amount-primary {
+  font-family: 'Montserrat', Arial, Helvetica, sans-serif;
+  line-height: 1;
+  margin-top: 4px;
+}
+
+.block-amount-primary > .amount-integer {
+  font-size: 32px;
+  font-weight: 700;
+}
+
+.block-amount-primary > .amount-fractional,
+.block-amount-primary > .currency-name {
+  font-size: 21px;
+}
+
+.block-amount-primary > .currency-name {
+  margin-left: 6px;
+}
+
+.block-balance .balance-amount-primary .amount-amount-sign,
+.block-balance .balance-amount-primary .amount-integer,
+.block-balance .balance-amount-primary .amount-fractional,
+.block-balance .balance-amount-primary .currency-name {
+  font-family: 'Montserrat', Arial, Helvetica, sans-serif;
+  font-size: 16px;
+}
+
+.block-balance .balance-amount-primary .amount-sign {
+  font-weight: 500;
+  margin-right: 1px;
+}
+
+.block-balance .balance-amount-primary .amount-integer {
+  font-weight: 700;
+}
+
+.block-balance .balance-amount-primary .amount-fractional {
+  font-weight: 500;
+}
+
+.block-balance .balance-amount-primary .currency-name {
+  font-weight: 400;
+  margin-left: 5px;
+}

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -6,84 +6,125 @@
     <!-- Confirmation Panel -->
     <div uk-grid *ngIf="activePanel == 'confirm'" class="uk-animation-slide-left">
       <div class="uk-width-1-1">
-        <div class="uk-card uk-card-default uk-width-1-1 uk-text-center">
-          <span *ngIf="!qrCodeImageBlock && shouldSign" style="display: block; padding-top: 8px;">You are about to sign a block to {{txTypeMessage}}</span>
-          <span *ngIf="qrCodeImageBlock && shouldSign" style="display: block; padding-top: 8px;">You have signed a block to {{txTypeMessage}}</span>
-          <span *ngIf="!blockProcessed && !shouldSign" style="display: block; padding-top: 8px;">You are about to {{txTypeMessage}}</span>
-          <span *ngIf="blockProcessed && !shouldSign" style="display: block; padding-top: 8px;">You have processed a block to {{txTypeMessage}}</span>
-          <span *ngIf="txType != txTypes.change" style="display:block; font-size: 32px;">{{ rawAmount | rai: 'mnano,true' | amountsplit: 0 }}{{ rawAmount | rai: 'mnano,true' | amountsplit: 1 }} NANO</span>
-          <span *ngIf="txType == txTypes.change" style="display:block; font-size: 20px;">{{ currentBlock.representative }}</span>
-        </div>
-        <br>
-        <div uk-grid>
-          <div class="uk-width-1-2@m">
-            <div class="uk-card uk-card-default">
-              <div class="uk-card-header uk-text-left" style="padding: 20px 20px; line-height: 22px;">
-                <span class="confirm-title uk-text-truncate">
-                  <div *ngIf="fromAddressBook">
-                    <span class="confirm-title uk-text-truncate">{{ fromAddressBook }}</span>
-                    <span class="confirm-subtitle">From Account</span>
-                    <span class="nano-address-monospace uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
-                  </div>
-                  <div *ngIf="!fromAddressBook">
-                    <span class="nano-address-monospace confirm-title uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></span>
-                    <span class="confirm-subtitle">From Account</span>
-                    <br class="br-spacer" />
-                  </div>
-                </span>
-                <ul class="uk-iconnav">
-                  <li><a ngxClipboard [cbContent]="fromAccountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
-                </ul>
+        <div class="uk-card uk-card-default uk-width-1-1 uk-text-center" style="margin-bottom: 20px;">
+          <div class="uk-card-body" style="padding: 15px;">
+            <div *ngIf="!qrCodeImageBlock && shouldSign" class="uk-text-danger">You are about to sign a block to {{txTypeMessage}}</div>
+            <div *ngIf="qrCodeImageBlock && shouldSign" class="uk-text-danger">You have signed a block to {{txTypeMessage}}</div>
+            <div *ngIf="!blockProcessed && !shouldSign" class="uk-text-danger">You are about to {{txTypeMessage}}</div>
+            <div *ngIf="blockProcessed && !shouldSign" class="uk-text-danger">You have processed a block to {{txTypeMessage}}</div>
+
+            <div *ngIf="txType != txTypes.change">
+              <div class="block-amount-primary uk-text-danger">
+                <span class="amount-integer">{{ rawAmount | rai: 'mnano,true' | amountsplit: 0 }}</span>
+                <span class="amount-fractional">{{ rawAmount | rai: 'mnano,true' | amountsplit: 1 }}</span>
+                <span class="currency-name">NANO</span>
               </div>
-              <div class="uk-card-body" style="padding: 20px 20px;">
+              <div style="margin: 8px 0 -1px 0;" class="text-half-muted" *ngIf="settings.settings.displayCurrency && amountFiat !== null">{{ amountFiat | fiat: settings.settings.displayCurrency }}</div>
+              <div style="margin: 1px 0 -1px 0;" class="uk-text-muted" *ngIf="settings.settings.displayCurrency && amountFiat !== null">{{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO</div>
+            </div>
+            <div *ngIf="txType == txTypes.change">
+              <div class="block-amount-primary uk-text-danger">
+                <span class="currency-name">{{ currentBlock.representative }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="account-snippet-container" style="margin-bottom: 20px;">
+          <div class="account-snippet uk-text-truncate">
+            <div class="uk-card uk-card-default uk-text-truncate" [class.identicons-enabled]="(settings.settings.identiconsStyle !== 'none')">
+              <div class="uk-card-header">
+                <div class="snippet-caption uk-text-small text-half-muted">From Account</div>
+                <div class="uk-flex uk-flex-nowrap uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
+                  <a [routerLink]="'/account/' + fromAccountID" class="uk-link-reset account-container uk-text-truncate" uk-tooltip title="View Account Details">
+                    <div class="identicon-address-book-row">
+                      <app-nano-identicon scale="12" [accountID]="fromAccountID" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
+                      <div class="account-label uk-text-truncate" *ngIf="fromAddressBook">{{ fromAddressBook }}</div>
+                    </div>
+                    <div class="nano-address-clickable nano-address-monospace uk-text-truncate"><app-nano-account-id [accountID]="fromAccountID"></app-nano-account-id></div>
+                  </a>
+                  <div class="snippet-address-actions uk-width-auto uk-flex uk-flex-bottom">
+                    <ul class="uk-iconnav">
+                      <li><a ngxClipboard [cbContent]="fromAccountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+              <div class="uk-card-body">
                 <div uk-grid>
                   <div class="uk-width-1-2 uk-text-muted">
-                    <span class="confirm-currency">{{ fromAccountBalance ? (fromAccountBalance | rai: 'mnano'): 'N/A'}}</span>
-                    <span class="confirm-subtitle">Balance when block was created</span>
+                    <div class="uk-text-small text-half-muted" style="height: 25px;">Balance when block was created</div>
+                    <span class="block-balance">
+                      <span class="balance-amount-primary">
+                        <span class="amount-integer">{{ (fromAccountBalance || 'N/A') | rai: 'mnano,true' | amountsplit: 0 }}</span>
+                        <span class="amount-fractional">{{ (fromAccountBalance || 'N/A') | rai: 'mnano,true' | amountsplit: 1 }}</span>
+                        <span class="currency-name">NANO</span>
+                      </span>
+                    </span>
                   </div>
                   <div class="uk-width-1-2 uk-text-right">
-                    <span class="confirm-currency uk-text-danger">-{{ rawAmount | rai: 'mnano' }}</span>
+                    <div class="uk-text-small text-half-muted" style="height: 25px;"></div>
+                    <span class="block-balance">
+                      <span class="balance-amount-primary uk-text-danger">
+                        <span class="amount-sign">-</span>
+                        <span class="amount-integer">{{ rawAmount | rai: 'mnano,true' | amountsplit: 0 }}</span>
+                        <span class="amount-fractional">{{ rawAmount | rai: 'mnano,true' | amountsplit: 1 }}</span>
+                        <span class="currency-name">NANO</span>
+                      </span>
+                    </span>
                   </div>
                 </div>
               </div>
             </div>
           </div>
 
-          <div class="uk-width-1-2@m">
-            <div class="uk-card uk-card-default">
-              <div class="uk-card-header uk-text-right" style="padding: 20px 20px; line-height: 22px;">
-
-                <span class="confirm-title uk-text-truncate">
-                  <div *ngIf="toAddressBook">
-                    <span class="confirm-title uk-text-truncate">{{ toAddressBook }}</span>
-                    <span class="confirm-subtitle">To Account</span>
-                    <span class="nano-address-monospace uk-text-small uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
+          <div class="account-snippet uk-text-truncate">
+            <div class="uk-card uk-card-default uk-text-truncate" [class.identicons-enabled]="(settings.settings.identiconsStyle !== 'none')">
+              <div class="uk-card-header">
+                <div class="snippet-caption uk-text-small text-half-muted">To Account</div>
+                <div class="uk-flex uk-flex-nowrap uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
+                  <a [routerLink]="'/account/' + toAccountID" class="uk-link-reset account-container uk-text-truncate" uk-tooltip title="View Account Details">
+                    <div class="identicon-address-book-row">
+                      <app-nano-identicon scale="12" [accountID]="toAccountID" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
+                      <div class="account-label uk-text-truncate" *ngIf="toAddressBook">{{ toAddressBook }}</div>
+                    </div>
+                    <div class="nano-address-clickable nano-address-monospace uk-text-truncate"><app-nano-account-id [accountID]="toAccountID"></app-nano-account-id></div>
+                  </a>
+                  <div class="snippet-address-actions uk-width-auto uk-flex uk-flex-bottom">
+                    <ul class="uk-iconnav">
+                      <li><a ngxClipboard [cbContent]="toAccountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
+                    </ul>
                   </div>
-                  <div *ngIf="!toAddressBook">
-                    <span class="nano-address-monospace confirm-title uk-text-truncate"><app-nano-account-id [accountID]="toAccountID" class="uk-flex-right"></app-nano-account-id></span>
-                    <span class="confirm-subtitle">To Account</span>
-                    <br class="br-spacer" />
-                  </div>
-                </span>
-                <ul class="uk-iconnav">
-                <li><a ngxClipboard [cbContent]="toAccountID" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
-                </ul>
+                </div>
               </div>
-              <div class="uk-card-body" style="padding: 20px 20px;">
+              <div class="uk-card-body">
                 <div uk-grid>
                   <div class="uk-width-1-2 uk-text-muted">
-                    <span class="confirm-currency">{{ toAccountBalance ? (toAccountBalance | rai: 'mnano'): 'N/A' }}</span>
-                    <span class="confirm-subtitle">Balance when block was created</span>
+                    <div class="uk-text-small text-half-muted" style="height: 25px;">Balance when block was created</div>
+                    <span class="block-balance">
+                      <span class="balance-amount-primary">
+                        <span class="amount-integer">{{ (toAccountBalance || 'N/A') | rai: 'mnano,true' | amountsplit: 0 }}</span>
+                        <span class="amount-fractional">{{ (toAccountBalance || 'N/A') | rai: 'mnano,true' | amountsplit: 1 }}</span>
+                        <span class="currency-name">NANO</span>
+                      </span>
+                    </span>
                   </div>
                   <div class="uk-width-1-2 uk-text-right">
-                    <span class="confirm-currency uk-text-success">+{{ rawAmount | rai: 'mnano' }}</span>
+                    <div class="uk-text-small text-half-muted" style="height: 25px;"></div>
+                    <span class="block-balance">
+                      <span class="balance-amount-primary uk-text-success">
+                        <span class="amount-sign">+</span>
+                        <span class="amount-integer">{{ rawAmount | rai: 'mnano,true' | amountsplit: 0 }}</span>
+                        <span class="amount-fractional">{{ rawAmount | rai: 'mnano,true' | amountsplit: 1 }}</span>
+                        <span class="currency-name">NANO</span>
+                      </span>
+                    </span>
                   </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <br>
 
         <div *ngIf="shouldSign" class="uk-card uk-card-default uk-width-1-1" style="padding: 20px 20px;">
           <span><strong>Signing Method </strong></span><span uk-icon="icon: info;" uk-tooltip title="The block is signed with a private key. If using the build-in wallet, it first needs to be created using any of the available methods."></span><br>

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -57,7 +57,7 @@
                       <span class="balance-amount-primary">
                         <span class="amount-integer">{{ fromAccountBalance ? (fromAccountBalance | rai: 'mnano,true' | amountsplit: 0) : 'N/A' }}</span>
                         <span class="amount-fractional">{{ fromAccountBalance ? (fromAccountBalance | rai: 'mnano,true' | amountsplit: 1) : '' }}</span>
-                        <span class="currency-name">NANO</span>
+                        <span class="currency-name">{{ fromAccountBalance ? 'NANO' : '' }}</span>
                       </span>
                     </span>
                   </div>
@@ -117,9 +117,9 @@
                     <div class="uk-text-small text-half-muted" style="height: 25px;">Balance when block was created</div>
                     <span class="block-balance">
                       <span class="balance-amount-primary">
-                        <span class="amount-integer">{{ (toAccountBalance || 'N/A') | rai: 'mnano,true' | amountsplit: 0 }}</span>
-                        <span class="amount-fractional">{{ (toAccountBalance || 'N/A') | rai: 'mnano,true' | amountsplit: 1 }}</span>
-                        <span class="currency-name">NANO</span>
+                        <span class="amount-integer">{{ toAccountBalance ? (toAccountBalance | rai: 'mnano,true' | amountsplit: 0) : 'N/A' }}</span>
+                        <span class="amount-fractional">{{ toAccountBalance ? (toAccountBalance | rai: 'mnano,true' | amountsplit: 1) : '' }}</span>
+                        <span class="currency-name">{{ toAccountBalance ? 'NANO' : '' }}</span>
                       </span>
                     </span>
                   </div>

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -8,13 +8,16 @@
       <div class="uk-width-1-1">
         <div class="uk-card uk-card-default uk-width-1-1 uk-text-center" style="margin-bottom: 20px;">
           <div class="uk-card-body" style="padding: 15px;">
-            <div *ngIf="!qrCodeImageBlock && shouldSign" class="uk-text-danger">You are about to sign a block to {{txTypeMessage}}</div>
-            <div *ngIf="qrCodeImageBlock && shouldSign" class="uk-text-danger">You have signed a block to {{txTypeMessage}}</div>
-            <div *ngIf="!blockProcessed && !shouldSign" class="uk-text-danger">You are about to {{txTypeMessage}}</div>
-            <div *ngIf="blockProcessed && !shouldSign" class="uk-text-danger">You have processed a block to {{txTypeMessage}}</div>
+            <div [class.uk-text-danger]="txType == txTypes.send" [class.uk-text-success]="txType == txTypes.receive" [class.text-rep-change]="txType == txTypes.change">
+              <div *ngIf="txType == txTypes.change" style="margin-bottom: 7px;" uk-icon="icon: cog; ratio: 1.2;"></div><br>
+              <div *ngIf="!qrCodeImageBlock && shouldSign">You are about to sign a block to {{txTypeMessage}}</div>
+              <div *ngIf="qrCodeImageBlock && shouldSign">You have signed a block to {{txTypeMessage}}</div>
+              <div *ngIf="!blockProcessed && !shouldSign">You are about to {{txTypeMessage}}</div>
+              <div *ngIf="blockProcessed && !shouldSign">You have processed a block to {{txTypeMessage}}</div>
+            </div>
 
             <div *ngIf="txType != txTypes.change">
-              <div class="block-amount-primary uk-text-danger">
+              <div class="block-amount-primary" [class.uk-text-danger]="txType == txTypes.send" [class.uk-text-success]="txType == txTypes.receive">
                 <span class="amount-integer">{{ rawAmount | rai: 'mnano,true' | amountsplit: 0 }}</span>
                 <span class="amount-fractional">{{ rawAmount | rai: 'mnano,true' | amountsplit: 1 }}</span>
                 <span class="currency-name">NANO</span>
@@ -52,8 +55,8 @@
                     <div class="uk-text-small text-half-muted" style="height: 25px;">Balance when block was created</div>
                     <span class="block-balance">
                       <span class="balance-amount-primary">
-                        <span class="amount-integer">{{ (fromAccountBalance || 'N/A') | rai: 'mnano,true' | amountsplit: 0 }}</span>
-                        <span class="amount-fractional">{{ (fromAccountBalance || 'N/A') | rai: 'mnano,true' | amountsplit: 1 }}</span>
+                        <span class="amount-integer">{{ fromAccountBalance ? (fromAccountBalance | rai: 'mnano,true' | amountsplit: 0) : 'N/A' }}</span>
+                        <span class="amount-fractional">{{ fromAccountBalance ? (fromAccountBalance | rai: 'mnano,true' | amountsplit: 1) : '' }}</span>
                         <span class="currency-name">NANO</span>
                       </span>
                     </span>

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -24,7 +24,9 @@
             </div>
             <div *ngIf="txType == txTypes.change">
               <div class="block-amount-primary uk-text-danger">
-                <span class="currency-name">{{ currentBlock.representative }}</span>
+                <a [routerLink]="'/account/' + currentBlock.representative" class="uk-link-reset account-container uk-text-truncate" uk-tooltip title="View Account Details">
+                  <div class="nano-address-clickable nano-address-monospace uk-text-truncate"><app-nano-account-id [accountID]="currentBlock.representative"></app-nano-account-id></div>
+                </a>
               </div>
             </div>
           </div>

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -9,7 +9,7 @@
         <div class="uk-card uk-card-default uk-width-1-1 uk-text-center" style="margin-bottom: 20px;">
           <div class="uk-card-body" style="padding: 15px;">
             <div [class.uk-text-danger]="txType == txTypes.send" [class.uk-text-success]="txType == txTypes.receive" [class.text-rep-change]="txType == txTypes.change">
-              <div *ngIf="txType == txTypes.change" style="margin-bottom: 7px;" uk-icon="icon: cog; ratio: 1.2;"></div><br>
+              <div *ngIf="txType == txTypes.change" style="margin-bottom: 7px;" uk-icon="icon: cog; ratio: 1.2;"><br></div>
               <div *ngIf="!qrCodeImageBlock && shouldSign">You are about to sign a block to {{txTypeMessage}}</div>
               <div *ngIf="qrCodeImageBlock && shouldSign">You have signed a block to {{txTypeMessage}}</div>
               <div *ngIf="!blockProcessed && !shouldSign">You are about to {{txTypeMessage}}</div>

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -52,7 +52,7 @@
               <div *ngIf="txType !== txTypes.change" class="uk-card-body">
                 <div uk-grid>
                   <div class="uk-width-1-2 uk-text-muted">
-                    <div class="uk-text-small text-half-muted" style="height: 25px;">Balance when block was created</div>
+                    <div class="uk-text-small text-half-muted" style="height: 25px;">Balance</div>
                     <span class="block-balance">
                       <span class="balance-amount-primary">
                         <span class="amount-integer">{{ fromAccountBalance ? (fromAccountBalance | rai: 'mnano,true' | amountsplit: 0) : 'N/A' }}</span>
@@ -114,12 +114,12 @@
               <div *ngIf="txType !== txTypes.change" class="uk-card-body">
                 <div uk-grid>
                   <div class="uk-width-1-2 uk-text-muted">
-                    <div class="uk-text-small text-half-muted" style="height: 25px;">Balance when block was created</div>
+                    <div class="uk-text-small text-half-muted" style="height: 25px;">Balance</div>
                     <span class="block-balance">
                       <span class="balance-amount-primary">
-                        <span class="amount-integer">{{ toAccountBalance ? (toAccountBalance | rai: 'mnano,true' | amountsplit: 0) : 'N/A' }}</span>
-                        <span class="amount-fractional">{{ toAccountBalance ? (toAccountBalance | rai: 'mnano,true' | amountsplit: 1) : '' }}</span>
-                        <span class="currency-name">{{ toAccountBalance ? 'NANO' : '' }}</span>
+                        <span class="amount-integer">{{ toAccountBalance && txType === txTypes.receive ? (toAccountBalance | rai: 'mnano,true' | amountsplit: 0) : 'N/A' }}</span>
+                        <span class="amount-fractional">{{ toAccountBalance && txType === txTypes.receive ? (toAccountBalance | rai: 'mnano,true' | amountsplit: 1) : '' }}</span>
+                        <span class="currency-name">{{ toAccountBalance && txType === txTypes.receive ? 'NANO' : '' }}</span>
                       </span>
                     </span>
                   </div>

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -22,13 +22,6 @@
               <div style="margin: 8px 0 -1px 0;" class="text-half-muted" *ngIf="settings.settings.displayCurrency && amountFiat !== null">{{ amountFiat | fiat: settings.settings.displayCurrency }}</div>
               <div style="margin: 1px 0 -1px 0;" class="uk-text-muted" *ngIf="settings.settings.displayCurrency && amountFiat !== null">{{ price.price.lastPrice | fiat: settings.settings.displayCurrency }} / NANO</div>
             </div>
-            <div *ngIf="txType == txTypes.change">
-              <div class="block-amount-primary uk-text-danger">
-                <a [routerLink]="'/account/' + currentBlock.representative" class="uk-link-reset account-container uk-text-truncate" uk-tooltip title="View Account Details">
-                  <div class="nano-address-clickable nano-address-monospace uk-text-truncate"><app-nano-account-id [accountID]="currentBlock.representative"></app-nano-account-id></div>
-                </a>
-              </div>
-            </div>
           </div>
         </div>
 
@@ -36,7 +29,8 @@
           <div class="account-snippet uk-text-truncate">
             <div class="uk-card uk-card-default uk-text-truncate" [class.identicons-enabled]="(settings.settings.identiconsStyle !== 'none')">
               <div class="uk-card-header">
-                <div class="snippet-caption uk-text-small text-half-muted">From Account</div>
+                <div *ngIf="txType === txTypes.change" class="snippet-caption uk-text-small text-half-muted">Account</div>
+                <div *ngIf="txType !== txTypes.change" class="snippet-caption uk-text-small text-half-muted">From Account</div>
                 <div class="uk-flex uk-flex-nowrap uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
                   <a [routerLink]="'/account/' + fromAccountID" class="uk-link-reset account-container uk-text-truncate" uk-tooltip title="View Account Details">
                     <div class="identicon-address-book-row">
@@ -52,7 +46,7 @@
                   </div>
                 </div>
               </div>
-              <div class="uk-card-body">
+              <div *ngIf="txType !== txTypes.change" class="uk-card-body">
                 <div uk-grid>
                   <div class="uk-width-1-2 uk-text-muted">
                     <div class="uk-text-small text-half-muted" style="height: 25px;">Balance when block was created</div>
@@ -83,8 +77,9 @@
           <div class="account-snippet uk-text-truncate">
             <div class="uk-card uk-card-default uk-text-truncate" [class.identicons-enabled]="(settings.settings.identiconsStyle !== 'none')">
               <div class="uk-card-header">
-                <div class="snippet-caption uk-text-small text-half-muted">To Account</div>
-                <div class="uk-flex uk-flex-nowrap uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
+                <div *ngIf="txType === txTypes.change" class="snippet-caption uk-text-small text-half-muted">New Representative</div>
+                <div *ngIf="txType !== txTypes.change" class="snippet-caption uk-text-small text-half-muted">To Account</div>
+                <div *ngIf="txType !== txTypes.change" class="uk-flex uk-flex-nowrap uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
                   <a [routerLink]="'/account/' + toAccountID" class="uk-link-reset account-container uk-text-truncate" uk-tooltip title="View Account Details">
                     <div class="identicon-address-book-row">
                       <app-nano-identicon scale="12" [accountID]="toAccountID" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
@@ -98,8 +93,22 @@
                     </ul>
                   </div>
                 </div>
+                <div *ngIf="txType === txTypes.change" class="uk-flex uk-flex-nowrap uk-width-auto uk-text-truncate" style="max-width: calc(100% - 35px);">
+                  <a [routerLink]="'/account/' + currentBlock.representative" class="uk-link-reset account-container uk-text-truncate" uk-tooltip title="View Account Details">
+                    <div class="identicon-address-book-row">
+                      <app-nano-identicon scale="12" [accountID]="currentBlock.representative" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
+                      <div class="account-label uk-text-truncate" *ngIf="repAddressBook">{{ repAddressBook }}</div>
+                    </div>
+                    <div class="nano-address-clickable nano-address-monospace uk-text-truncate"><app-nano-account-id [accountID]="currentBlock.representative"></app-nano-account-id></div>
+                  </a>
+                  <div class="snippet-address-actions uk-width-auto uk-flex uk-flex-bottom">
+                    <ul class="uk-iconnav">
+                      <li><a ngxClipboard [cbContent]="currentBlock.representative" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Account Address" uk-tooltip></a></li>
+                    </ul>
+                  </div>
+                </div>
               </div>
-              <div class="uk-card-body">
+              <div *ngIf="txType !== txTypes.change" class="uk-card-body">
                 <div uk-grid>
                   <div class="uk-width-1-2 uk-text-muted">
                     <div class="uk-text-small text-half-muted" style="height: 25px;">Balance when block was created</div>

--- a/src/app/components/sign/sign.component.ts
+++ b/src/app/components/sign/sign.component.ts
@@ -46,6 +46,7 @@ export class SignComponent implements OnInit {
   toAccountID = '';
   toAccountBalance: BigNumber = null;
   toAddressBook = '';
+  repAddressBook = '';
   toAccountStatus = null;
   currentBlock: StateBlock = null;
   previousBlock: StateBlock = null;
@@ -227,7 +228,7 @@ export class SignComponent implements OnInit {
             this.previousBlock.representative !== this.currentBlock.representative && this.currentBlock.link === this.nullBlock) {
           // it's a change block
           this.txType = TxType.change;
-          this.txTypeMessage = 'change representative to';
+          this.txTypeMessage = 'change the representative';
           this.rawAmount = new BigNumber(0);
           this.fromAccountID = this.currentBlock.account;
           this.toAccountID = this.currentBlock.account;
@@ -426,6 +427,7 @@ export class SignComponent implements OnInit {
 
     this.fromAddressBook = this.addressBookService.getAccountName(this.fromAccountID);
     this.toAddressBook = this.addressBookService.getAccountName(this.toAccountID);
+    this.repAddressBook = this.addressBookService.getAccountName(this.currentBlock.representative);
 
     this.activePanel = 'confirm';
     // Start precopmuting the work...

--- a/src/app/components/sign/sign.component.ts
+++ b/src/app/components/sign/sign.component.ts
@@ -423,7 +423,7 @@ export class SignComponent implements OnInit {
     if (this.settings.settings.serverAPI) {
       this.amountFiat = this.util.nano.rawToMnano(this.rawAmount).times(this.price.price.lastPrice).toNumber();
     }
-    
+
     this.fromAddressBook = this.addressBookService.getAccountName(this.fromAccountID);
     this.toAddressBook = this.addressBookService.getAccountName(this.toAccountID);
 

--- a/src/app/components/sign/sign.component.ts
+++ b/src/app/components/sign/sign.component.ts
@@ -10,6 +10,7 @@ import {AppSettingsService} from '../../services/app-settings.service';
 import {ActivatedRoute, Router} from '@angular/router';
 import {NanoBlockService} from '../../services/nano-block.service';
 import {ApiService} from '../../services/api.service';
+import {PriceService} from '../../services/price.service';
 import * as QRCode from 'qrcode';
 import * as bip39 from 'bip39';
 import * as bip39Wallet from 'nanocurrency-web';
@@ -38,6 +39,7 @@ export class SignComponent implements OnInit {
   addressBookMatch = '';
   amount = null;
   rawAmount: BigNumber = new BigNumber(0);
+  amountFiat: number|null = null;
   fromAccountID: any = '';
   fromAccountBalance: BigNumber = null;
   fromAddressBook = '';
@@ -122,7 +124,8 @@ export class SignComponent implements OnInit {
     private api: ApiService,
     private util: UtilService,
     private qrModalService: QrModalService,
-    private musigService: MusigService) { }
+    private musigService: MusigService,
+    public price: PriceService) { }
 
   @ViewChild('dataAddFocus') _el: ElementRef;
 
@@ -416,6 +419,11 @@ export class SignComponent implements OnInit {
   }
 
   async prepareTransaction() {
+    // Determine fiat value of the amount (if not offline mode)
+    if (this.settings.settings.serverAPI) {
+      this.amountFiat = this.util.nano.rawToMnano(this.rawAmount).times(this.price.price.lastPrice).toNumber();
+    }
+    
     this.fromAddressBook = this.addressBookService.getAccountName(this.fromAccountID);
     this.toAddressBook = this.addressBookService.getAccountName(this.toAccountID);
 


### PR DESCRIPTION
Fixes #427 

* Fiat amount hidden if signing on an offline device
* Another detail that differs from the original SEND screen is the "N/A balance" of the sender when receiving funds. That's how the nano protocol is designed, the info is not part of the block. Plus it's forced to N/A also for the recipient balance to avoid confusion if the recipient balance changes while doing the signing of SEND blocks (which it's allowed to do)

Example screens:
![image](https://user-images.githubusercontent.com/2406720/126913141-9ec4ebf5-1964-4d37-a907-f68d15861880.png)

![image](https://user-images.githubusercontent.com/2406720/126913179-41523f88-65a3-425c-b306-2266435caf78.png)

![image](https://user-images.githubusercontent.com/2406720/126913194-d2c6e879-e067-4325-8aab-7d86b8c84659.png)
