### PR TITLE
Fixes to allow successful builds and checks

### DIFF
--- a/.github/workflows/electron_hash.yml
+++ b/.github/workflows/electron_hash.yml
@@ -198,7 +198,7 @@ jobs:
 
       # Artifacts are always uploaded. Both untagged pushes and PRs
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}
           path: |

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "nanocurrency": "^2.5.0",
     "nanocurrency-web": "^1.4.3",
     "ngx-clipboard": "^12.3.0",
-    "node-hid": "^1.3.0",
+    "node-hid": "^2.2.0",
     "qrcode": "^1.4.4",
     "rxjs": "^6.5.5",
     "rxjs-compat": "^6.5.5",


### PR DESCRIPTION
Upgrade package.json to use node-hid v2 which apparently is API compatible - see https://github.com/Nault/Nault/issues/614