### PR TITLE
Fix application becoming unusable upon restart after removing the currently selected account

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -113,7 +113,7 @@ export class AppComponent implements OnInit {
 
     // update selected account object with the latest balance, pending, etc
     if (this.wallet.selectedAccountId) {
-      const currentUpdatedAccount = this.wallet.accounts.find(a => a.id === this.wallet.selectedAccountId);
+      const currentUpdatedAccount = this.wallet.accounts.find(a => a.id === this.wallet.selectedAccountId) ?? null;
       this.wallet.selectedAccount = currentUpdatedAccount;
     }
 


### PR DESCRIPTION
If the address stored in local storage does not match any of the accounts in the wallet, an `undefined` value is returned. Various components of the wallet strictly expect a valid address or the value `null`.

This PR assigns `wallet.selectedAccount` the value of `null` if `undefined` is returned.