### PR TITLE
Require API calls to return a JSON response

### DIFF
--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -22,14 +22,21 @@ export class ApiService {
         this.node.setLoading();
       }
     }
-    let header;
+    let options: any = {
+      responseType: 'json',
+    };
     if (this.appSettings.settings.serverAuth != null && this.appSettings.settings.serverAuth !== '') {
-      header = {
-        headers: new HttpHeaders()
-          .set('Authorization',  this.appSettings.settings.serverAuth)
-      };
+      options =
+        Object.assign(
+          {},
+          options,
+          {
+            headers: new HttpHeaders()
+              .set('Authorization', this.appSettings.settings.serverAuth)
+          }
+        );
     }
-    return await this.http.post(apiUrl, data, header).toPromise()
+    return await this.http.post(apiUrl, data, options).toPromise()
       .then(res => {
         this.node.setOnline();
         return res;


### PR DESCRIPTION
Potential fix for #471

Please test with a custom backend server that returns a non-JSON response (e.g. missing `}` at the end) and verify that node is considered offline as a result of the call (should autoswitch backend if set to "Random")