### PR TITLE
Print hashes to the GitHub Action log while preparing a release draft

### DIFF
--- a/.github/workflows/electron_hash.yml
+++ b/.github/workflows/electron_hash.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Build Electron app
         run: |
-          npm run desktop:local --openssl_fips=''
+          npm run desktop:local
 
       - name: Create Hashes
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/electron_hash.yml
+++ b/.github/workflows/electron_hash.yml
@@ -91,12 +91,12 @@ jobs:
       - name: Create Hashes
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          openssl sha1 desktop-app/build/*.${{ matrix.app_ext }} >> desktop-app/build/${{ matrix.artifact_name }} | bash
-          openssl md5 desktop-app/build/*.${{ matrix.app_ext }} >> desktop-app/build/${{ matrix.artifact_name }} | bash
-          openssl sha256 desktop-app/build/*.${{ matrix.app_ext }} >> desktop-app/build/${{ matrix.artifact_name }} | bash
-          openssl sha512 desktop-app/build/*.${{ matrix.app_ext }} >> desktop-app/build/${{ matrix.artifact_name }} | bash
-          openssl sha3-512 desktop-app/build/*.${{ matrix.app_ext }} >> desktop-app/build/${{ matrix.artifact_name }} | bash
-          openssl blake2b512 desktop-app/build/*.${{ matrix.app_ext }} >> desktop-app/build/${{ matrix.artifact_name }} | bash
+          openssl sha1 desktop-app/build/*.${{ matrix.app_ext }}       | tee -a desktop-app/build/${{ matrix.artifact_name }} 
+          openssl md5 desktop-app/build/*.${{ matrix.app_ext }}        | tee -a desktop-app/build/${{ matrix.artifact_name }} 
+          openssl sha256 desktop-app/build/*.${{ matrix.app_ext }}     | tee -a desktop-app/build/${{ matrix.artifact_name }} 
+          openssl sha512 desktop-app/build/*.${{ matrix.app_ext }}     | tee -a desktop-app/build/${{ matrix.artifact_name }} 
+          openssl sha3-512 desktop-app/build/*.${{ matrix.app_ext }}   | tee -a desktop-app/build/${{ matrix.artifact_name }} 
+          openssl blake2b512 desktop-app/build/*.${{ matrix.app_ext }} | tee -a desktop-app/build/${{ matrix.artifact_name }} 
         shell: bash
 
       - name: Rename file paths in .yml (Linux)

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@types/qrcode": "^0.8.1",
     "@typescript-eslint/eslint-plugin": "5.17.0",
     "@typescript-eslint/parser": "5.17.0",
-    "electron": "^9.4.0",
+    "electron": "^18.3.7",
     "electron-builder": "^22.14.5",
     "eslint": "^8.12.0",
     "jasmine-core": "~3.6.0",

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -200,13 +200,13 @@
                 <hr>
 
                 <div class="uk-margin">
-                  <p class="uk-text-lead uk-text-center">Select a representative recommended by <a href="https://mynano.ninja" target="_blank" rel="noopener noreferrer" class="uk-link-text">MyNanoNinja</a></p>
+                  <!-- <p class="uk-text-lead uk-text-center">Recommended</p> -->
                   <!--<h4>Or, Select a recommended representative</h4>-->
                   <ul class="uk-list uk-list-striped" style="margin-bottom: 0;">
                     <li class="uk-list-header">
                       <div uk-grid>
-                        <div class="uk-width-expand">Representative</div>
-                        <div class="uk-width-1-2">Weight / Uptime / Accounts</div>
+                        <div class="uk-width-expand">Representatives</div>
+                        <!-- <div class="uk-width-1-2">Weight / Uptime / Accounts</div> -->
                         <!--<div class="uk-width-1-5">Uptime / Delegators</div>-->
                       </div>
                     </li>
@@ -221,14 +221,14 @@
                     <li *ngFor="let rep of recommendedRepsPaginated">
                       <div uk-grid >
                         <div class="uk-width-expand" (click)="selectRecommendedRep(rep)" style="cursor: pointer;">
-                          <span class="uk-badge" uk-tooltip title="My Nano Ninja Score" style="margin-right: 4px;">{{ rep.score }}</span> <span uk-tooltip title="Select this representative">{{ rep.alias }}</span>
-
+                          <!-- <span class="uk-badge" uk-tooltip title="My Nano Ninja Score" style="margin-right: 4px;">{{ rep.weight }}</span> -->
+                          <span uk-tooltip title="Select this representative">{{ rep.alias }}</span>
                         </div>
                         <div class="uk-width-1-2">
-                          <a [href]="'https://mynano.ninja/account/' + rep.account" target="_blank" rel="noopener noreferrer" style="float: right;" uk-tooltip title="View more details on My Nano Ninja" class="uk-link-muted"><span uk-icon="search"></span></a>
+                          <!-- <a [href]="'https://mynano.ninja/account/' + rep.account" target="_blank" rel="noopener noreferrer" style="float: right;" uk-tooltip title="View more details on My Nano Ninja" class="uk-link-muted"><span uk-icon="search"></span></a> -->
 
-                          <span style="display: inline-block; margin-right: 15px;" uk-tooltip title="Percentage of network voting weight delegated" class="uk-text-primary"><span uk-icon="users"></span> {{ rep.percent }}%</span>
-                          <span style="display: inline-block; margin-right: 15px; color: #13ab60;" uk-tooltip title="Uptime since creation" class=""><span uk-icon="bolt"></span> {{ rep.uptime.toFixed(2) }}%</span>
+                          <!-- <span style="display: inline-block; margin-right: 15px;" uk-tooltip title="Percentage of network voting weight delegated" class="uk-text-primary"><span uk-icon="users"></span> {{ rep.percent }}%</span> -->
+                          <!-- <span style="display: inline-block; margin-right: 15px; color: #13ab60;" uk-tooltip title="Uptime since creation" class=""><span uk-icon="bolt"></span> {{ rep.uptime }}</span> -->
 
                         </div>
                       </div>

--- a/src/app/components/representatives/representatives.component.ts
+++ b/src/app/components/representatives/representatives.component.ts
@@ -213,13 +213,15 @@ export class RepresentativesComponent implements OnInit {
     }
 
     const rep = this.representativeService.getRepresentative(this.toRepresentativeID);
-    const ninjaRep = await this.ninja.getAccount(this.toRepresentativeID);
+    // const ninjaRep = await this.ninja.getAccount(this.toRepresentativeID);
 
     if (rep) {
       this.representativeListMatch = rep.name;
-    } else if (ninjaRep) {
-      this.representativeListMatch = ninjaRep.alias;
-    } else {
+    } 
+    // else if (ninjaRep) {
+    //   this.representativeListMatch = ninjaRep.alias;
+    // } 
+    else {
       this.representativeListMatch = '';
     }
   }
@@ -231,7 +233,7 @@ export class RepresentativesComponent implements OnInit {
       const totalSupply = new BigNumber(133248289);
 
       const reps = scores.map(rep => {
-        const nanoWeight = this.util.nano.rawToMnano(rep.votingweight.toString() || 0);
+        const nanoWeight = this.util.nano.rawToMnano(rep.weight.toString() || 0);
         const percent = nanoWeight.div(totalSupply).times(100);
 
         // rep.weight = nanoWeight.toString(10);
@@ -275,7 +277,7 @@ export class RepresentativesComponent implements OnInit {
 
   selectRecommendedRep(rep) {
     this.selectedRecommendedRep = rep;
-    this.toRepresentativeID = rep.account;
+    this.toRepresentativeID = rep.rep_address;
     this.showRecommendedReps = false;
     this.representativeListMatch = rep.alias; // We will save if they use this, so this is a nice little helper
   }

--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -20,7 +20,6 @@ interface AppSettings {
   multiplierSource: number;
   customWorkServer: string;
   pendingOption: string;
-  decentralizedAliasesOption: string;
   serverName: string;
   serverAPI: string | null;
   serverWS: string | null;
@@ -49,7 +48,6 @@ export class AppSettingsService {
     multiplierSource: 1,
     customWorkServer: '',
     pendingOption: 'amount',
-    decentralizedAliasesOption: 'disabled',
     serverName: 'random',
     serverAPI: null,
     serverWS: null,
@@ -70,10 +68,10 @@ export class AppSettingsService {
       shouldRandom: false,
     },
     {
-      name: 'My Nano Ninja',
-      value: 'ninja',
-      api: 'https://mynano.ninja/api/node',
-      ws: 'wss://ws.mynano.ninja',
+      name: 'Rainstorm City',
+      value: 'rainstorm',
+      api: 'https://rainstorm.city/api',
+      ws: 'wss://rainstorm.city/websocket',
       auth: null,
       shouldRandom: true,
     },
@@ -86,10 +84,34 @@ export class AppSettingsService {
       shouldRandom: true,
     },
     {
-      name: 'Rainstorm City',
-      value: 'rainstorm',
-      api: 'https://rainstorm.city/api',
-      ws: 'wss://rainstorm.city/websocket',
+      name: 'Nano Garden',
+      value: 'nanogarden',
+      api: 'https://node.nano.garden/api',
+      ws: 'wss://node.nano.garden/ws',
+      auth: null,
+      shouldRandom: true,
+    },
+    {
+      name: 'Nano.to RPC (No Websocket)',
+      value: 'nanogarden',
+      api: 'https://rpc.nano.to',
+      ws: null,
+      auth: null,
+      shouldRandom: true,
+    },
+    {
+      name: 'Nano.to US-1 (No Websocket)',
+      value: 'nanogarden',
+      api: 'https://us-1.nano.to',
+      ws: null,
+      auth: null,
+      shouldRandom: true,
+    },
+    {
+      name: 'Nano.to US-2 (No Websocket)',
+      value: 'nanogarden',
+      api: 'https://us-2.nano.to',
+      ws: null,
       auth: null,
       shouldRandom: true,
     },
@@ -106,6 +128,14 @@ export class AppSettingsService {
       value: 'offline',
       api: null,
       ws: null,
+      auth: null,
+      shouldRandom: false,
+    },
+    {
+      name: 'Test Network Mode',
+      value: 'test-network',
+      api: 'https://xnotest.com/api',
+      ws: 'wss://xnotest.com/ws',
       auth: null,
       shouldRandom: false,
     }
@@ -219,7 +249,6 @@ export class AppSettingsService {
       multiplierSource: 1,
       customWorkServer: '',
       pendingOption: 'amount',
-      decentralizedAliasesOption: 'disabled',
       serverName: 'random',
       serverAPI: null,
       serverWS: null,

--- a/src/app/services/ninja.service.ts
+++ b/src/app/services/ninja.service.ts
@@ -30,13 +30,13 @@ export class NinjaService {
     const newlist = [];
 
     for (const account of replist) {
-      scores[account.score] = scores[account.score] || [];
-      scores[account.score].push(account);
+      scores[account.weight] = scores[account.weight] || [];
+      scores[account.weight].push(account);
     }
 
-    for (const score in scores) {
-      if (scores.hasOwnProperty(score)) {
-        let accounts = scores[score];
+    for (const weight in scores) {
+      if (scores.hasOwnProperty(weight)) {
+        let accounts = scores[weight];
         accounts = this.util.array.shuffle(accounts);
 
         for (const account of accounts) {
@@ -49,7 +49,7 @@ export class NinjaService {
   }
 
   async recommended(): Promise<any> {
-    return await this.request('accounts/verified');
+    return await this.http.post('https://rpc.nano.to', { action: "representatives" }).toPromise();
   }
 
   async recommendedRandomized(): Promise<any> {
@@ -67,7 +67,8 @@ export class NinjaService {
     const REQUEST_TIMEOUT_MS = 10000;
 
     const successPromise =
-      this.http.get(this.ninjaUrl + 'accounts/' + account).toPromise()
+      this.http.post('https://rpc.nano.to', { action: "ninja_info", account }).toPromise()
+      // this.http.get(this.ninjaUrl + 'accounts/' + account).toPromise()
         .then(res => {
           return res;
         })


### PR DESCRIPTION
Currently, the GitHub Action will compute the file hashes and append them to the checksum file. However, it is trivial to tamper with the executables and the checskum files before finalizing the release. GitHub does not provide a way to check whether this has happened - at least not one that I know of.

By using "tee" to pipe the hashes to the GitHub Action log while simultaneously appending them to the file, one can use GitHub as a third-party verifier of the integrity of the build. 

This very simple modification significantly reduces the amount of trust a user has to place on the maintainers of Nault or any of its future forks. 

An example of this modification in practice can be seen in these logs, under the "Create Hashes" section: https://github.com/nanogarden/Nault/actions/runs/5866326649/job/15904942936

Here is a screenshot:

![image](https://github.com/Nault/Nault/assets/140966624/dfa515f7-40d8-41cd-a4cf-1fc870e5d731)