### PR TITLE
Prompt wallet password instead of stating that "Wallet must be unlocked"

### DIFF
--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -957,9 +957,14 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
   async receiveReceivableBlock(receivableBlock) {
     const sourceBlock = receivableBlock.hash;
 
-    if (this.wallet.walletIsLocked()) {
-      return this.notifications.sendWarning(`Wallet must be unlocked`);
+    if (this.wallet.isLocked()) {
+      const wasUnlocked = await this.wallet.requestWalletUnlock();
+
+      if (wasUnlocked === false) {
+        return;
+      }
     }
+
     receivableBlock.loading = true;
 
     const createdReceiveBlockHash =

--- a/src/app/components/accounts/accounts.component.ts
+++ b/src/app/components/accounts/accounts.component.ts
@@ -48,8 +48,13 @@ export class AccountsComponent implements OnInit {
 
   async createAccount() {
     if (this.walletService.isLocked()) {
-      return this.notificationService.sendError(this.translocoService.translate('accounts.wallet-is-locked'));
+      const wasUnlocked = await this.walletService.requestWalletUnlock();
+
+      if (wasUnlocked === false) {
+        return;
+      }
     }
+
     if ((this.isLedgerWallet) && (this.ledger.ledger.status !== LedgerStatus.READY)) {
       return this.notificationService.sendWarning(this.translocoService.translate('accounts.ledger-device-must-be-ready'));
     }
@@ -113,9 +118,14 @@ export class AccountsComponent implements OnInit {
   }
 
   async deleteAccount(account) {
-    if (this.walletService.walletIsLocked()) {
-      return this.notificationService.sendWarning(this.translocoService.translate('accounts.wallet-is-locked'));
+    if (this.walletService.isLocked()) {
+      const wasUnlocked = await this.walletService.requestWalletUnlock();
+
+      if (wasUnlocked === false) {
+        return;
+      }
     }
+
     try {
       await this.walletService.removeWalletAccount(account.id);
       this.notificationService.sendSuccess(

--- a/src/app/components/manage-wallet/manage-wallet.component.ts
+++ b/src/app/components/manage-wallet/manage-wallet.component.ts
@@ -73,8 +73,12 @@ export class ManageWalletComponent implements OnInit {
     if (this.newPassword.length < 1) {
       return this.notifications.sendError(`Password cannot be empty`);
     }
-    if (this.walletService.walletIsLocked()) {
-      return this.notifications.sendWarning(`Wallet must be unlocked`);
+    if (this.walletService.isLocked()) {
+      const wasUnlocked = await this.walletService.requestWalletUnlock();
+
+      if (wasUnlocked === false) {
+        return;
+      }
     }
 
     this.walletService.wallet.password = this.newPassword;
@@ -88,8 +92,12 @@ export class ManageWalletComponent implements OnInit {
   }
 
   async exportWallet() {
-    if (this.walletService.walletIsLocked()) {
-      return this.notifications.sendWarning(`Wallet must be unlocked`);
+    if (this.walletService.isLocked()) {
+      const wasUnlocked = await this.walletService.requestWalletUnlock();
+
+      if (wasUnlocked === false) {
+        return;
+      }
     }
 
     const exportUrl = this.walletService.generateExportUrl();
@@ -174,9 +182,13 @@ export class ManageWalletComponent implements OnInit {
     }
   }
 
-  exportToFile() {
-    if (this.walletService.walletIsLocked()) {
-      return this.notifications.sendWarning(`Wallet must be unlocked`);
+  async exportToFile() {
+    if (this.walletService.isLocked()) {
+      const wasUnlocked = await this.walletService.requestWalletUnlock();
+
+      if (wasUnlocked === false) {
+        return;
+      }
     }
 
     const fileName = `Nault-Wallet.json`;

--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -311,8 +311,12 @@ export class ReceiveComponent implements OnInit, OnDestroy {
       throw new Error(`Unable to find receiving account in wallet`);
     }
 
-    if (this.walletService.walletIsLocked()) {
-      return this.notificationService.sendWarning(`Wallet must be unlocked`);
+    if (this.walletService.isLocked()) {
+      const wasUnlocked = await this.walletService.requestWalletUnlock();
+
+      if (wasUnlocked === false) {
+        return;
+      }
     }
     receivableBlock.loading = true;
 

--- a/src/app/components/representatives/representatives.component.ts
+++ b/src/app/components/representatives/representatives.component.ts
@@ -287,8 +287,12 @@ export class RepresentativesComponent implements OnInit {
     if (this.changingRepresentatives) {
       return; // Already running
     }
-    if (this.walletService.walletIsLocked()) {
-      return this.notifications.sendWarning(`Wallet must be unlocked`);
+    if (this.walletService.isLocked()) {
+      const wasUnlocked = await this.walletService.requestWalletUnlock();
+
+      if (wasUnlocked === false) {
+        return;
+      }
     }
     if (!accounts || !accounts.length) {
       return this.notifications.sendWarning(`You must select at least one account to change`);

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -358,8 +358,12 @@ export class SendComponent implements OnInit {
     if (!walletAccount) {
       throw new Error(`Unable to find sending account in wallet`);
     }
-    if (this.walletService.walletIsLocked()) {
-      return this.notificationService.sendWarning(`Wallet must be unlocked`);
+    if (this.walletService.isLocked()) {
+      const wasUnlocked = await this.walletService.requestWalletUnlock();
+
+      if (wasUnlocked === false) {
+        return;
+      }
     }
 
     this.confirmingTransaction = true;

--- a/src/app/components/sign/sign.component.ts
+++ b/src/app/components/sign/sign.component.ts
@@ -453,8 +453,12 @@ export class SignComponent implements OnInit {
 
     // using internal wallet
     if (this.signTypeSelected === this.signTypes[0] && walletAccount) {
-      if (this.walletService.walletIsLocked()) {
-        return this.notificationService.sendWarning('Wallet must be unlocked for signing with it');
+      if (this.walletService.isLocked()) {
+        const wasUnlocked = await this.walletService.requestWalletUnlock();
+
+        if (wasUnlocked === false) {
+          return;
+        }
       }
     } else if (this.signTypeSelected === this.signTypes[0]) {
       return this.notificationService.sendWarning('Could not find a matching wallet account to sign with. Make sure it\'s added under your accounts');

--- a/src/app/components/wallet-widget/wallet-widget.component.html
+++ b/src/app/components/wallet-widget/wallet-widget.component.html
@@ -65,7 +65,7 @@
   </div>
 </a>
 
-<div id="unlock-wallet-modal" uk-modal>
+<div class="modal-position-bottom" id="unlock-wallet-modal" uk-modal>
   <div class="uk-modal-dialog">
     <button class="uk-modal-close-default" type="button" uk-close></button>
     <div class="uk-modal-header">

--- a/src/app/components/wallet-widget/wallet-widget.component.ts
+++ b/src/app/components/wallet-widget/wallet-widget.component.ts
@@ -34,11 +34,15 @@ export class WalletWidgetComponent implements OnInit {
   ngOnInit() {
     const UIkit = (window as any).UIkit;
     const modal = UIkit.modal(document.getElementById('unlock-wallet-modal'));
+    UIkit.util.on('#unlock-wallet-modal', 'hidden', () => {
+      this.onModalHidden();
+    });
     this.modal = modal;
 
     this.ledgerService.ledgerStatus$.subscribe((ledgerStatus: any) => {
       this.ledgerStatus = ledgerStatus.status;
     });
+
     // Detect if a PoW is taking too long and alert
     this.powService.powAlert$.subscribe(async shouldAlert => {
       if (shouldAlert) {
@@ -47,11 +51,22 @@ export class WalletWidgetComponent implements OnInit {
         this.powAlert = false;
       }
     });
+
+    this.walletService.wallet.unlockModalRequested$.subscribe(async wasRequested => {
+      if (wasRequested === true) {
+        this.showModal();
+      }
+    });
   }
 
   showModal() {
     this.unlockPassword = '';
     this.modal.show();
+  }
+
+  onModalHidden() {
+    this.unlockPassword = '';
+    this.walletService.wallet.unlockModalRequested$.next(false);
   }
 
   async lockWallet() {

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -1152,6 +1152,6 @@ export class WalletService {
             }
           });
       }
-     );
+    );
   }
 }

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -63,6 +63,8 @@ export interface FullWallet {
   selectedAccount: WalletAccount|null;
   selectedAccount$: BehaviorSubject<WalletAccount|null>;
   locked: boolean;
+  locked$: BehaviorSubject<boolean|false>;
+  unlockModalRequested$: BehaviorSubject<boolean|false>;
   password: string;
   pendingBlocks: Block[];
   pendingBlocksUpdate$: BehaviorSubject<ReceivableBlockUpdate|null>;
@@ -111,6 +113,8 @@ export class WalletService {
     selectedAccount: null,
     selectedAccount$: new BehaviorSubject(null),
     locked: false,
+    locked$: new BehaviorSubject(false),
+    unlockModalRequested$: new BehaviorSubject(false),
     password: '',
     pendingBlocks: [],
     pendingBlocksUpdate$: new BehaviorSubject(null),
@@ -315,6 +319,7 @@ export class WalletService {
       this.wallet.seed = walletJson.seed;
       this.wallet.seedBytes = this.util.hex.toUint8(walletJson.seed);
       this.wallet.locked = true;
+      this.wallet.locked$.next(true);
     }
     if (walletType === 'ledger') {
       // Check ledger status?
@@ -409,6 +414,7 @@ export class WalletService {
     });
 
     this.wallet.locked = true;
+    this.wallet.locked$.next(true);
     this.wallet.password = '';
 
     this.saveWalletExport(); // Save so that a refresh gives you a locked wallet
@@ -433,6 +439,7 @@ export class WalletService {
       });
 
       this.wallet.locked = false;
+      this.wallet.locked$.next(false);
       this.wallet.password = password;
 
       this.notifications.removeNotification('pending-locked'); // If there is a notification to unlock, remove it
@@ -446,10 +453,6 @@ export class WalletService {
     } catch (err) {
       return false;
     }
-  }
-
-  walletIsLocked() {
-    return this.wallet.locked;
   }
 
   async createWalletFromSeed(seed: string) {
@@ -632,6 +635,7 @@ export class WalletService {
     this.wallet.type = 'seed';
     this.wallet.password = '';
     this.wallet.locked = false;
+    this.wallet.locked$.next(false);
     this.wallet.seed = '';
     this.wallet.seedBytes = null;
     this.wallet.accounts = [];
@@ -1108,5 +1112,46 @@ export class WalletService {
   informBalanceRefresh() {
     this.wallet.refresh$.next(true);
     this.wallet.refresh$.next(false);
+  }
+
+  requestWalletUnlock() {
+    this.wallet.unlockModalRequested$.next(true);
+
+    return new Promise(
+      (resolve, reject) => {
+        let subscriptionForUnlock;
+        let subscriptionForCancel;
+
+        const removeSubscriptions = () => {
+          if (subscriptionForUnlock != null) {
+            subscriptionForUnlock.unsubscribe();
+          }
+
+          if (subscriptionForCancel != null) {
+            subscriptionForCancel.unsubscribe();
+          }
+        };
+
+        subscriptionForUnlock =
+          this.wallet.locked$.subscribe(async isLocked => {
+            if (isLocked === false) {
+              removeSubscriptions();
+
+              const wasUnlocked = true;
+              resolve(wasUnlocked);
+            }
+          });
+
+        subscriptionForCancel =
+          this.wallet.unlockModalRequested$.subscribe(async wasRequested => {
+            if (wasRequested === false) {
+              removeSubscriptions();
+
+              const wasUnlocked = false;
+              resolve(wasUnlocked);
+            }
+          });
+      }
+     );
   }
 }

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -489,19 +489,19 @@ input[type=number] {
 	.uk-tooltip {
 		display: none !important;
 	}
+
+	// Menu modal
+	.modal-position-bottom[style*="display: block;"] {
+		display: flex !important;
+		flex-direction: column;
+		justify-content: flex-end;
+	}
 }
 
 @media (min-width: 940px) {
 	.only-on-small-viewports {
 		display: none;
 	}
-}
-
-// Menu modal
-.modal-position-bottom[style*="display: block;"] {
-	display: flex !important;
-	flex-direction: column;
-	justify-content: flex-end;
 }
 
 .uk-modal {


### PR DESCRIPTION
Fixes #260

![2021-12-23_16-10-45](https://user-images.githubusercontent.com/29272208/147267969-e684be77-da38-4d37-aa30-587cbfc2909e.gif)

Replace `walletService.walletIsLocked()` with `walletService.isLocked()` as they seem to be serving the same purpose
Clear password variable/input when hiding wallet unlock modal (previously only cleared upon modal show / wallet unlock)
Wallet unlock modal is now bottom-aligned on small viewports
All other bottom-aligned modals are now only bottom-aligned on small viewports