### PR TITLE
Account/frontier validation fixes, improved UX upon encountering transaction errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "hw-app-nano": "^1.3.0",
         "nano-base32": "^1.0.1",
         "nanocurrency": "^2.5.0",
-        "nanocurrency-web": "^1.2.1",
+        "nanocurrency-web": "^1.4.3",
         "ngx-clipboard": "^12.3.0",
         "node-hid": "^1.3.0",
         "qrcode": "^1.4.4",
@@ -6951,9 +6951,9 @@
       }
     },
     "node_modules/blakejs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
     "node_modules/blocking-proxy": {
       "version": "1.0.1",
@@ -7552,6 +7552,11 @@
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
+    },
+    "node_modules/byte-base64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/byte-base64/-/byte-base64-1.1.0.tgz",
+      "integrity": "sha512-56cXelkJrVMdCY9V/3RfDxTh4VfMFCQ5km7B7GkIGfo4bcPL9aACyJLB0Ms3Ezu5rsHmLB2suis96z4fLM03DA=="
     },
     "node_modules/bytes": {
       "version": "3.0.0",
@@ -14617,19 +14622,20 @@
       }
     },
     "node_modules/nanocurrency-web": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/nanocurrency-web/-/nanocurrency-web-1.2.1.tgz",
-      "integrity": "sha512-OmGazZ4nl0PiUzL2Ag355cikU4yBgOa3ggEUsxF0T1dNqaxhoS7qeF7tEhDxwo7hqtqV49XwtQyWc7r000/6Dg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/nanocurrency-web/-/nanocurrency-web-1.4.3.tgz",
+      "integrity": "sha512-okmnHweUjZq3j/f2W5qYl4Ir4GAhGyL2BJJQEeZvo+qIHkdI4d7RbJDQKNK1VXAmdFZ4mElOPLGUBv6i+x+XRg==",
       "dependencies": {
-        "bignumber.js": "9.0.0",
-        "blakejs": "1.1.0",
+        "bignumber.js": "9.0.2",
+        "blakejs": "1.2.1",
+        "byte-base64": "1.1.0",
         "crypto-js": "3.1.9-1"
       }
     },
     "node_modules/nanocurrency-web/node_modules/bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
       "engines": {
         "node": "*"
       }
@@ -25728,9 +25734,9 @@
       }
     },
     "blakejs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
     "blocking-proxy": {
       "version": "1.0.1",
@@ -26192,6 +26198,11 @@
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
+    },
+    "byte-base64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/byte-base64/-/byte-base64-1.1.0.tgz",
+      "integrity": "sha512-56cXelkJrVMdCY9V/3RfDxTh4VfMFCQ5km7B7GkIGfo4bcPL9aACyJLB0Ms3Ezu5rsHmLB2suis96z4fLM03DA=="
     },
     "bytes": {
       "version": "3.0.0",
@@ -31507,19 +31518,20 @@
       }
     },
     "nanocurrency-web": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/nanocurrency-web/-/nanocurrency-web-1.2.1.tgz",
-      "integrity": "sha512-OmGazZ4nl0PiUzL2Ag355cikU4yBgOa3ggEUsxF0T1dNqaxhoS7qeF7tEhDxwo7hqtqV49XwtQyWc7r000/6Dg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/nanocurrency-web/-/nanocurrency-web-1.4.3.tgz",
+      "integrity": "sha512-okmnHweUjZq3j/f2W5qYl4Ir4GAhGyL2BJJQEeZvo+qIHkdI4d7RbJDQKNK1VXAmdFZ4mElOPLGUBv6i+x+XRg==",
       "requires": {
-        "bignumber.js": "9.0.0",
-        "blakejs": "1.1.0",
+        "bignumber.js": "9.0.2",
+        "blakejs": "1.2.1",
+        "byte-base64": "1.1.0",
         "crypto-js": "3.1.9-1"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+          "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
         },
         "crypto-js": {
           "version": "3.1.9-1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "hw-app-nano": "^1.3.0",
     "nano-base32": "^1.0.1",
     "nanocurrency": "^2.5.0",
-    "nanocurrency-web": "^1.2.1",
+    "nanocurrency-web": "^1.4.3",
     "ngx-clipboard": "^12.3.0",
     "node-hid": "^1.3.0",
     "qrcode": "^1.4.4",

--- a/src/app/components/representatives/representatives.component.ts
+++ b/src/app/components/representatives/representatives.component.ts
@@ -341,7 +341,7 @@ export class RepresentativesComponent implements OnInit {
           this.notifications.sendError(`Error changing representative for ${account.id}, please try again`);
         }
       } catch (err) {
-        this.notifications.sendError(err.message);
+        this.notifications.sendError('Error changing representative: ' + err.message);
       }
     }
 


### PR DESCRIPTION
\- await for asynchronous call `this.validateAccount`, which previously had non-essential checks and didn't interrupt the signing process if small issues were found
\- run `this.validateAccount` not only for non-hardware wallets, but also for hardware wallets (in theory there isn't anything hardware wallet specific? but i didn't test it on hardware wallets)
\- add signature validation for frontier blocks to `this.validateAccount`
\- update nanocurrency-web from 1.2.1 to 1.4.3

UX fixes
\- fix error notifications not being shown to user when encountering a non-generic error during manual receive
\- change "try manually" in generic error notifications for manual receives to "please try again"
\- fix representative change transaction error not having a description