### PR TITLE
Clear password field when the wallet unlock modal is shown

### DIFF
--- a/src/app/components/wallet-widget/wallet-widget.component.html
+++ b/src/app/components/wallet-widget/wallet-widget.component.html
@@ -38,7 +38,7 @@
 </div>
 
 <ng-container *ngIf="walletService.isConfigured() && !walletService.isLedgerWallet()">
-  <div class="nav-status-row half-muted interactable" (click)="modal.show()" *ngIf="walletService.isLocked()">
+  <div class="nav-status-row half-muted interactable" (click)="showModal()" *ngIf="walletService.isLocked()">
     <div class="status-icon">
       <span uk-icon="icon: lock; ratio: 1.2;" class="uk-text-top"></span>
     </div>

--- a/src/app/components/wallet-widget/wallet-widget.component.ts
+++ b/src/app/components/wallet-widget/wallet-widget.component.ts
@@ -49,6 +49,11 @@ export class WalletWidgetComponent implements OnInit {
     });
   }
 
+  showModal() {
+    this.unlockPassword = '';
+    this.modal.show();
+  }
+
   async lockWallet() {
     if (this.wallet.type === 'ledger') {
       return; // No need to lock a ledger wallet, no password saved


### PR DESCRIPTION
1. click Wallet Locked
2. modal appears
3. type "123"
4. close modal
5. click Wallet Locked

before PR:
6. "123" is still there

after PR
6. the field is empty