### PR TITLE
Mark main navigation as such with role and aria-label tags

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -217,7 +217,7 @@
 
         </div>
 
-        <ul class="uk-nav uk-nav-default uk-nav-parent-icon left-nav" uk-nav>
+        <ul role="navigation" aria-label="Main" class="uk-nav uk-nav-default uk-nav-parent-icon left-nav" uk-nav>
           <li><a routerLink="/accounts" routerLinkActive="active"><div class="label">{{ 'general.accounts' | transloco }}</div></a></li>
           <li><a routerLink="/send" routerLinkActive="active"><div class="label">{{ 'general.send' | transloco }}</div></a></li>
           <li>


### PR DESCRIPTION
a very small step of accessibility improvements that are currently lacking across the board

should make it easier for screen readers to locate/interpret the main navigation