### PR TITLE
Fix infinite load of account balances on V25.0+ nodes

### DIFF
--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -754,7 +754,7 @@ export class WalletService {
 
       walletAccount.balanceFiat = this.util.nano.rawToMnano(walletAccount.balance).times(fiatPrice).toNumber();
 
-      walletAccount.frontier = frontiers.frontiers[accountID] || null;
+      walletAccount.frontier = frontiers.frontiers?.[accountID] || null;
 
       walletBalance = walletBalance.plus(walletAccount.balance);
       walletPendingInclUnconfirmed = walletPendingInclUnconfirmed.plus(accountBalancePendingInclUnconfirmed);


### PR DESCRIPTION
This small change is required for V25.0 node compatibility to prevent an error when the response json contains no `frontiers` property