### PR TITLE
Add hash/navigation to successor block on the Transaction Details page

### DIFF
--- a/src/app/components/transaction-details/transaction-details.component.html
+++ b/src/app/components/transaction-details/transaction-details.component.html
@@ -191,6 +191,29 @@
             </div>
           </div>
         </div>
+        <div class="uk-margin" *ngIf="successorHash">
+          <label class="uk-form-label">Successor:</label>
+          <div class="uk-form-controls uk-text-truncate">
+            <div uk-grid class="uk-flex-nowrap uk-text-truncate">
+              <a
+                class="uk-width-auto uk-text-truncate block-hash-monospace block-hash-clickable"
+                [routerLink]="'/transaction/' + successorHash"
+                style="max-width: calc(100% - 35px);"
+                title="View Block Details"
+                uk-tooltip
+              >{{ successorHash }}</a>
+              <div class="uk-width-auto block-hash-actions">
+                <ul class="uk-iconnav">
+                  <li><a ngxClipboard [cbContent]="successorHash" (cbOnSuccess)="copied()" uk-icon="icon: copy" title="Copy Successor Block Hash" uk-tooltip></a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="uk-margin" *ngIf="blockHeight != -1">
+          <label class="uk-form-label">Height:</label>
+          <div class="uk-form-controls uk-text-truncate">{{ blockHeight | number:'':'en-US' }}</div>
+        </div>
         <div class="uk-margin" *ngIf="(transaction?.contents?.link || transaction?.contents?.source) && (blockType == 'open' || blockType == 'receive')">
           <label class="uk-form-label">Link (Source):</label>
           <div class="uk-form-controls uk-text-truncate">
@@ -219,10 +242,6 @@
               </span>
             </a>
           </div>
-        </div>
-        <div class="uk-margin" *ngIf="blockHeight != -1">
-          <label class="uk-form-label">Height:</label>
-          <div class="uk-form-controls uk-text-truncate">{{ blockHeight | number:'':'en-US' }}</div>
         </div>
         <div class="uk-margin" *ngIf="transaction?.contents?.work">
           <label class="uk-form-label">Work:</label>

--- a/src/app/components/transaction-details/transaction-details.component.ts
+++ b/src/app/components/transaction-details/transaction-details.component.ts
@@ -34,6 +34,7 @@ export class TransactionDetailsComponent implements OnInit {
   showBlockData = false;
 
   amountRaw = new BigNumber(0);
+  successorHash = '';
 
   constructor(
     private walletService: WalletService,
@@ -69,6 +70,7 @@ export class TransactionDetailsComponent implements OnInit {
     let legacyFromAccount = '';
     this.blockType = '';
     this.amountRaw = new BigNumber(0);
+    this.successorHash = '';
     const hash = this.route.snapshot.params.transaction;
     this.hashID = hash;
 
@@ -90,9 +92,11 @@ export class TransactionDetailsComponent implements OnInit {
     this.isUnconfirmedBlock = (hashData.confirmed === 'false') ? true : false;
     this.blockHeight = hashData.height;
 
+    const HASH_ONLY_ZEROES = '0000000000000000000000000000000000000000000000000000000000000000';
+
     const blockType = hashData.contents.type;
     if (blockType === 'state') {
-      const isOpen = hashData.contents.previous === '0000000000000000000000000000000000000000000000000000000000000000';
+      const isOpen = (hashData.contents.previous === HASH_ONLY_ZEROES);
 
       if (isOpen) {
         this.blockType = 'open';
@@ -124,6 +128,13 @@ export class TransactionDetailsComponent implements OnInit {
 
     if (hashData.amount) {
       this.amountRaw = new BigNumber(hashData.amount).mod(this.nano);
+    }
+
+    if (
+          (hashData.successor != null)
+        && (hashData.successor !== HASH_ONLY_ZEROES)
+      ) {
+        this.successorHash = hashData.successor;
     }
 
     this.transaction = hashData;


### PR DESCRIPTION
This allows to navigate to the next block (e.g. from height 108 to 109)

Requires V23.0+ backend server: https://docs.nano.org/releases/release-v23-0/#rpc-updates

![image](https://user-images.githubusercontent.com/29272208/157228641-d85207ff-1c79-4a53-9744-7dd86b338a0f.png)

`Height` field has been moved above `Link` field to avoid accidental clicks on `Link` field when trying to navigate to successor of the last block in chain (which it doesn't have)