### PR TITLE
Fix minor console error caused by code expecting 100% success rate fetching a list of recommended representatives

### DIFF
--- a/src/app/services/ninja.service.ts
+++ b/src/app/services/ninja.service.ts
@@ -54,6 +54,11 @@ export class NinjaService {
 
   async recommendedRandomized(): Promise<any> {
     const replist = await this.recommended();
+
+    if (replist == null) {
+      return [];
+    }
+
     return this.randomizeByScore(replist);
   }
 


### PR DESCRIPTION
To my knowledge this does not affect much other than printing errors in console, but may result in representative label not updating on Account Details page.

![image](https://github.com/Nault/Nault/assets/29272208/c26669e4-fcc3-40a7-9ce6-d2a86711205f)
