### PR TITLE
fix BigNumber usage with undefined - assume 0 in that case.

### DIFF
--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -747,8 +747,8 @@ export class WalletService {
 
       if (!walletAccount) continue;
 
-      walletAccount.balance = new BigNumber(accounts.balances[accountID].balance);
-      const accountBalancePendingInclUnconfirmed = new BigNumber(accounts.balances[accountID].pending);
+      walletAccount.balance = new BigNumber(accounts.balances[accountID].balance || 0);
+      const accountBalancePendingInclUnconfirmed = new BigNumber(accounts.balances[accountID].pending || 0);
 
       walletAccount.balanceRaw = new BigNumber(walletAccount.balance).mod(this.nano);
 


### PR DESCRIPTION
Nano Node v24.0 returns no values for unused accounts rather than 0 in pre v24.0
Nano Node PR: https://github.com/nanocurrency/nano-node/pull/3790

