### PR TITLE
Add XNOPay UK 1 Node as a server option

### DIFF
--- a/src/app/services/app-settings.service.ts
+++ b/src/app/services/app-settings.service.ts
@@ -70,6 +70,14 @@ export class AppSettingsService {
       shouldRandom: false,
     },
     {
+      name: 'XNOPay UK 1',
+      value: 'xnopay-uk-1',
+      api: 'https://uk1.public.xnopay.com/proxy',
+      ws: 'wss://uk1.public.xnopay.com/ws',
+      auth: null,
+      shouldRandom: true,
+    },
+    {
       name: 'Rainstorm City',
       value: 'rainstorm',
       api: 'https://rainstorm.city/api',


### PR DESCRIPTION
Add XNOPay UK 1 Node as a server option.

Reliable dedicated work server part of the node work_generate command.