### PR TITLE
Print hashes to the GitHub Action log while preparing a release draft

### DIFF
--- a/.github/workflows/electron_hash.yml
+++ b/.github/workflows/electron_hash.yml
@@ -91,12 +91,12 @@ jobs:
       - name: Create Hashes
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          openssl sha1 desktop-app/build/*.${{ matrix.app_ext }} >> desktop-app/build/${{ matrix.artifact_name }} | bash
-          openssl md5 desktop-app/build/*.${{ matrix.app_ext }} >> desktop-app/build/${{ matrix.artifact_name }} | bash
-          openssl sha256 desktop-app/build/*.${{ matrix.app_ext }} >> desktop-app/build/${{ matrix.artifact_name }} | bash
-          openssl sha512 desktop-app/build/*.${{ matrix.app_ext }} >> desktop-app/build/${{ matrix.artifact_name }} | bash
-          openssl sha3-512 desktop-app/build/*.${{ matrix.app_ext }} >> desktop-app/build/${{ matrix.artifact_name }} | bash
-          openssl blake2b512 desktop-app/build/*.${{ matrix.app_ext }} >> desktop-app/build/${{ matrix.artifact_name }} | bash
+          openssl sha1 desktop-app/build/*.${{ matrix.app_ext }}       | tee -a desktop-app/build/${{ matrix.artifact_name }} 
+          openssl md5 desktop-app/build/*.${{ matrix.app_ext }}        | tee -a desktop-app/build/${{ matrix.artifact_name }} 
+          openssl sha256 desktop-app/build/*.${{ matrix.app_ext }}     | tee -a desktop-app/build/${{ matrix.artifact_name }} 
+          openssl sha512 desktop-app/build/*.${{ matrix.app_ext }}     | tee -a desktop-app/build/${{ matrix.artifact_name }} 
+          openssl sha3-512 desktop-app/build/*.${{ matrix.app_ext }}   | tee -a desktop-app/build/${{ matrix.artifact_name }} 
+          openssl blake2b512 desktop-app/build/*.${{ matrix.app_ext }} | tee -a desktop-app/build/${{ matrix.artifact_name }} 
         shell: bash
 
       - name: Rename file paths in .yml (Linux)


### PR DESCRIPTION
Currently, the GitHub Action will compute the file hashes and append them to the checksum file. However, it is trivial to tamper with the executables and the checskum files before finalizing the release. GitHub does not provide a way to check whether this has happened - at least not one that I know of.

By using "tee" to pipe the hashes to the GitHub Action log while simultaneously appending them to the file, one can use GitHub as a third-party verifier of the integrity of the build. 

This very simple modification significantly reduces the amount of trust a user has to place on the maintainers of Nault or any of its future forks. 

An example of this modification in practice can be seen in these logs, under the "Create Hashes" section: https://github.com/nanogarden/Nault/actions/runs/5866326649/job/15904942936

Here is a screenshot:

![image](https://github.com/Nault/Nault/assets/140966624/dfa515f7-40d8-41cd-a4cf-1fc870e5d731)