### PR TITLE
Decentralized aliases

### DIFF
--- a/src/app/components/account-details/account-details.component.ts
+++ b/src/app/components/account-details/account-details.component.ts
@@ -744,14 +744,18 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
 
     const regexp = new RegExp('^(Account|' + this.translocoService.translate('general.account') + ') #\\d+$', 'g');
     if ( regexp.test(this.addressBookModel) === true ) {
-      return this.notifications.sendError(`This name is reserved for wallet accounts without a label`);
+      return this.notifications.sendError(this.translocoService.translate('address-book.this-name-is-reserved-for-wallet-accounts-without-a-label'));
+    }
+
+    if ( this.addressBookModel.startsWith('@') === true ) {
+      return this.notifications.sendError(this.translocoService.translate('address-book.this-name-is-reserved-for-decentralized-aliases'));
     }
 
     // Make sure no other entries are using that name
     const accountIdWithSameName = this.addressBook.getAccountIdByName(this.addressBookModel);
 
     if ( (accountIdWithSameName !== null) && (accountIdWithSameName !== this.accountID) ) {
-      return this.notifications.sendError(`This name is already in use! Please use a unique name`);
+      return this.notifications.sendError(this.translocoService.translate('address-book.this-name-is-already-in-use-please-use-a-unique-name'));
     }
 
     try {
@@ -759,11 +763,11 @@ export class AccountDetailsComponent implements OnInit, OnDestroy {
       const currentTransactionTracking = this.addressBook.getTransactionTrackingById(this.accountID);
       await this.addressBook.saveAddress(this.accountID, this.addressBookModel, currentBalanceTracking, currentTransactionTracking);
     } catch (err) {
-      this.notifications.sendError(`Unable to save entry: ${err.message}`);
+      this.notifications.sendError(this.translocoService.translate('address-book.unable-to-save-entry', { message: err.message }));
       return;
     }
 
-    this.notifications.sendSuccess(`Address book entry saved successfully!`);
+    this.notifications.sendSuccess(this.translocoService.translate('address-book.address-book-entry-saved-successfully'));
 
     this.addressBookEntry = this.addressBookModel;
     this.showEditAddressBook = false;

--- a/src/app/components/address-book/address-book.component.ts
+++ b/src/app/components/address-book/address-book.component.ts
@@ -281,6 +281,10 @@ export class AddressBookComponent implements OnInit, AfterViewInit, OnDestroy {
       return this.notificationService.sendError(this.translocoService.translate('address-book.this-name-is-reserved-for-wallet-accounts-without-a-label'));
     }
 
+    if ( this.newAddressName.startsWith('@') === true ) {
+      return this.notificationService.sendError(this.translocoService.translate('address-book.this-name-is-reserved-for-decentralized-aliases'));
+    }
+
     // Remove spaces and convert to nano prefix
     this.newAddressAccount = this.newAddressAccount.replace(/ /g, '').replace('xrb_', 'nano_');
 

--- a/src/app/components/configure-app/configure-app.component.html
+++ b/src/app/components/configure-app/configure-app.component.html
@@ -201,6 +201,23 @@
             <div class="uk-form-horizontal">
 
               <div class="uk-margin">
+                <label class="uk-form-label">{{ 'configure-app.decentralized-aliases' | transloco }} <span uk-icon="icon: info;" uk-tooltip [title]="t('configure-app.decentralized-aliases-require-external-requests')"></span></label>
+                <div class="uk-form-controls">
+
+                  <div class="uk-inline uk-width-1-1">
+                    <select class="uk-select" [(ngModel)]="selectedDecentralizedAliasesOption">
+                      <option *ngFor="let decentralizedAliasesOption of decentralizedAliasesOptions" [value]="decentralizedAliasesOption.value">{{ decentralizedAliasesOption.name }}</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="uk-width-1-1">
+            <div class="uk-form-horizontal">
+
+              <div class="uk-margin">
                 <label class="uk-form-label">{{ 'configure-app.default-representative' | transloco }} <span uk-icon="icon: info;" uk-tooltip [title]="t('configure-app.this-representative-will-be-used-for-any-new-account')"></span></label>
 
                 <div class="uk-form-controls">

--- a/src/app/components/configure-app/configure-app.component.ts
+++ b/src/app/components/configure-app/configure-app.component.ts
@@ -148,6 +148,12 @@ export class ConfigureAppComponent implements OnInit {
   ];
   selectedPendingOption = this.pendingOptions[0].value;
 
+  decentralizedAliasesOptions = [
+    { name: this.translocoService.translate('configure-app.decentralized-aliases-options.disabled'), value: 'disabled' },
+    { name: this.translocoService.translate('configure-app.decentralized-aliases-options.enabled'), value: 'enabled' },
+  ];
+  selectedDecentralizedAliasesOption = this.decentralizedAliasesOptions[0].value;
+
   // prefixOptions = [
   //   { name: 'xrb_', value: 'xrb' },
   //   { name: 'nano_', value: 'nano' },
@@ -282,6 +288,9 @@ export class ConfigureAppComponent implements OnInit {
     const matchingPendingOption = this.pendingOptions.find(d => d.value === settings.pendingOption);
     this.selectedPendingOption = matchingPendingOption ? matchingPendingOption.value : this.pendingOptions[0].value;
 
+    const matchingDecentralizedAliasesOption = this.decentralizedAliasesOptions.find(d => d.value === settings.decentralizedAliasesOption);
+    this.selectedDecentralizedAliasesOption = matchingDecentralizedAliasesOption ? matchingDecentralizedAliasesOption.value : this.decentralizedAliasesOptions[0].value;
+
     this.serverOptions = this.appSettings.serverOptions;
     this.selectedServer = settings.serverName;
     this.serverAPI = settings.serverAPI;
@@ -371,6 +380,8 @@ export class ConfigureAppComponent implements OnInit {
       minReceive = this.minimumReceive;
     }
 
+    const decentralizedAliasesOption = this.selectedDecentralizedAliasesOption;
+
     // reload pending if threshold changes or if receive priority changes from manual to auto
     let reloadPending = this.appSettings.settings.minimumReceive !== this.minimumReceive
     || (pendingOption !== 'manual' && pendingOption !== this.appSettings.settings.pendingOption);
@@ -432,6 +443,7 @@ export class ConfigureAppComponent implements OnInit {
       multiplierSource: Number(this.selectedMultiplierOption),
       customWorkServer: this.customWorkServer,
       pendingOption: pendingOption,
+      decentralizedAliasesOption: decentralizedAliasesOption,
       minimumReceive: minReceive,
       defaultRepresentative: this.defaultRepresentative || null,
     };

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -32,7 +32,7 @@
                 <div class="uk-form-controls">
                   <div class="form-input-destination uk-inline uk-width-1-1">
                     <a class="hide-on-small-viewports uk-form-icon uk-form-icon-flip" uk-icon="icon: camera" (click)="openQR('account1','account')" uk-tooltip title="Scan from QR code"></a>
-                    <input (blur)="validateDestination()" (input)="searchAddressBook()" (focus)="searchAddressBook()" [(ngModel)]="toAccountID" [ngClass]="{ 'uk-form-success': toAccountStatus === 2, 'uk-form-danger': toAccountStatus === 0 }" class="uk-input" id="form-horizontal-text2" type="text" placeholder="Address to send to" autocomplete="off">
+                    <input (blur)="validateDestination()" (input)="onDestinationAddressInput()" (focus)="searchAddressBook()" [(ngModel)]="toAccountID" [ngClass]="{ 'uk-form-success': toAccountStatus === 2, 'uk-form-danger': toAccountStatus === 0 }" class="uk-input" id="form-horizontal-text2" type="text" placeholder="Address to send to / nano:.." autocomplete="off">
 
                     <div *ngIf="(addressBookResults$ | async).length" [hidden]="!showAddressBook" class="nlt-dropdown uk-animation-slide-down-small uk-width-1-1 uk-card uk-card-default uk-card-body uk-position-absolute" style="z-index: 15000">
                       <ul class="uk-nav uk-nav-default">

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -32,23 +32,41 @@
                 <div class="uk-form-controls">
                   <div class="form-input-destination uk-inline uk-width-1-1">
                     <a class="hide-on-small-viewports uk-form-icon uk-form-icon-flip" uk-icon="icon: camera" (click)="openQR('account1','account')" uk-tooltip title="Scan from QR code"></a>
-                    <input (blur)="validateDestination()" (input)="onDestinationAddressInput()" (focus)="searchAddressBook()" [(ngModel)]="toAccountID" [ngClass]="{ 'uk-form-success': toAccountStatus === 2, 'uk-form-danger': toAccountStatus === 0 }" class="uk-input" id="form-horizontal-text2" type="text" placeholder="Address to send to / nano:.." autocomplete="off">
+                    <input (blur)="validateDestination()" (input)="onDestinationAddressInput()" (keydown.enter)="lookupAlias()" (focus)="searchAddressBook()" [(ngModel)]="toAccountID" [ngClass]="{ 'uk-form-success': toAccountStatus === 2, 'uk-form-danger': toAccountStatus === 0 }" class="uk-input" id="form-horizontal-text2" type="text" placeholder="Address to send to / Alias / nano:.." autocomplete="off">
 
-                    <div *ngIf="(addressBookResults$ | async).length" [hidden]="!showAddressBook" class="nlt-dropdown uk-animation-slide-down-small uk-width-1-1 uk-card uk-card-default uk-card-body uk-position-absolute" style="z-index: 15000">
+                    <div *ngIf="(aliasResults$ | async).length || (addressBookResults$ | async).length" [hidden]="!showAddressBook && !isDestinationAccountAlias" class="nlt-dropdown uk-animation-slide-down-small uk-width-1-1 uk-card uk-card-default uk-card-body uk-position-absolute" style="z-index: 15000">
                       <ul class="uk-nav uk-nav-default">
-                        <li class="uk-nav-header">Address Book Results</li>
-                        <li class="uk-nav-divider"></li>
-                        <li *ngFor="let book of addressBookResults$ | async">
-                          <a (click)="selectBookEntry(book.account)">{{ book.name }}</a>
-                        </li>
+                        <ng-container *ngIf="(aliasResults$ | async).length">
+                          <li class="uk-nav-header">Alias Lookup</li>
+                          <li class="uk-nav-divider"></li>
+                          <li *ngFor="let alias of aliasResults$ | async">
+                            <a (click)="lookupAlias()" class="uk-padding-remove-bottom">
+                              <span class="text-half-muted">Press Enter or click here to request alias from</span>
+                            </a>
+                            <a (click)="lookupAlias()">
+                              <span class="uk-text-primary">{{ alias.domain }}</span>
+                            </a>
+                          </li>
+                          <li class="uk-nav-divider" *ngIf="(addressBookResults$ | async).length"></li>
+                        </ng-container>
+                        <ng-container *ngIf="(addressBookResults$ | async).length">
+                          <li class="uk-nav-header">Address Book Results</li>
+                          <li class="uk-nav-divider"></li>
+                          <li *ngFor="let book of addressBookResults$ | async">
+                            <a (click)="selectBookEntry(book.account)">{{ book.name }}</a>
+                          </li>
+                        </ng-container>
                       </ul>
                     </div>
                   </div>
                 </div>
 
-                <div class="uk-form-controls" *ngIf="addressBookMatch">
-                  <div class="uk-inline uk-width-1-1">
+                <div class="uk-form-controls" *ngIf="addressBookMatch || addressAliasMatch">
+                  <div class="uk-inline uk-width-auto uk-margin-small-right" *ngIf="addressBookMatch">
                     <span class="account-label blue uk-margin-small-top">{{ addressBookMatch }}</span>
+                  </div>
+                  <div class="uk-inline uk-width-auto" *ngIf="addressAliasMatch">
+                    <span class="account-label alias uk-margin-small-top">{{ addressAliasMatch }}</span>
                   </div>
                 </div>
               </div>

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -39,14 +39,21 @@
                         <ng-container *ngIf="(aliasResults$ | async).length">
                           <li class="uk-nav-header">Alias Lookup</li>
                           <li class="uk-nav-divider"></li>
-                          <li *ngFor="let alias of aliasResults$ | async">
-                            <a (click)="lookupAlias()" class="uk-padding-remove-bottom">
-                              <span class="text-half-muted">Press Enter or click here to request alias from</span>
-                            </a>
-                            <a (click)="lookupAlias()">
-                              <span class="uk-text-primary">{{ alias.domain }}</span>
+                          <li *ngIf="(aliasLookupInProgress.domain !== '')">
+                            <a>
+                              <span class="spinner uk-margin-small-right" uk-spinner="ratio: 0.5;"></span><span class="text-half-muted">Looking up {{ aliasLookupInProgress.fullText }}...</span>
                             </a>
                           </li>
+                          <ng-container *ngIf="(aliasLookupInProgress.domain === '')">
+                            <li *ngFor="let alias of aliasResults$ | async">
+                              <a (click)="lookupAlias()" class="uk-padding-remove-bottom">
+                                <span class="text-half-muted">Press Enter or click here to request alias from</span>
+                              </a>
+                              <a (click)="lookupAlias()">
+                                <span class="uk-text-primary">{{ alias.domain }}</span>
+                              </a>
+                            </li>
+                          </ng-container>
                           <li class="uk-nav-divider" *ngIf="(addressBookResults$ | async).length"></li>
                         </ng-container>
                         <ng-container *ngIf="(addressBookResults$ | async).length">

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -156,6 +156,7 @@ export class SendComponent implements OnInit {
 
     if (params && params.to) {
       this.toAccountID = params.to;
+      this.offerLookupIfDestinationIsAlias();
       this.validateDestination();
       this.sendDestinationType = 'external-address';
     }

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -291,7 +291,12 @@ export class SendComponent implements OnInit {
 
     this.isDestinationAccountAlias = true;
 
-    const aliasWithoutFirstSymbol = destinationAddress.slice(1);
+    let aliasWithoutFirstSymbol = destinationAddress.slice(1);
+
+    if (aliasWithoutFirstSymbol.startsWith('_@') === true ) {
+      aliasWithoutFirstSymbol = aliasWithoutFirstSymbol.slice(2);
+    }
+
     const aliasSplitResults = aliasWithoutFirstSymbol.split('@');
 
     let aliasName = ''
@@ -305,7 +310,7 @@ export class SendComponent implements OnInit {
     }
 
     this.aliasLookup = {
-      fullText: destinationAddress,
+      fullText: `@${aliasWithoutFirstSymbol}`,
       name: aliasName,
       domain: aliasDomain,
     };

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -345,12 +345,14 @@ export class SendComponent implements OnInit {
 
     this.toAccountStatus = 1; // Neutral state
 
-    const aliasFullText = this.aliasLookup.fullText;
-    const aliasDomain = this.aliasLookup.domain;
+    const aliasLookup = { ...this.aliasLookup };
+
+    const aliasFullText = aliasLookup.fullText;
+    const aliasDomain = aliasLookup.domain;
 
     const aliasName = (
-        (this.aliasLookup.name !== '')
-      ? this.aliasLookup.name
+        (aliasLookup.name !== '')
+      ? aliasLookup.name
       : '_'
     );
 
@@ -358,7 +360,7 @@ export class SendComponent implements OnInit {
       `https://${ aliasDomain }/.well-known/nano-currency.json?names=${ aliasName }`;
 
     this.aliasLookupInProgress = {
-      ...this.aliasLookup,
+      ...aliasLookup,
     };
 
     await this.http.get<any>(lookupUrl).toPromise()
@@ -410,9 +412,9 @@ export class SendComponent implements OnInit {
           this.toAccountID = matchingAccount.address;
 
           this.aliasLookupLatestSuccessful = {
-            ...this.aliasLookupInProgress,
+            ...aliasLookup,
             address: this.toAccountID,
-          }
+          };
 
           this.onDestinationAddressInput();
           this.validateDestination();

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -377,6 +377,18 @@ export class SendComponent implements OnInit {
         };
 
         try {
+          const aliasesInJsonCount = (
+              ( Array.isArray(res.names) === true )
+            ? res.names.length
+            : 0
+          );
+
+          if (aliasesInJsonCount === 0) {
+            this.toAccountStatus = 0; // Error state
+            this.notificationService.sendWarning(`No aliases found on ${aliasDomain}`);
+            return;
+          }
+
           const matchingAccount =
             res.names.find(
               (account) =>
@@ -385,11 +397,13 @@ export class SendComponent implements OnInit {
 
           if (matchingAccount == null) {
             this.toAccountStatus = 0; // Error state
+            this.notificationService.sendWarning(`Alias @${aliasName} not found on ${aliasDomain}`);
             return;
           }
 
           if (!this.util.account.isValidAccount(matchingAccount.address)) {
             this.toAccountStatus = 0; // Error state
+            this.notificationService.sendWarning(`Alias ${aliasFullText} does not have a valid address`);
             return;
           }
 
@@ -406,6 +420,7 @@ export class SendComponent implements OnInit {
           return;
         } catch(err) {
           this.toAccountStatus = 0; // Error state
+          this.notificationService.sendWarning(`Unknown error has occurred while trying to lookup ${aliasFullText}`);
           return;
         }
       })
@@ -414,6 +429,13 @@ export class SendComponent implements OnInit {
           ...this.ALIAS_LOOKUP_DEFAULT_STATE,
         };
         this.toAccountStatus = 0; // Error state
+
+        if (err.status === 404) {
+          this.notificationService.sendWarning(`No aliases found on ${aliasDomain}`);
+        } else {
+          this.notificationService.sendWarning(`Could not reach domain ${aliasDomain}`);
+        }
+
         return;
       });
   }

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -393,7 +393,7 @@ export class SendComponent implements OnInit {
 
           if (aliasesInJsonCount === 0) {
             this.toAccountStatus = 0; // Error state
-            this.notificationService.sendWarning(`No aliases found on ${aliasDomain}`);
+            this.notificationService.sendWarning(`Alias @${aliasName} not found on ${aliasDomain}`);
             return;
           }
 

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -316,6 +316,29 @@ export class SendComponent implements OnInit {
       return;
     }
 
+    if (this.settings.settings.decentralizedAliasesOption === 'disabled') {
+      const UIkit = window['UIkit'];
+      try {
+        await UIkit.modal.confirm(
+          `<p class="uk-alert uk-alert-warning"><br><span class="uk-flex"><span uk-icon="icon: warning; ratio: 3;" class="uk-align-center"></span></span>
+          <span style="font-size: 18px;">
+          ${ this.translocoService.translate('configure-app.decentralized-aliases-require-external-requests') }
+          </span>`,
+          {
+            labels: {
+              cancel: this.translocoService.translate('general.cancel'),
+              ok: this.translocoService.translate('configure-app.allow-external-requests'),
+            }
+          }
+        );
+
+        this.settings.setAppSetting('decentralizedAliasesOption', 'enabled');
+      } catch (err) {
+        // pressed cancel, or a different error
+        return;
+      }
+    }
+
     this.toAccountStatus = 1; // Neutral state
 
     const aliasDomain = this.aliasLookup.domain;

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -292,7 +292,7 @@ export class SendComponent implements OnInit {
 
     this.isDestinationAccountAlias = true;
 
-    let aliasWithoutFirstSymbol = destinationAddress.slice(1);
+    let aliasWithoutFirstSymbol = destinationAddress.slice(1).toLowerCase();
 
     if (aliasWithoutFirstSymbol.startsWith('_@') === true ) {
       aliasWithoutFirstSymbol = aliasWithoutFirstSymbol.slice(2);

--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -20,6 +20,7 @@ interface AppSettings {
   multiplierSource: number;
   customWorkServer: string;
   pendingOption: string;
+  decentralizedAliasesOption: string;
   serverName: string;
   serverAPI: string | null;
   serverWS: string | null;
@@ -48,6 +49,7 @@ export class AppSettingsService {
     multiplierSource: 1,
     customWorkServer: '',
     pendingOption: 'amount',
+    decentralizedAliasesOption: 'disabled',
     serverName: 'random',
     serverAPI: null,
     serverWS: null,
@@ -241,6 +243,7 @@ export class AppSettingsService {
       multiplierSource: 1,
       customWorkServer: '',
       pendingOption: 'amount',
+      decentralizedAliasesOption: 'disabled',
       serverName: 'random',
       serverAPI: null,
       serverWS: null,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -84,6 +84,7 @@
     "the-balance-will-be-displayed-in-the-address-book": "The balance will be displayed in the address book.",
     "this-name-is-already-in-use-please-use-a-unique-name": "This name is already in use! Please use a unique name",
     "this-name-is-reserved-for-wallet-accounts-without-a-label": "This name is reserved for wallet accounts without a label",
+    "this-name-is-reserved-for-decentralized-aliases": "Names starting with @ are reserved for decentralized aliases",
     "track-balance": "Track Balance",
     "track-transactions": "Track Transactions",
     "unable-to-delete-entry": "Unable to delete entry: {{ message }}",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -134,6 +134,7 @@
   },
   "configure-app": {
     "advanced-options": "Advanced Options",
+    "allow-external-requests": "Allow External Requests",
     "api-server": "API Server",
     "app-display-settings-successfully-updated": "App display settings successfully updated!",
     "app-wallet-settings-successfully-updated": "App wallet settings successfully updated!",
@@ -159,6 +160,12 @@
     },
     "custom-api-server-has-an-invalid-address": "Custom API Server has an invalid address.",
     "custom-update-server-has-an-invalid-address": "Custom Update Server has an invalid address.",
+    "decentralized-aliases": "Decentralized Aliases",
+    "decentralized-aliases-options": {
+      "disabled": "Disabled",
+      "enabled": "Enabled - Allow External Requests to Alias Domains"
+    },
+    "decentralized-aliases-require-external-requests": "Decentralized aliases require external requests to alias domains. When you try to lookup the address of @madeline@example.com, the domain example.com may record your IP address.",
     "default-representative": "Default Representative",
     "default-representative-is-not-a-valid-account": "Default representative is not a valid account",
     "delete-all-data": "Delete ALL Data",

--- a/src/less/nault-theme.less
+++ b/src/less/nault-theme.less
@@ -347,6 +347,11 @@ input[type=number] {
 		background: @rep-label-color;
 		color: #FFF;
 	}
+
+	&.alias {
+		text-transform: none;
+		font-family: 'Roboto Mono', monospace;
+	}
 }
 
 .rep-donation-icon {


### PR DESCRIPTION
This PR adds support for decentralized aliases per [the following draft spec](https://github.com/mistakia/nano-community/pull/72/files#diff-37cf3c467ab0be513bb3784f1d0e7ef16f57cd74f5b7e2b181fb4890b1507108R221-R243).

Entering the alias `@madeline@example.com` and agreeing to perform lookup (Enter key or click/tap) makes a GET request to
`https://example.com/.well-known/nano-currency.json?names=madeline`

and expects the following output:
```json
{
    "names": [
        {
            "name": "madeline",
            "address": "<nano-address>",
            ...
        },
        ...
    ]
}
```

Filtering via `?names=madeline` is merely an optimization, as static json files are also supported.

The endpoint *must* have `Access-Control-Allow-Origin: *` to allow cross-domain requests.

* * *

External requests to alias domains require opt-in either via App Settings or confirmation prompt (agreeing to which changes said setting):

https://github.com/Nault/Nault/assets/29272208/c711532d-35c1-4460-b686-ad5c15727d2e

![image](https://github.com/Nault/Nault/assets/29272208/084257bf-d76f-4b26-82a6-53d39ba550d3)

* * *

I've tried to avoid common risks, but like any other code on here, it's provided "as is", so I cannot vouch that it's secure. 

To avoid merge conflicts, this PR is built on top of PR #580 (which adds support for nano URI on the Send page)

#414 (an issue about Open Alias support) can likely be closed if this is merged