### PR TITLE
Fix inaccurate account balances due to balances being refreshed too quickly after receive

### DIFF
--- a/src/app/components/receive/receive.component.ts
+++ b/src/app/components/receive/receive.component.ts
@@ -375,7 +375,6 @@ export class ReceiveComponent implements OnInit, OnDestroy {
     }
 
     receivableBlock.loading = false;
-    await this.walletService.reloadBalances();
     this.updatePendingBlocks(); // update the list
   }
 

--- a/src/app/components/send/send.component.ts
+++ b/src/app/components/send/send.component.ts
@@ -659,8 +659,6 @@ export class SendComponent implements OnInit {
 
 
     this.confirmingTransaction = false;
-
-    await this.walletService.reloadBalances();
   }
 
   setMaxAmount() {

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -154,10 +154,26 @@ export class WalletService {
 
       const walletAccountIDs = this.wallet.accounts.map(a => a.id);
 
-      // If an incoming pending
-      if (transaction.block.type === 'state' && transaction.block.subtype === 'send'
-      && walletAccountIDs.indexOf(transaction.block.link_as_account) !== -1) {
-        if (shouldNotify) {
+      const isConfirmedIncomingTransactionForOwnWalletAccount = (
+          (transaction.block.type === 'state')
+        && (transaction.block.subtype === 'send')
+        && ( walletAccountIDs.includes(transaction.block.link_as_account) === true )
+      );
+
+      const isConfirmedSendTransactionFromOwnWalletAccount = (
+          (transaction.block.type === 'state')
+        && (transaction.block.subtype === 'send')
+        && ( walletAccountIDs.includes(transaction.block.account) === true )
+      );
+
+      const isConfirmedReceiveTransactionFromOwnWalletAccount = (
+          (transaction.block.type === 'state')
+        && (transaction.block.subtype === 'receive')
+        && ( walletAccountIDs.includes(transaction.block.account) === true )
+      );
+
+      if (isConfirmedIncomingTransactionForOwnWalletAccount === true) {
+        if (shouldNotify === true) {
           if (this.wallet.locked && this.appSettings.settings.pendingOption !== 'manual') {
             this.notifications.sendWarning(`New incoming transaction - Unlock the wallet to receive`, { length: 10000, identifier: 'pending-locked' });
           } else if (this.appSettings.settings.pendingOption === 'manual') {
@@ -171,12 +187,11 @@ export class WalletService {
           );
         }
         await this.processStateBlock(transaction);
-
-        // If a confirmed outgoing transaction
-      } else if (transaction.block.type === 'state' && transaction.block.subtype === 'send'
-      && walletAccountIDs.indexOf(transaction.block.account) !== -1) {
+      } else if (isConfirmedSendTransactionFromOwnWalletAccount === true) {
         shouldNotify = true;
         await this.processStateBlock(transaction);
+      } else if (isConfirmedReceiveTransactionFromOwnWalletAccount === true) {
+        shouldNotify = true;
       }
 
       // Find if the source or destination is a tracked address in the address book
@@ -229,8 +244,16 @@ export class WalletService {
       // I'm not sure about that because what happens if the websocket is disconnected and misses a transaction?
       // won't the balance be incorrect if relying only on the websocket? / Json
 
-      // Only reload balance if the incoming is to an internal wallet (to avoid RPC spam)
-      if (shouldNotify && walletAccountIDs.indexOf(transaction.block.link_as_account) !== -1) {
+      const shouldReloadBalances = (
+          (shouldNotify === true)
+        && (
+            (isConfirmedIncomingTransactionForOwnWalletAccount === true)
+          || (isConfirmedSendTransactionFromOwnWalletAccount === true)
+          || (isConfirmedReceiveTransactionFromOwnWalletAccount === true)
+        )
+      );
+
+      if (shouldReloadBalances === true) {
         await this.reloadBalances();
       }
     });


### PR DESCRIPTION
Requesting a balance refresh too soon has not been an issue before, but likely due to changes in Nano Node V24/V25 it's now a common occurrence that after receiving funds the balances would not include funds that were received just moments ago.

Additionally, this PR potentially fixes a bug where users were shown an incoming balance card listing amount of funds that were already received.