### PR TITLE
Try to be compatible with address book exports from some other wallet apps

### DIFF
--- a/src/app/components/address-book/address-book.component.ts
+++ b/src/app/components/address-book/address-book.component.ts
@@ -403,7 +403,7 @@ export class AddressBookComponent implements OnInit, AfterViewInit, OnDestroy {
       const fileData = event.target['result'] as string;
       try {
         const importData = JSON.parse(fileData);
-        if (!importData.length || !importData[0].account) {
+        if (!importData.length || (!importData[0].account && !importData[0].address)) {
           return this.notificationService.sendError(this.translocoService.translate('address-book.bad-import-data-make-sure-you-selected-a-nault-address-book'));
         }
 

--- a/src/app/components/import-address-book/import-address-book.component.html
+++ b/src/app/components/import-address-book/import-address-book.component.html
@@ -38,7 +38,7 @@
                 <div uk-grid>
                   <div class="uk-width-1-4">New Name</div>
                   <div class="uk-width-1-4">Current Name</div>
-                  <div class="uk-width-1-2 uk-text-truncate">Account</div>
+                  <div class="uk-width-expand uk-text-truncate">Account</div>
                 </div>
               </li>
             </ul>


### PR DESCRIPTION
Will no longer display multiple entries with the same nano\_ address if imported data contains duplicate entries.

Fixes 3rd column's header deciding to leave its layout and become a 1st column.

Log address book import errors in console.