### PR TITLE
Add transloco test to make sure that you cannot use the language word…

### DIFF
--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -551,7 +551,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const regexp = new RegExp('^Account|' + this.translocoService.translate('general.account') + ' #\\d+$', 'g');
+    const regexp = new RegExp('^(Account)|(' + this.translocoService.translate('general.account') + ') #\\d+$', 'g');
     if ( regexp.test(this.addressBookModel) === true ) {
       return this.notifications.sendError(`This name is reserved for wallet accounts without a label`);
     }

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -551,7 +551,8 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if ( /^Account #\d+$/g.test(this.addressBookModel) === true ) {
+    let regexp = new RegExp('^' + this.translocoService.translate('general.account') + ' #\\d+$', 'g');
+    if ( regexp.test(this.addressBookModel) === true ) {
       return this.notifications.sendError(`This name is reserved for wallet accounts without a label`);
     }
 

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -551,7 +551,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const regexp = new RegExp('^(Account)|(' + this.translocoService.translate('general.account') + ') #\\d+$', 'g');
+    const regexp = new RegExp('^(Account|' + this.translocoService.translate('general.account') + ') #\\d+$', 'g');
     if ( regexp.test(this.addressBookModel) === true ) {
       return this.notifications.sendError(`This name is reserved for wallet accounts without a label`);
     }

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -551,7 +551,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    let regexp = new RegExp('^' + this.translocoService.translate('general.account') + ' #\\d+$', 'g');
+    const regexp = new RegExp('^' + this.translocoService.translate('general.account') + ' #\\d+$', 'g');
     if ( regexp.test(this.addressBookModel) === true ) {
       return this.notifications.sendError(`This name is reserved for wallet accounts without a label`);
     }

--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -551,7 +551,7 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const regexp = new RegExp('^' + this.translocoService.translate('general.account') + ' #\\d+$', 'g');
+    const regexp = new RegExp('^Account|' + this.translocoService.translate('general.account') + ' #\\d+$', 'g');
     if ( regexp.test(this.addressBookModel) === true ) {
       return this.notifications.sendError(`This name is reserved for wallet accounts without a label`);
     }

--- a/src/app/components/address-book/address-book.component.ts
+++ b/src/app/components/address-book/address-book.component.ts
@@ -11,6 +11,7 @@ import {BigNumber} from 'bignumber.js';
 import {ApiService} from '../../services/api.service';
 import {PriceService} from '../../services/price.service';
 import {AppSettingsService} from '../../services/app-settings.service';
+import {TranslocoService} from '@ngneat/transloco';
 
 export interface BalanceAccount {
   balance: BigNumber;
@@ -65,7 +66,8 @@ export class AddressBookComponent implements OnInit, AfterViewInit, OnDestroy {
     private router: Router,
     private api: ApiService,
     private price: PriceService,
-    public appSettings: AppSettingsService) { }
+    public appSettings: AppSettingsService,
+    private translocoService: TranslocoService) { }
 
   async ngOnInit() {
     this.addressBookService.loadAddressBook();
@@ -274,7 +276,8 @@ export class AddressBookComponent implements OnInit, AfterViewInit, OnDestroy {
     // Trim and remove duplicate spaces
     this.newAddressName = this.newAddressName.trim().replace(/ +/g, ' ');
 
-    if ( /^Account #\d+$/g.test(this.newAddressName) === true ) {
+    let regexp = new RegExp('^' + this.translocoService.translate('general.account') + ' #\\d+$', 'g');
+    if ( regexp.test(this.newAddressName) === true ) {
       return this.notificationService.sendError(`This name is reserved for wallet accounts without a label`);
     }
 

--- a/src/app/components/address-book/address-book.component.ts
+++ b/src/app/components/address-book/address-book.component.ts
@@ -276,7 +276,7 @@ export class AddressBookComponent implements OnInit, AfterViewInit, OnDestroy {
     // Trim and remove duplicate spaces
     this.newAddressName = this.newAddressName.trim().replace(/ +/g, ' ');
 
-    const regexp = new RegExp('^(Account)|(' + this.translocoService.translate('general.account') + ') #\\d+$', 'g');
+    const regexp = new RegExp('^(Account|' + this.translocoService.translate('general.account') + ') #\\d+$', 'g');
     if ( regexp.test(this.newAddressName) === true ) {
       return this.notificationService.sendError(`This name is reserved for wallet accounts without a label`);
     }

--- a/src/app/components/address-book/address-book.component.ts
+++ b/src/app/components/address-book/address-book.component.ts
@@ -276,7 +276,7 @@ export class AddressBookComponent implements OnInit, AfterViewInit, OnDestroy {
     // Trim and remove duplicate spaces
     this.newAddressName = this.newAddressName.trim().replace(/ +/g, ' ');
 
-    let regexp = new RegExp('^' + this.translocoService.translate('general.account') + ' #\\d+$', 'g');
+    const regexp = new RegExp('^' + this.translocoService.translate('general.account') + ' #\\d+$', 'g');
     if ( regexp.test(this.newAddressName) === true ) {
       return this.notificationService.sendError(`This name is reserved for wallet accounts without a label`);
     }

--- a/src/app/components/address-book/address-book.component.ts
+++ b/src/app/components/address-book/address-book.component.ts
@@ -276,7 +276,7 @@ export class AddressBookComponent implements OnInit, AfterViewInit, OnDestroy {
     // Trim and remove duplicate spaces
     this.newAddressName = this.newAddressName.trim().replace(/ +/g, ' ');
 
-    const regexp = new RegExp('^' + this.translocoService.translate('general.account') + ' #\\d+$', 'g');
+    const regexp = new RegExp('^Account|' + this.translocoService.translate('general.account') + ' #\\d+$', 'g');
     if ( regexp.test(this.newAddressName) === true ) {
       return this.notificationService.sendError(`This name is reserved for wallet accounts without a label`);
     }

--- a/src/app/components/address-book/address-book.component.ts
+++ b/src/app/components/address-book/address-book.component.ts
@@ -276,7 +276,7 @@ export class AddressBookComponent implements OnInit, AfterViewInit, OnDestroy {
     // Trim and remove duplicate spaces
     this.newAddressName = this.newAddressName.trim().replace(/ +/g, ' ');
 
-    const regexp = new RegExp('^Account|' + this.translocoService.translate('general.account') + ' #\\d+$', 'g');
+    const regexp = new RegExp('^(Account)|(' + this.translocoService.translate('general.account') + ') #\\d+$', 'g');
     if ( regexp.test(this.newAddressName) === true ) {
       return this.notificationService.sendError(`This name is reserved for wallet accounts without a label`);
     }


### PR DESCRIPTION
… set in general.account followed by space#number as the name used in Address Book.

Fixes #463 assuming that just the current chosen language is restricted.

A potential loophole is that if I set to 'Account #1' while in German, it will stay when setting language to English.