### PR TITLE
Fix mismatching percentages in representative health tooltip

### DIFF
--- a/src/app/components/change-rep-widget/change-rep-widget.component.html
+++ b/src/app/components/change-rep-widget/change-rep-widget.component.html
@@ -55,10 +55,10 @@
         <span uk-icon="icon: warning;"></span>{{ 'change-rep-widget.this-representative-has-announced-plans-to-permanently-shutdown' | transloco }}
       </p>
       <p class="uk-text-danger" *ngIf="rep.status.veryHighWeight">
-        <span uk-icon="icon: warning;"></span>{{ 'change-rep-widget.this-representative-has-a-very-high-voting-weight' | transloco: { percent: 5 } }}
+        <span uk-icon="icon: warning;"></span>{{ 'change-rep-widget.this-representative-has-a-very-high-voting-weight' | transloco: { percent: 3 } }}
       </p>
       <p class="uk-text-warning" *ngIf="rep.status.highWeight">
-        <span uk-icon="icon: warning;"></span>{{ 'change-rep-widget.this-representative-has-a-high-voting-weight' | transloco: { percent: 3 } }}
+        <span uk-icon="icon: warning;"></span>{{ 'change-rep-widget.this-representative-has-a-high-voting-weight' | transloco: { percent: 2 } }}
       </p>
       <p class="uk-text-danger" *ngIf="rep.status.veryLowUptime && rep.status.uptime > 0">
         <span uk-icon="icon: warning;"></span>{{ 'change-rep-widget.this-representative-is-often-offline' | transloco: { percent: rep.status.uptime.toFixed(1) } }}


### PR DESCRIPTION
Text error introduced in #457 (transloco localization)

Source for 2% and 3% being in use in the code:

https://github.com/Nault/Nault/blob/cd6d388e60ce84affaa813991445734cdf64c49f/src/app/services/representative.service.ts#L163-L170