### PR TITLE
Fix 20 unused accounts being added on wallet import, and malformed lightweight proof of work requests for unused accounts

### DIFF
--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -512,8 +512,12 @@ export class WalletService {
         for (const accountID in batchResponse.frontiers) {
           if (batchResponse.frontiers.hasOwnProperty(accountID)) {
             const frontier = batchResponse.frontiers[accountID];
-            if (frontier !== batchAccounts[accountID].publicKey) {
-              usedIndices.push(batchAccounts[accountID].index);
+            const frontierIsValidHash = this.util.nano.isValidHash(frontier);
+
+            if (frontierIsValidHash === true) {
+              if (frontier !== batchAccounts[accountID].publicKey) {
+                usedIndices.push(batchAccounts[accountID].index);
+              }
             }
           }
         }
@@ -754,7 +758,14 @@ export class WalletService {
 
       walletAccount.balanceFiat = this.util.nano.rawToMnano(walletAccount.balance).times(fiatPrice).toNumber();
 
-      walletAccount.frontier = frontiers.frontiers[accountID] || null;
+      const walletAccountFrontier = frontiers.frontiers[accountID];
+      const walletAccountFrontierIsValidHash = this.util.nano.isValidHash(walletAccountFrontier);
+
+      walletAccount.frontier = (
+          (walletAccountFrontierIsValidHash === true)
+        ? walletAccountFrontier
+        : null
+      );
 
       walletBalance = walletBalance.plus(walletAccount.balance);
       walletPendingInclUnconfirmed = walletPendingInclUnconfirmed.plus(accountBalancePendingInclUnconfirmed);


### PR DESCRIPTION
Starting Node V24.0, `account_frontiers` can return errors alongside valid hashes, e.g. :

```json
{
  "frontiers": {
    "nano_3wfddg7a1paogrcwi3yhwnaerboukbr7rs3z3ino5toyq3yyhimo6f6egij6": "75BD65296241EB871918EBE3E99E9A191970A2724B3214B27F8AB205FF4FC30A",
    "nano_36uccgpjzhjsdbj44wm1y5hyz8gefx3wjpp1jircxt84nopxkxti5bzq1rnz": "error: Bad account number",
    "nano_1hrts7hcoozxccnffoq9hqhngnn9jz783usapejm57ejtqcyz9dpso1bibuy": "error: Account not found"
  }
}
```

This PR adds handling for `account_frontiers` RPC call return values that aren't valid hashes

Fixes #579