### PR TITLE
Wallet creation wording changes and UI/UX improvements

### DIFF
--- a/src/app/components/configure-wallet/configure-wallet.component.css
+++ b/src/app/components/configure-wallet/configure-wallet.component.css
@@ -1,3 +1,7 @@
+.new-wallet-seed {
+  word-wrap: anywhere;
+}
+
 pre.mnemonic {
   white-space: pre-wrap;
 }

--- a/src/app/components/configure-wallet/configure-wallet.component.html
+++ b/src/app/components/configure-wallet/configure-wallet.component.html
@@ -413,73 +413,83 @@
 
 <div class="uk-card uk-card-default" *ngIf="activePanel === panels.backup">
   <div class="uk-card-header">
-    <h3 class="uk-card-title">Save Wallet Backup</h3>
+    <h3 class="uk-card-title">{{ 'configure-wallet.new-wallet.recovery-phrases-for-new-wallet' | transloco }}</h3>
   </div>
   <div class="uk-card-body">
-    <p>
-      Below is the seed and mnemonic backup. You can use whichever you prefer in any compatible wallet.
-    </p>
+    <p>{{ 'configure-wallet.new-wallet.please-take-some-time-to-write-down-recovery-phrases' | transloco }}</p>
     <div>
       <div class="uk-alert uk-alert-danger nlt-inline-alert">
         <div class="icon-column">
           <div uk-icon="icon: warning; ratio: 2;"></div>
         </div>
         <p>
-          Make sure to write down your seed and/or mnemonic or save it somewhere safe, and <strong>never share it with anyone!</strong><br>
-      It is the master key to all of your accounts, and the only way to recover your funds in an emergency.<br>
+          {{ 'configure-wallet.new-wallet.recovery-phrases-alert.1.1' | transloco }}<strong>{{ 'configure-wallet.new-wallet.recovery-phrases-alert.1.2-strong' | transloco }}</strong>{{ 'configure-wallet.new-wallet.recovery-phrases-alert.1.3' | transloco }}<br>
+          {{ 'configure-wallet.new-wallet.recovery-phrases-alert.2' | transloco }}
         </p>
       </div>
     </div>
     <br>
 
     <div uk-grid>
-      <div class="uk-width-1-4">Nano Seed</div>
-      <div class="uk-width-3-4 uk-text-truncate">
+      <div class="uk-width-1-4@m">{{ 'configure-wallet.new-wallet.secret-recovery-seed' | transloco }}</div>
+      <div class="uk-width-3-4@m uk-text-truncate">
         <div class="uk-margin-small-bottom">{{ newWalletSeed }}</div>
-        <a title="Copy Seed To Clipboard" ngxClipboard [cbContent]="newWalletSeed" (cbOnSuccess)="copied()" uk-tooltip>Copy seed to clipboard</a>
+        <button
+          class="uk-button uk-button-secondary uk-text-center nlt-icon-button"
+          type="button"
+          ngxClipboard
+          [cbContent]="newWalletSeed"
+          (cbOnSuccess)="copiedNewWalletSeed()"
+        >
+          <span class="nlt-icon" uk-icon="icon: copy;"></span>
+          {{ 'configure-wallet.new-wallet.copy-secret-recovery-seed' | transloco }}
+        </button>
       </div>
     </div>
 
     <hr class="uk-divider-icon">
 
     <div uk-grid>
-      <div class="uk-width-1-4@m">
-        Nano Mnemonic<br>
-      </div>
+      <div class="uk-width-1-4@m">{{ 'configure-wallet.new-wallet.secret-recovery-mnemonic' | transloco }}</div>
       <div class="uk-width-3-4@m">
         <pre class="mne-box"><span *ngFor="let line of newWalletMnemonicLines; let l = index" class="mne-cont"><span *ngFor="let word of line; let i = index" class="mne-word"><span class="mne-num">{{ (l * 4) + i + 1 }}</span> {{ word }}</span></span></pre>
-        <a title="Copy Mnemonic To Clipboard" ngxClipboard [cbContent]="newWalletMnemonic" (cbOnSuccess)="copied()" uk-tooltip>Copy mnemonic to clipboard</a>
+        <button
+          class="uk-button uk-button-secondary uk-text-center nlt-icon-button"
+          type="button"
+          ngxClipboard
+          [cbContent]="newWalletMnemonic"
+          (cbOnSuccess)="copiedNewWalletMnemonic()"
+        >
+          <span class="nlt-icon" uk-icon="icon: copy;"></span>
+          {{ 'configure-wallet.new-wallet.copy-secret-recovery-mnemonic' | transloco }}
+        </button>
       </div>
     </div>
     <hr/>
     <div class="uk-width-1-1">
-      <label style="cursor: pointer;"><input type="checkbox" class="uk-checkbox" [(ngModel)]="hasConfirmedBackup"> &nbsp; I have securely stored the seed and/or mnemonic</label>
+      <label style="cursor: pointer;"><input type="checkbox" class="uk-checkbox" [(ngModel)]="hasConfirmedBackup"> &nbsp; {{ 'configure-wallet.new-wallet.i-have-securely-stored-recovery-phrases' | transloco }}</label>
     </div>
   </div>
   <div class="uk-card-footer uk-text-right nlt-button-group">
-    <button class="uk-button uk-button-primary uk-width-auto@s uk-width-1-1" id="create-wallet" [disabled]="!hasConfirmedBackup" (click)="confirmNewSeed()">CREATE WALLET</button>
+    <button class="uk-button uk-button-primary uk-width-auto@s uk-width-1-1" id="create-wallet" [disabled]="!hasConfirmedBackup" (click)="confirmNewSeed()">{{ 'configure-wallet.new-wallet.create-wallet' | transloco }}</button>
   </div>
 </div>
 
 <div class="uk-card uk-card-default" *ngIf="activePanel === panels.password">
   <div class="uk-card-header">
-    <h3 class="uk-card-title">Set Wallet Password</h3>
+    <h3 class="uk-card-title">{{ 'configure-wallet.set-wallet-password.set-wallet-password' | transloco }}</h3>
   </div>
   <div class="uk-card-body">
-    <p>
-      Your password is used to encrypt the sensitive parts of
-      your wallet when it is locked, which disables sending, receiving, creating accounts, and other operations.
-    </p>
-
-    <p>
-      For the safety of your funds, use a secure password (the bar should be green).
-    </p>
+    <p>{{ 'configure-wallet.set-wallet-password.choose-a-wallet-password-that-will-be-used-to-unlock-this-application' | transloco }}</p>
+    <p>{{ 'configure-wallet.set-wallet-password.while-the-application-is-locked-the-secret-recovery-phrase-will-be-encrypted' | transloco }}</p>
+    <p>{{ 'configure-wallet.set-wallet-password.for-the-safety-of-your-funds-use-a-secure-password' | transloco }}</p>
+    <br>
     <div uk-grid>
       <div class="uk-width-1-2@m">
         <input type="password" class="uk-input" [(ngModel)]="walletPasswordModel" placeholder="New Wallet Password">
         <password-strength-meter *ngIf="walletPasswordModel.length > 0" [password]="walletPasswordModel" [enableFeedback]="true" [minPasswordLength]="6"></password-strength-meter>
-        <span class="password-helper" *ngIf="walletPasswordModel.length > 0 && walletPasswordModel.length < 6">Password must be at least 6 characters long</span>
-        <span class="password-helper" *ngIf="walletPasswordConfirmModel.length >= 6 && walletPasswordModel !== walletPasswordConfirmModel">Passwords do not match!</span>
+        <span class="password-helper" *ngIf="walletPasswordModel.length > 0 && walletPasswordModel.length < 6">{{ 'configure-wallet.set-wallet-password.errors.password-must-be-at-least-x-characters-long' | transloco: { minCharacters: 6 } }}</span>
+        <span class="password-helper" *ngIf="walletPasswordConfirmModel.length >= 6 && walletPasswordModel !== walletPasswordConfirmModel">{{ 'configure-wallet.set-wallet-password.errors.passwords-do-not-match' | transloco }}</span>
       </div>
       <div class="uk-width-1-2@m">
         <input type="password" class="uk-input" (keyup.enter)="saveWalletPassword()" [(ngModel)]="walletPasswordConfirmModel" placeholder="Confirm Wallet Password">

--- a/src/app/components/configure-wallet/configure-wallet.component.html
+++ b/src/app/components/configure-wallet/configure-wallet.component.html
@@ -433,7 +433,7 @@
     <div uk-grid>
       <div class="uk-width-1-4@m">{{ 'configure-wallet.new-wallet.secret-recovery-seed' | transloco }}</div>
       <div class="uk-width-3-4@m uk-text-truncate">
-        <div class="uk-margin-small-bottom">{{ newWalletSeed }}</div>
+        <div class="uk-margin-small-bottom uk-text-truncate">{{ newWalletSeed }}</div>
         <button
           class="uk-button uk-button-secondary uk-text-center nlt-icon-button"
           type="button"

--- a/src/app/components/configure-wallet/configure-wallet.component.html
+++ b/src/app/components/configure-wallet/configure-wallet.component.html
@@ -432,8 +432,8 @@
 
     <div uk-grid>
       <div class="uk-width-1-4@m">{{ 'configure-wallet.new-wallet.secret-recovery-seed' | transloco }}</div>
-      <div class="uk-width-3-4@m uk-text-truncate">
-        <div class="uk-margin-small-bottom uk-text-truncate">{{ newWalletSeed }}</div>
+      <div class="uk-width-3-4@m">
+        <div class="new-wallet-seed uk-margin-small-bottom">{{ newWalletSeed }}</div>
         <button
           class="uk-button uk-button-secondary uk-text-center nlt-icon-button"
           type="button"

--- a/src/app/components/configure-wallet/configure-wallet.component.ts
+++ b/src/app/components/configure-wallet/configure-wallet.component.ts
@@ -6,6 +6,7 @@ import {LedgerService, LedgerStatus} from '../../services/ledger.service';
 import { QrModalService } from '../../services/qr-modal.service';
 import {UtilService} from '../../services/util.service';
 import { wallet } from 'nanocurrency-web';
+import { TranslocoService } from '@ngneat/transloco';
 
 enum panels {
   'landing',
@@ -77,7 +78,8 @@ export class ConfigureWalletComponent implements OnInit {
     private route: Router,
     private qrModalService: QrModalService,
     private ledgerService: LedgerService,
-    private util: UtilService) {
+    private util: UtilService,
+    private translocoService: TranslocoService) {
     if (this.route.getCurrentNavigation().extras.state && this.route.getCurrentNavigation().extras.state.seed) {
       this.activePanel = panels.import;
       this.importSeedModel = this.route.getCurrentNavigation().extras.state.seed;
@@ -362,9 +364,20 @@ export class ConfigureWalletComponent implements OnInit {
     }
   }
 
-  copied() {
+  copiedNewWalletSeed() {
     this.notifications.removeNotification('success-copied');
-    this.notifications.sendSuccess(`Wallet seed copied to clipboard!`, { identifier: 'success-copied' });
+    this.notifications.sendSuccess(
+      this.translocoService.translate('configure-wallet.new-wallet.successfully-copied-secret-recovery-seed'),
+      { identifier: 'success-copied' }
+    );
+  }
+
+  copiedNewWalletMnemonic() {
+    this.notifications.removeNotification('success-copied');
+    this.notifications.sendSuccess(
+      this.translocoService.translate('configure-wallet.new-wallet.successfully-copied-secret-recovery-mnemonic'),
+      { identifier: 'success-copied' }
+    );
   }
 
   importFromFile(files) {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -82,6 +82,38 @@
     "you-can-change-representative-at-any-time": "You can change representative at any time by clicking on its name above.",
     "you-have-marked-this-representative-as-trusted": "You have marked this representative as trusted, meaning its status will remain \"Good\" even in case of severe issues with uptime or weight distribution."
   },
+  "configure-wallet": {
+    "set-wallet-password": {
+      "set-wallet-password": "Set Wallet Password",
+      "choose-a-wallet-password-that-will-be-used-to-unlock-this-application": "Choose a wallet password that will be used to unlock this application.",
+      "while-the-application-is-locked-the-secret-recovery-phrase-will-be-encrypted": "While the application is locked, the secret recovery phrase will be encrypted, which prevents sending/receiving funds and managing accounts.",
+      "for-the-safety-of-your-funds-use-a-secure-password": "For the safety of your funds, use a secure password (the bar should be green).",
+      "errors": {
+        "password-must-be-at-least-x-characters-long": "Password must be at least {{ minCharacters }} characters long",
+        "passwords-do-not-match": "Passwords do not match!"
+      }
+    },
+    "new-wallet": {
+      "recovery-phrases-for-new-wallet": "Recovery Phrases for New Wallet",
+      "please-take-some-time-to-write-down-recovery-phrases": "Please take some time to backup the secret recovery seed and/or mnemonic, to be able to access this wallet in the future.",
+      "recovery-phrases-alert": {
+        "1": {
+          "1": "Make sure to write down your seed and/or mnemonic or save it somewhere safe, and ",
+          "2-strong": "never share it with anyone",
+          "3": "!"
+        },
+        "2": "It is the master key to all of your accounts, and the only way to recover your funds in an emergency."
+      },
+      "secret-recovery-seed": "Secret Recovery Seed",
+      "secret-recovery-mnemonic": "Secret Recovery Mnemonic",
+      "copy-secret-recovery-seed": "Copy Secret Recovery Seed",
+      "copy-secret-recovery-mnemonic": "Copy Secret Recovery Mnemonic",
+      "successfully-copied-secret-recovery-seed": "Successfully copied Secret Recovery Seed to clipboard!",
+      "successfully-copied-secret-recovery-mnemonic": "Successfully copied Secret Recovery Mnemonic to clipboard!",
+      "i-have-securely-stored-recovery-phrases": "I have securely stored the secret recovery seed and/or mnemonic",
+      "create-wallet": "Create Wallet"
+    }
+  },
   "configure-app": {
     "language": "Language"
   },


### PR DESCRIPTION
this PR tries to improve wording that's shown to users in hopes that it reduces common mistakes, reduces confusion and misinformation

\-

additionally, it fixes a pretty bad display issue with secret recovery seeds on the wallet creation page, where the user might manually copy or write down the displayed secret recovery seed, not realizing that only a part of it is shown:

![2021-10-26_14-06-51](https://user-images.githubusercontent.com/29272208/138895843-e4f64345-404d-4af0-8f9a-2dcbcebb104f.gif)

(please do not use the seed above, it's here for demonstrational purposes only)

\-

the PR also fixes a bug where copying mnemonic would display a "Seed successfully copied" notification, and replaces "copy to clipboard" links with buttons

\-

set wallet password (old):

![image](https://user-images.githubusercontent.com/29272208/138892269-ffa99a63-e53d-4a1b-a4b7-f76b0dae498d.png)

set wallet password (new):

![image](https://user-images.githubusercontent.com/29272208/138892355-7d13651d-c154-4980-a16a-99458e57dc49.png)

\-

wallet creation page (old):

![image](https://user-images.githubusercontent.com/29272208/138893718-488f01e7-9923-4f4e-ba8f-525fa75e70b5.png)

wallet creation page (new):

![image](https://user-images.githubusercontent.com/29272208/138895146-9e9f5b0e-22fa-46dc-a13c-61ff86d163b3.png)